### PR TITLE
Update nf-ntddk-rtlinitializecorrelationvector.md

### DIFF
--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlinitializecorrelationvector.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlinitializecorrelationvector.md
@@ -2,7 +2,7 @@
 UID: NF:ntddk.RtlInitializeCorrelationVector
 title: RtlInitializeCorrelationVector function
 author: windows-driver-content
-description: Initializes the specified correlation vector with the supplied GUID.
+description: Initializes the specified [correlation vector](https://github.com/Microsoft/CorrelationVector) with the supplied GUID.
 old-location: kernel\rtlinitializecorrelationvector.htm
 tech.root: kernel
 ms.assetid: ebf5ccbe-3325-4d3d-86c9-230776f2c9ef


### PR DESCRIPTION
Adding link to correlation vector implementation. The link will help customers to navigate to Microsoft implementation of correlation vector used for diagnostic purposes.