### PR TITLE
typo: acccess -> access

### DIFF
--- a/wdk-ddi-src/content/nfcsedev/ni-nfcsedev-ioctl_nfcse_set_card_emulation_mode.md
+++ b/wdk-ddi-src/content/nfcsedev/ni-nfcsedev-ioctl_nfcse_set_card_emulation_mode.md
@@ -48,7 +48,7 @@ req.typenames:
 
 
 The <b>IOCTL_NFCSE_SET_CARD_EMULATION_MODE</b> 
-   control code sets whether the specified secure element is exposed in card emulation mode. When a secure element is “exposed” as card emulation, it means when the device is brought to an external reader that secure element can be accessed by the reader. The IOCTL is issued on a file handle opened with a relative filename ‘SEManage’. The driver MUST grant exclusive access to the client to manage card emulation mode, that is, subsequent calls to open a file handle using relative filename ‘SEManage’ will fail with STATUS_ACCCESS_DENIED until the client with exclusive access closes its file handle.
+   control code sets whether the specified secure element is exposed in card emulation mode. When a secure element is “exposed” as card emulation, it means when the device is brought to an external reader that secure element can be accessed by the reader. The IOCTL is issued on a file handle opened with a relative filename ‘SEManage’. The driver MUST grant exclusive access to the client to manage card emulation mode, that is, subsequent calls to open a file handle using relative filename ‘SEManage’ will fail with STATUS_ACCESS_DENIED until the client with exclusive access closes its file handle.
 
 
 ## -ioctlparameters
@@ -133,7 +133,7 @@ The following are requirements that the driver must adhere to. <ul>
 <li>If card emulation mode is set to EmulationOff for all the secure elements that are attached to the NFC controller, the emulation mode of the polling loop must be disabled. If proximity features are also disabled, the driver should transition to a low power mode.</li>
 <li>If card emulation mode is set to a value other than EmulationOff, then the driver must continue to be in the D0 state and the emulation mode of the polling loop should be enabled (detectable to external readers).</li>
 <li>When the SEManage opened file handle is closed, the driver must set the card emulation mode settings of all secure elements to be EmulationOff except when the last set card emulation mode state is EmulationOnPowerIndependent. If the last set card emulation mode state is EmulationOnPowerIndependent, the driver must remain with the card emulation mode setting to On with the PbF option for the specific secure elements.</li>
-<li>The driver must grant exclusive access to the client to manage card emulation mode. Subsequent calls to open a file handle using relative filename SEManage would fail with STATUS_ACCCESS_DENIED until the client with exclusive access closes its file handle.</li>
+<li>The driver must grant exclusive access to the client to manage card emulation mode. Subsequent calls to open a file handle using relative filename SEManage would fail with STATUS_ACCESS_DENIED until the client with exclusive access closes its file handle.</li>
 </ul>
 
 


### PR DESCRIPTION
Didn't confirm if this is a product bug or docs issue