### PR TITLE
Add warnings about call stack usage.

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefile.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefile.md
@@ -991,6 +991,8 @@ NTFS is the only Microsoft file system that implements FILE_RESERVE_OPFILTER.
 
 Minifilter drivers must use <a href="https://msdn.microsoft.com/library/windows/hardware/ff544516">FltSetInformationFile</a>, not <a href="https://msdn.microsoft.com/library/windows/hardware/ff567096">ZwSetInformationFile</a>, to rename a file. 
 
+In versions of Windows 10 starting 1809 calling this function can consume over 13 Kilobytes of call stack.  Filter writers should bracket calls to this function of <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/ntddk/nf-ntddk-keexpandkernelstackandcallout">KeExpandKernelStackAndCallout</a>
+
 <div class="alert"><b>Note</b>    If you try to open a volume but only specify a combination of the following flags for the <i>DesiredAccess</i> parameter, <b>FltCreateFile</b> will open a handle, independent of the file system, that has direct access to the storage device for the volume.<dl>
 <dd>
 FILE_READ_ATTRIBUTES

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefileex.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefileex.md
@@ -993,6 +993,8 @@ NTFS is the only Microsoft file system that implements FILE_RESERVE_OPFILTER.
 
 Minifilter drivers must use <a href="https://msdn.microsoft.com/library/windows/hardware/ff544516">FltSetInformationFile</a>, not <a href="https://msdn.microsoft.com/library/windows/hardware/ff567096">ZwSetInformationFile</a>, to rename a file. 
 
+In versions of Windows 10 starting 1809 calling this function can consume over 13 Kilobytes of call stack.  Filter writers should bracket calls to this function of <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/ntddk/nf-ntddk-keexpandkernelstackandcallout">KeExpandKernelStackAndCallout</a>
+
 <div class="alert"><b>Note</b>    If you try to open a volume but only specify a combination of the following flags for the <i>DesiredAccess</i> parameter, <b>FltCreateFileEx</b> will open a handle, independent of the file system, that has direct access to the storage device for the volume.<dl>
 <dd>
 FILE_READ_ATTRIBUTES

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefileex2.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefileex2.md
@@ -1011,7 +1011,10 @@ Step three makes this practical only for filter oplocks. The handle opened in st
 
 NTFS is the only Microsoft file system that implements FILE_RESERVE_OPFILTER. 
 
-Minifilter drivers must use <a href="https://msdn.microsoft.com/library/windows/hardware/ff544516">FltSetInformationFile</a>, not <a href="https://msdn.microsoft.com/library/windows/hardware/ff567096">ZwSetInformationFile</a>, to rename a file. 
+Minifilter drivers must use <a href="https://msdn.microsoft.com/library/windows/hardware/ff544516">FltSetInformationFile</a>, not <a href="https://msdn.microsoft.com/library/windows/hardware/ff567096">ZwSetInformationFile</a>, to rename a file.
+
+In versions of Windows 10 starting 1809 calling this function can consume over 13 Kilobytes of call stack.  Filter writers should bracket calls to this function of <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/ntddk/nf-ntddk-keexpandkernelstackandcallout">KeExpandKernelStackAndCallout</a>
+
 
 <div class="alert"><b>Note</b>    If you try to open a volume but only specify a combination of the following flags for the <i>DesiredAccess</i> parameter, <b>FltCreateFileEx2</b> will open a handle, independent of the file system, that has direct access to the storage device for the volume.<dl>
 <dd>

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-exfreepool.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-exfreepool.md
@@ -73,7 +73,7 @@ Drivers can also use the <b>ExFreePoolWithTag</b> routine to free buffers alloca
 
 Callers of <b>ExFreePool</b> must be running at IRQL &lt;= DISPATCH_LEVEL. A caller at DISPATCH_LEVEL must have specified a <b>NonPaged</b><i>Xxx</i><i>PoolType</i> when the memory was allocated. Otherwise, the caller must be running at IRQL &lt;= APC_LEVEL.
 
-
+In versions of Windows 10 starting 1809 calling this function can consume over 4700 bytes of call stack.
 
 
 ## -see-also


### PR DESCRIPTION
The change to Pool management in RS5 is cuasing me more problems than just
the inability to debug pool management.

This PR is an attempt to flag this us to users, in particular the use of
FltCreateXXX needs to be notified.

The URL for KeExpandStackAndCallOut will need massaged I suspect.