### PR TITLE
Fix upper bound for characters in pool tag

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolwithtag.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolwithtag.md
@@ -74,7 +74,7 @@ The number of bytes to allocate.
 
 ### -param Tag [in]
 
-The pool tag to use for the allocated memory. Specify the pool tag as a character literal of up to four characters delimited by single quotation marks (for example, 'Tag1'). The string is usually specified in reverse order (for example, '1gaT'). Each ASCII character in the tag must be a value in the range 0x20 (space) to 0x126 (tilde). Each allocation code path should use a unique pool tag to help debuggers and verifiers identify the code path.
+The pool tag to use for the allocated memory. Specify the pool tag as a character literal of up to four characters delimited by single quotation marks (for example, 'Tag1'). The string is usually specified in reverse order (for example, '1gaT'). Each ASCII character in the tag must be a value in the range 0x20 (space) to 0x7E (tilde). Each allocation code path should use a unique pool tag to help debuggers and verifiers identify the code path.
 
 
 ## -returns


### PR DESCRIPTION
The tilde character is 126 in decimal, which is 0x7E in hex.