### PR TITLE
Fixed links

### DIFF
--- a/wdk-ddi-src/content/storport/nc-storport-virtual_hw_find_adapter.md
+++ b/wdk-ddi-src/content/storport/nc-storport-virtual_hw_find_adapter.md
@@ -85,7 +85,7 @@ A pointer to a null-terminated ASCII string. This string, if supplied, contains 
 
 ### -param ConfigInfo
 
-A pointer to a <a href="https://msdn.microsoft.com/library/windows/hardware/ff567785">PORT_CONFIGURATION_INFORMATION</a> structure. The port driver initializes this structure with any known configuration information, such as values that the miniport driver's <a href="https://msdn.microsoft.com/library/windows/hardware/ff552644">DriverEntry</a> set in the <a href="https://msdn.microsoft.com/library/windows/hardware/ff568010">VIRTUAL_HW_INITIALIZATION_DATA</a>. <b>VirtualHwStorFindAdapter</b>  must use any supplied information to determine if the virtual HBA it describes is one that the miniport driver supports. If so, <b>VirtualHwStorFindAdapter</b> initializes and configures that HBA and fills in any missing configuration information. If possible, a miniport driver should have default configuration values for each type of HBA that it supports, in the event that the operating system-dependent port driver cannot supply additional configuration information that was not provided by the miniport driver's <b>DriverEntry</b> routine.
+A pointer to a [PORT_CONFIGURATION_INFORMATION](https://docs.microsoft.com/windows-hardware/drivers/ddi/content/storport/ns-storport-_port_configuration_information) structure. The port driver initializes this structure with any known configuration information, such as values that the miniport driver's [DriverEntry](https://msdn.microsoft.com/library/windows/hardware/ff552644) set in the [VIRTUAL_HW_INITIALIZATION_DATA](https://msdn.microsoft.com/library/windows/hardware/ff568010). **VirtualHwStorFindAdapter**  must use any supplied information to determine if the virtual HBA it describes is one that the miniport driver supports. If so, **VirtualHwStorFindAdapter** initializes and configures that HBA and fills in any missing configuration information. If possible, a miniport driver should have default configuration values for each type of HBA that it supports, in the event that the operating system-dependent port driver cannot supply additional configuration information that was not provided by the miniport driver's **DriverEntry** routine.
 
 
 ### -param Again
@@ -97,7 +97,7 @@ Not used.
 
 
 
-<b>VirtualHwStorFindAdapter</b> must return one of the following status values:
+**VirtualHwStorFindAdapter** must return one of the following status values:
 
 <table>
 <tr>
@@ -111,7 +111,7 @@ Not used.
 </dl>
 </td>
 <td width="60%">
-Indicates that a supported HBA was found and that the HBA-relevant configuration information was determined successfully and set in the <a href="https://msdn.microsoft.com/library/windows/hardware/ff567785">PORT_CONFIGURATION_INFORMATION</a> structure.
+Indicates that a supported HBA was found and that the HBA-relevant configuration information was determined successfully and set in the <a href="https://docs.microsoft.com/windows-hardware/drivers/ddi/content/storport/ns-storport-_port_configuration_information">PORT_CONFIGURATION_INFORMATION</a> structure.
 
 </td>
 </tr>
@@ -240,7 +240,7 @@ The <b>VIRTUAL_HW_FIND_ADAPTER</b> function type is defined in the Storport.h he
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff567785">PORT_CONFIGURATION_INFORMATION</a>
+<a href="https://docs.microsoft.com/windows-hardware/drivers/ddi/content/storport/ns-storport-_port_configuration_information">PORT_CONFIGURATION_INFORMATION</a>
 
 
 


### PR DESCRIPTION
Fixed link to _PORT_CONFIGURATION_INFORMATION structure so that it points to the one from storport.h