### PR TITLE
Add brightness3 uncalibrated nits scenario info

### DIFF
--- a/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_dxgk_brightness_caps.md
+++ b/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_dxgk_brightness_caps.md
@@ -73,7 +73,9 @@ Setting this member is equivalent to setting the second bit of a 32-bit value (0
 
 ### -field NitsBrightness
 
-[in] Nit-based brightness support. If NitsBrightness is set, then the display brightness is calibrated to correspond to absolute brightness levels measured in nits.  Calibrated data provided to the Display Driver by OEMs should be taken with an On Pixel Ratio (OPR) percentage of 100% where each pixel is set to an RGB value of (255, 255, 255) or floating point equivalent.  If it is not set, then the OS is aware that the levels exposed by GetNitRanges do not necessarily represent the actual luminance of the display.
+[in] Nit-based brightness support. If <b>NitsBrightness</b> is set, then the display brightness is calibrated to correspond to absolute brightness levels measured in nits.  Calibrated data provided to the Display Driver by OEMs should be taken with an On Pixel Ratio (OPR) percentage of 100% where each pixel is set to an RGB value of (255, 255, 255) or floating point equivalent.
+
+If <b>NitsBrightness</b> is not set, then the OS will interpret all values that are defined in nits/millinits, for example [DXGK_BRIGHTNESS_NIT_RANGE](ns-d3dkmdt-_dxgk_brightness_nit_range.md), as uncalibrated thousandths of a percent of the maximum brightness level.
 
 ### -field Reserved
 

--- a/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_dxgk_brightness_nit_range.md
+++ b/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_dxgk_brightness_nit_range.md
@@ -41,7 +41,7 @@ tech.root: display
 
 ## -description
 
-This structure represents a linear range of supported millinit levels.
+This structure represents a linear range of supported millinit levels. If the driver has not set [DXGK_BRIGHTNESS_CAPS.NitsBrightness](ns-d3dkmdt-_dxgk_brightness_caps.md), then all values represent brightness level in uncalibrated thousandths of a percent. 
 
 ## -struct-fields
 

--- a/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_dxgk_brightness_set_in.md
+++ b/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_dxgk_brightness_set_in.md
@@ -47,11 +47,13 @@ Contains input parameters for the [DxgkBrightnessSet3](..\dispmprt\nc-dispmprt-d
 
 ### -field BrightnessMillinits
 
-The brightness level in millinits to transition to.
+The brightness level in millinits to transition to. If the driver has not set [DXGK_BRIGHTNESS_CAPS.NitsBrightness](ns-d3dkmdt-_dxgk_brightness_caps.md), then this value means the brightness level in uncalibrated 1/10000ths of a percent.
+
+For example, if <b>BrightnessMillinits</b> is set to 60500 and <b>NitsBrightness</b> is set, this means 60.5 nits luminance. If <b>NitsBrightness</b> is not set, this means 60.5%.
 
 ### -field TransitionTimeMs
 
-How long the transition should take.
+How long the transition should take in milliseconds.
 
 ### -field SensorReadings
 

--- a/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_dxgk_brightness_set_in.md
+++ b/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_dxgk_brightness_set_in.md
@@ -47,7 +47,7 @@ Contains input parameters for the [DxgkBrightnessSet3](..\dispmprt\nc-dispmprt-d
 
 ### -field BrightnessMillinits
 
-The brightness level in millinits to transition to. If the driver has not set [DXGK_BRIGHTNESS_CAPS.NitsBrightness](ns-d3dkmdt-_dxgk_brightness_caps.md), then this value means the brightness level in uncalibrated 1/10000ths of a percent.
+The brightness level in millinits to transition to. If the driver has not set [DXGK_BRIGHTNESS_CAPS.NitsBrightness](ns-d3dkmdt-_dxgk_brightness_caps.md), then this value means the brightness level in uncalibrated thousandths of a percent.
 
 For example, if <b>BrightnessMillinits</b> is set to 60500 and <b>NitsBrightness</b> is set, this means 60.5 nits luminance. If <b>NitsBrightness</b> is not set, this means 60.5%.
 


### PR DESCRIPTION
Brightness3 can be used to represent calibrated nits brightness, or uncalibrated percent brightness. DDI members' interpretations will change depending on the driver caps.