### PR TITLE
Typo in ns-windot11-_dot11_received_invitation_response_parameters.md

### DIFF
--- a/wdk-ddi-src/content/windot11/ns-windot11-_dot11_received_invitation_response_parameters.md
+++ b/wdk-ddi-src/content/windot11/ns-windot11-_dot11_received_invitation_response_parameters.md
@@ -113,7 +113,7 @@ The dialog token received in invitation response packet.
 
 ### -field uIEsOffset
 
-The offset, in bytes,  of the array of additional information elements (IEs) received in the the invitation response packet. This offset is from the start of the buffer that contains this structure.
+The offset, in bytes,  of the array of additional information elements (IEs) received in the invitation response packet. This offset is from the start of the buffer that contains this structure.
 
 
 ### -field uIEsLength


### PR DESCRIPTION
Remove duplicated 'the'.