### PR TITLE
Put "#define RTL_USE_AVL_TABLES 0" in a code block

### DIFF
--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlnumbergenerictableelements.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlnumbergenerictableelements.md
@@ -76,7 +76,7 @@ Callers of the <i>Rtl..GenericTable</i> routines are responsible for exclusively
 
 By default, the operating system uses splay trees to implement generic tables. Under some circumstances, operations on a splay tree will make the tree deep and narrow and might even turn it into a straight line. Very deep trees degrade the performance of searches. You can ensure a more balanced, shallower tree implementation of generic tables by using Adelson-Velsky/Landis (AVL) trees. If you want to configure the generic table routines to use AVL trees instead of splay trees in your driver, insert the following define statement in a common header file before including <i>Ntddk.h</i>:
 
-#define RTL_USE_AVL_TABLES 0
+`#define RTL_USE_AVL_TABLES 0`
 
 If RTL_USE_AVL_TABLES is not defined, you must use the AVL form of the generic table routines. For example, use the <a href="https://msdn.microsoft.com/library/windows/hardware/hh406522">RtlNumberGenericTableElementsAvl</a> routine instead of <b>RtlNumberGenericTableElements</b>. In the call to <b>RtlNumberGenericTableElementsAvl</b>, the caller must pass a <a href="https://msdn.microsoft.com/library/windows/hardware/ff553327">RTL_AVL_TABLE</a> table structure rather than <a href="https://msdn.microsoft.com/library/windows/hardware/ff553345">RTL_GENERIC_TABLE</a>.
 


### PR DESCRIPTION
Put "#define RTL_USE_AVL_TABLES 0" in a code block. Currently it displays as a header due to the '#' character.