### PR TITLE
Typo in ns-windot11-_dot11_go_negotiation_confirmation_send_complete_…

### DIFF
--- a/wdk-ddi-src/content/windot11/ns-windot11-_dot11_go_negotiation_confirmation_send_complete_parameters.md
+++ b/wdk-ddi-src/content/windot11/ns-windot11-_dot11_go_negotiation_confirmation_send_complete_parameters.md
@@ -103,7 +103,7 @@ The device address of the Peer-to-Peer (P2P) Wi-Fi Direct (WFD) device that the 
 
 ### -field DialogToken
 
-The dialog token from the GO negotiation  confirmation packet. This must match the dialog token sent with the <a href="https://msdn.microsoft.com/library/windows/hardware/hh451803">OID_DOT11_WFD_SEND_GO_NEGOTIATION_CONFIRMATION</a> request.
+The dialog token from the GO negotiation confirmation packet. This must match the dialog token sent with the <a href="https://msdn.microsoft.com/library/windows/hardware/hh451803">OID_DOT11_WFD_SEND_GO_NEGOTIATION_CONFIRMATION</a> request.
 
 
 ### -field Status
@@ -113,7 +113,7 @@ The status of the request send attempt. Set to <b>NDIS_STATUS_SUCCESS</b> if the
 
 ### -field uIEsOffset
 
-The offset, in bytes,  of the array of additional information elements (IEs) which were included in the the GO negotiation confirmation packet. This offset is from the start of the buffer that contains this structure.
+The offset, in bytes, of the array of additional information elements (IEs) which were included in the GO negotiation confirmation packet. This offset is from the start of the buffer that contains this structure.
 
 
 ### -field uIEsLength


### PR DESCRIPTION
…parameters.md

Remove duplicated 'the' and spaces.