### PR TITLE
D3DDDI_HDR_METADATA_HDR10 MaxMasteringLuminance

### DIFF
--- a/wdk-ddi-src/content/d3dukmdt/ns-d3dukmdt-_d3dddi_hdr_metadata_hdr10.md
+++ b/wdk-ddi-src/content/d3dukmdt/ns-d3dukmdt-_d3dddi_hdr_metadata_hdr10.md
@@ -95,7 +95,7 @@ The chromaticity coordinates of the white point in the CIE xy color space. Index
 
 ### -field MaxMasteringLuminance
 
-The maximum number of nits of the display used to master the content. Values are normalized to 10,000.
+The maximum number of nits of the display used to master the content. Values are in whole nits.
 
 
 ### -field MinMasteringLuminance


### PR DESCRIPTION
A previous PR to update the units definitions of the various fields missed one change for MaxMasteringLuminance.