### PR TITLE
Markdown/HTML confusion

### DIFF
--- a/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_operation_registration.md
+++ b/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_operation_registration.md
@@ -102,9 +102,10 @@ FLTFL_OPERATION_REGISTRATION_SKIP_NON_DASD_IO
 A minifilter sets this flag so that all operations that are not issued on a DASD (volume) handle will be skipped:
 
 Note the following:
-
-    * The minifilter's callback for this operation will be bypassed.
-    * This flag is relevant for all operations.
+<ul>
+    <li> The minifilter's callback for this operation will be bypassed.</li>
+    <li> This flag is relevant for all operations.</li>
+</ul>
 </td>
 </tr>
 


### PR DESCRIPTION
Was just skimming [this ](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/fltkernel/ns-fltkernel-_flt_operation_registration) and spotted some oddness.

> A minifilter sets this flag so that all operations that are not issued on a DASD (volume) handle will be skipped: Note the following: * The minifilter's callback for this operation will be bypassed. * This flag is relevant for all operations.

By eyeballing it looks like somone added markdown and the text expected HTML.  Dunno how all your process works, but this is an attempt to fix it.

