### PR TITLE
Fix up some formatting in ZwLoadDriver

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-zwloaddriver.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-zwloaddriver.md
@@ -71,7 +71,7 @@ NTSTATUS ZwLoadDriver(
 
 ### -param DriverServiceName [in]
 
-Pointer to a counted Unicode string that specifies a path to the driver's registry key, <b>\Registry\Machine\System\CurrentControlSet\Services\</b><i>DriverName</i>, where <i>DriverName</i> is the name of the driver. 
+Pointer to a counted Unicode string that specifies a path to the driver's registry key, <b>\Registry\Machine\System\CurrentControlSet\Services\<i>DriverName</i></b>, where <i>DriverName</i> is the name of the driver. 
 
 
 ## -returns


### PR DESCRIPTION
The system interprets the \ between Services and DriverName as an escape for the closing </b> tag. This results in the </b> being shown literally to the user and the remainder of the page formatted as bold face. Move the closing </b> to the end of DriverName.