### PR TITLE
Update ns-gnssdriver-gnss_device_capability.md

### DIFF
--- a/wdk-ddi-src/content/gnssdriver/ns-gnssdriver-gnss_device_capability.md
+++ b/wdk-ddi-src/content/gnssdriver/ns-gnssdriver-gnss_device_capability.md
@@ -95,7 +95,9 @@ Specifies a bitmask containing the different AGNSS formats (GNSS_AGNSSFORMAT_*) 
 #define GNSS_AGNSSFORMAT_XTRA2      0x02
 #define GNSS_AGNSSFORMAT_LTO        0x04
 #define GNSS_AGNSSFORMAT_XTRA3      0x08
-#define GNSS_AGNSSFORMAT_XTRA3_1    0x16
+#define GNSS_AGNSSFORMAT_XTRA3_1    0x10
+#define GNSS_AGNSSFORMAT_XTRA3_2    0x20
+#define GNSS_AGNSSFORMAT_XTRA_INT   0x40
 </code></pre>
 The values 0x0020-0xFFFF are  reserved for extensibility.
 

--- a/wdk-ddi-src/content/gnssdriver/ns-gnssdriver-gnss_device_capability.md
+++ b/wdk-ddi-src/content/gnssdriver/ns-gnssdriver-gnss_device_capability.md
@@ -96,8 +96,8 @@ Specifies a bitmask containing the different AGNSS formats (GNSS_AGNSSFORMAT_*) 
 #define GNSS_AGNSSFORMAT_LTO        0x04
 #define GNSS_AGNSSFORMAT_XTRA3      0x08
 #define GNSS_AGNSSFORMAT_XTRA3_1    0x10
-#define GNSS_AGNSSFORMAT_XTRA3_2    0x20
-#define GNSS_AGNSSFORMAT_XTRA_INT   0x40
+#define GNSS_AGNSSFORMAT_XTRA3_2    0x20 //Note: This value is currently in prerelease, and is subject to change.
+#define GNSS_AGNSSFORMAT_XTRA_INT   0x40 //Note: This value is currently in prerelease, and is subject to change.
 </code></pre>
 The values 0x0020-0xFFFF are  reserved for extensibility.
 


### PR DESCRIPTION
We have added XTRA_3.2 and XTRA_INT definition and its functionality from 19H1 release. We update the MSDN document accordingly.

Also we found an typo, i.e., GNSS_AGNSSFORMAT_XTRA3_1 should be 0x10, not 0x16, so we fix it together.