### PR TITLE
Note MiniportInitializeEx-DriverEntry relationship

### DIFF
--- a/wdk-ddi-src/content/ndis/nf-ndis-ndismregisterminiportdriver.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndismregisterminiportdriver.md
@@ -214,7 +214,7 @@ After a driver calls
     <b>NdisMRegisterMiniportDriver</b>, the driver should be prepared to be called back at the 
     <a href="https://msdn.microsoft.com/b146fa81-005b-4a6c-962d-4cb023ea790e">MiniportInitializeEx</a> function that
     is specified in the 
-    <i>MiniportDriverCharacteristics</i> parameter. (These calls will not take place until DriverEntry returns.)
+    <i>MiniportDriverCharacteristics</i> parameter any time after DriverEntry returns.
 
 If an error occurs in 
     <a href="https://msdn.microsoft.com/library/windows/hardware/ff552644">DriverEntry</a> after 
@@ -231,7 +231,7 @@ If an error occurs in
 
 ## -see-also
 
-
+[Initializing a Miniport Driver](https://docs.microsoft.com/windows-hardware/drivers/network/initializing-a-miniport-driver)
 
 
 <a href="https://msdn.microsoft.com/library/windows/hardware/ff552644">DriverEntry</a>

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndismregisterminiportdriver.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndismregisterminiportdriver.md
@@ -214,7 +214,7 @@ After a driver calls
     <b>NdisMRegisterMiniportDriver</b>, the driver should be prepared to be called back at the 
     <a href="https://msdn.microsoft.com/b146fa81-005b-4a6c-962d-4cb023ea790e">MiniportInitializeEx</a> function that
     is specified in the 
-    <i>MiniportDriverCharacteristics</i> parameter.
+    <i>MiniportDriverCharacteristics</i> parameter. (These calls will not take place until DriverEntry returns.)
 
 If an error occurs in 
     <a href="https://msdn.microsoft.com/library/windows/hardware/ff552644">DriverEntry</a> after 


### PR DESCRIPTION
While `NdisMRegisterMiniportDriver` should do the necessary work to render `MiniportInitializeEx` calls valid, NDIS will not call `MiniportInitializeEx` until `DriverEntry` returns. This allows `MiniportInitializeEx` to rely on locks allocated using `NdisAllocateRWLock` which uses (and, as I read its doc for Windows 7 and Vista, requires) the `NDIS_HANDLE` returned by `NdisMRegisterMiniportDriver`.