### PR TITLE
Typo in ns-pepfx-_pep_acpi_abandon_device.md

### DIFF
--- a/wdk-ddi-src/content/pepfx/ns-pepfx-_pep_acpi_abandon_device.md
+++ b/wdk-ddi-src/content/pepfx/ns-pepfx-_pep_acpi_abandon_device.md
@@ -70,7 +70,7 @@ typedef struct _PEP_ACPI_ABANDON_DEVICE {
 
 ### -field AcpiDeviceName
 
-[in] A pointer to an <a href="https://msdn.microsoft.com/library/windows/hardware/ff540605">ANSI_STRING</a> structure that contains the fully qualified BIOS name for the device. This name specifies the the path and name of the device in the ACPI namespace. For more information, see <a href="https://msdn.microsoft.com/fe0553df-a5b9-46c4-8e1d-8b89a7d4ad67">Enumerating Child Devices and Control Methods</a>.
+[in] A pointer to an <a href="https://msdn.microsoft.com/library/windows/hardware/ff540605">ANSI_STRING</a> structure that contains the fully qualified BIOS name for the device. This name specifies the path and the name of the device in the ACPI namespace. For more information, see <a href="https://msdn.microsoft.com/fe0553df-a5b9-46c4-8e1d-8b89a7d4ad67">Enumerating Child Devices and Control Methods</a>.
 
 
 ### -field DeviceAccepted


### PR DESCRIPTION
'the the path and name' => 'the path and the name'