### PR TITLE
Fixed PsGetCurrentProcess link (by analogy with cbf436d)

### DIFF
--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psgetcurrentthread.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psgetcurrentthread.md
@@ -91,7 +91,7 @@ This macro
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
 
 
 

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psgetprocesscreatetimequadpart.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psgetprocesscreatetimequadpart.md
@@ -60,7 +60,7 @@ The <b>PsGetProcessCreateTimeQuadPart</b> routine returns a LONGLONG value that 
 
 ### -param Process [in]
 
-A pointer to the EPROCESS structure that represents the process. Drivers can use the <a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a> and <a href="https://msdn.microsoft.com/library/windows/hardware/ff558679">ObReferenceObjectByHandle</a> routines to obtain a pointer to the EPROCESS structure for a process. 
+A pointer to the EPROCESS structure that represents the process. Drivers can use the [PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer) and <a href="https://msdn.microsoft.com/library/windows/hardware/ff558679">ObReferenceObjectByHandle</a> routines to obtain a pointer to the EPROCESS structure for a process. 
 
 
 ## -returns
@@ -85,7 +85,7 @@ A pointer to the EPROCESS structure that represents the process. Drivers can use
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
  
 
  

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psgetprocessid.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psgetprocessid.md
@@ -76,7 +76,7 @@ A pointer to a process object structure.
 
 
 
-The EPROCESS-typed process object structure is an opaque data structure that the operating system uses internally. To obtain a pointer to the EPROCESS structure for the current process, a driver can call <a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>. To obtain a pointer to the EPROCESS structure for a different process, the driver can call <a href="https://msdn.microsoft.com/library/windows/hardware/ff558679">ObReferenceObjectByHandle</a>. 
+The EPROCESS-typed process object structure is an opaque data structure that the operating system uses internally. To obtain a pointer to the EPROCESS structure for the current process, a driver can call [PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer). To obtain a pointer to the EPROCESS structure for a different process, the driver can call <a href="https://msdn.microsoft.com/library/windows/hardware/ff558679">ObReferenceObjectByHandle</a>. 
 
 
 
@@ -90,7 +90,7 @@ The EPROCESS-typed process object structure is an opaque data structure that the
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
  
 
  

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-iothreadtoprocess.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-iothreadtoprocess.md
@@ -83,7 +83,7 @@ For more information about using system threads and managing synchronization wit
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
 
 
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-kestackattachprocess.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-kestackattachprocess.md
@@ -96,7 +96,7 @@ Every call to <b>KeStackAttachProcess</b> must be matched by a subsequent call t
 <div> </div>
 
 
-For more information about using system threads and managing synchronization within a nonarbitrary thread context, see [Windows Kernel-Mode Process and Thread Manager](https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/windows-kernel-mode-process-and-thread-manager). 
+For more information about using system threads and managing synchronization within a nonarbitrary thread context, see [Windows Kernel-Mode Process and Thread Manager](https://docs.microsoft.com/windows-hardware/drivers/kernel/windows-kernel-mode-process-and-thread-manager). 
 
 
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-kestackattachprocess.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-kestackattachprocess.md
@@ -60,7 +60,7 @@ The <b>KeStackAttachProcess</b> routine attaches the current thread to the addre
 
 ### -param PROCESS
 
-Pointer to the target process object. This parameter can be a PEPROCESS pointer returned by <a href="https://msdn.microsoft.com/library/windows/hardware/ff549177">IoGetCurrentProcess</a> or <a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>. 
+Pointer to the target process object. This parameter can be a PEPROCESS pointer returned by <a href="https://msdn.microsoft.com/library/windows/hardware/ff549177">IoGetCurrentProcess</a> or [PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer). 
 
 
 ### -param ApcState [out]
@@ -130,7 +130,7 @@ For more information about using system threads and managing synchronization wit
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
 
 
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-keunstackdetachprocess.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-keunstackdetachprocess.md
@@ -121,7 +121,7 @@ For more information about using system threads and managing synchronization wit
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
 
 
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-psgetcurrentthread.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-psgetcurrentthread.md
@@ -91,7 +91,7 @@ This macro
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
 
 
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-pslookupprocessbyprocessid.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-pslookupprocessbyprocessid.md
@@ -137,7 +137,7 @@ The <b>PsLookupProcessByProcessId</b> routine contains pageable code.
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
 
 
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-pslookupthreadbythreadid.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-pslookupthreadbythreadid.md
@@ -122,7 +122,7 @@ The <b>PsLookupThreadByThreadId</b> routine contains pageable code.
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
 
 
 

--- a/wdk-ddi-src/content/rxprocs/nf-rxprocs-rxdriverentry.md
+++ b/wdk-ddi-src/content/rxprocs/nf-rxprocs-rxdriverentry.md
@@ -167,7 +167,7 @@ On X86 systems, 64K is the largest write that will be issued by the Memory Manag
 
 On Windows Server 2003, a registry value to set ReadAheadGranularity is not exposed and RDBSS defaults to 32K (8 4K PAGE_SIZE pages). This is the same default value adopted for local files systems.
 
-<b>RxDriverEntry</b> retrieves a pointer to the kernel process that is running by calling <a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a> and stores this value in an internal RDBSS data structure. This kernel process is sometimes called the file system process.
+<b>RxDriverEntry</b> retrieves a pointer to the kernel process that is running by calling [PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer) and stores this value in an internal RDBSS data structure. This kernel process is sometimes called the file system process.
 
 <b>RxDriverEntry</b> then copies a pointer to the <a href="https://msdn.microsoft.com/library/windows/hardware/ff554468">RxFsdDispatch</a> routine over all of the entries in the driver dispatch table. So if a monolithic network mini-redirector driver needs to receive specific IRPs for special processing before the RDBSS library, then a copy of its original driver dispatch table should be saved before calling <b>RxDriverEntry</b> and any routine pointers restored after the call to <b>RxDriverEntry</b> has returned. Note that RDBSS will also copy <b>RxFsdDispatch</b> to all the driver dispatch table entries when <a href="https://msdn.microsoft.com/library/windows/hardware/ff554693">RxRegisterMiniRdr</a> is called unless an option is set to prevent this behavior..
 

--- a/wdk-ddi-src/content/rxstruc/nf-rxstruc-rxgetrdbssprocess.md
+++ b/wdk-ddi-src/content/rxstruc/nf-rxstruc-rxgetrdbssprocess.md
@@ -83,7 +83,7 @@ When <b>RxDriverEntry</b> is called to initialize RDBSS, a pointer to the kernel
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
 
 
 

--- a/wdk-ddi-src/content/wdm/nf-wdm-psgetcurrentthread.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-psgetcurrentthread.md
@@ -91,7 +91,7 @@ This macro
 
 
 
-<a href="https://msdn.microsoft.com/library/windows/hardware/ff559933">PsGetCurrentProcess</a>
+[PsGetCurrentProcess](https://docs.microsoft.com/windows-hardware/drivers/kernel/mm-bad-pointer)
 
 
 


### PR DESCRIPTION
Link https://msdn.microsoft.com/library/windows/hardware/ff559933 is broken.
Fixed link to PsGetCurrentProcess (by analogy with cbf436da4d822a35f63054d328fe133f03f5e2fa)

#217 fix for entire repository