### PR TITLE
Make definitions consistent with DXGI

### DIFF
--- a/wdk-ddi-src/content/d3dukmdt/ns-d3dukmdt-_d3dddi_hdr_metadata_hdr10.md
+++ b/wdk-ddi-src/content/d3dukmdt/ns-d3dukmdt-_d3dddi_hdr_metadata_hdr10.md
@@ -75,40 +75,43 @@ typedef struct _D3DDDI_HDR_METADATA_HDR10 {
 
 ### -field RedPrimary
 
-The chromaticity coordinates of the 1.0 red value. Index 0 contains the X coordinate and index 1 contains the Y coordinate. 
+The chromaticity coordinates of the red color primary in the CIE xy color space. Index 0 contains the x coordinate and index 1 contains the y coordinate. Values are normalized to 50,000.
 
 
 ### -field GreenPrimary
 
-The chromaticity coordinates of the 1.0 green value. Index 0 contains the X coordinate and index 1 contains the Y coordinate. 
+The chromaticity coordinates of the green color primary in the CIE xy color space. Index 0 contains the x coordinate and index 1 contains the y coordinate. Values are normalized to 50,000.
 
 
 ### -field BluePrimary
 
-The chromaticity coordinates of the 1.0 blue value. Index 0 contains the X coordinate and index 1 contains the Y coordinate. 
+The chromaticity coordinates of the blue color primary in the CIE xy color space. Index 0 contains the x coordinate and index 1 contains the y coordinate. Values are normalized to 50,000.
 
 
 ### -field WhitePoint
 
- 
+The chromaticity coordinates of the white point in the CIE xy color space. Index 0 contains the x coordinate and index 1 contains the y coordinate. Values are normalized to 50,000.
 
 
 ### -field MaxMasteringLuminance
 
-The maximum number of nits of the display used to master the content. 
+The maximum number of nits of the display used to master the content. Values are normalized to 10,000.
 
 
 ### -field MinMasteringLuminance
 
-The minimum number of nits of the display used to master the content.
+The minimum number of nits of the display used to master the content. Values are normalized to 10,000.
 
 
 ### -field MaxContentLightLevel
 
-The maximum nit value used anywhere in the content. 
+The maximum content light level (MaxCLL). This is the nit value corresponding to the brightest pixel used anywhere in the content.
 
 
 ### -field MaxFrameAverageLightLevel
 
-The per-frame average of the maximum nit values. 
+The maximum frame average light level (MaxFALL). This is the nit value corresponding to the average luminance of the frame which has the brightest average luminance anywhere in the content.
 
+## -remarks
+
+D3DDDI_HDR_METADATA_HDR10 has equivalent definitions to <a href="https://msdn.microsoft.com/library/windows/desktop/mt732700.aspx">DXGI_HDR_METADATA_HDR10</a>.


### PR DESCRIPTION
D3DDDI_HDR_METADATA_HDR10 and DXGI_HDR_METADATA_HDR10 are semantically equivalent (they are API/DDI counterparts). Updating the D3DDI version to match DXGI and remove ambiguity in units.