### PR TITLE
Fixing documentation for UcmUcsiPpmStop DDI

### DIFF
--- a/wdk-ddi-src/content/ucmucsippm/nf-ucmucsippm-ucmucsippmstop.md
+++ b/wdk-ddi-src/content/ucmucsippm/nf-ucmucsippm-ucmucsippmstop.md
@@ -57,7 +57,7 @@ This function returns VOID.
 
 **UcmUcsiPpmStop** indicates that the client driver is no longer ready to receive requests from the class extension. The class extension guarantees that there will not be any requests made to the client after this call returns. The driver should call this DDI when it encounters a fault and wants the class extension to stop sending PPM requests. After the call completes, the driver should start the PPM again using [**UcmUcsiPpmStart**](nf-ucmucsippm-ucmucsippmstart.md).
 
-The client driver may not explicitly call this function on Sx transition or driver unload. The class extension latches on the PnP callbacks to do the operations required for uninitialize operations.
+The client driver is expected to call this function on Sx transition or driver unload. This is important to gracefully tear down the internal state machines that the class extension manages. It is recommended that the client driver calls this function from its EVT_WDF_DEVICE_RELEASE_HARDWARE callback.
 
 Because **UcmUcsiPpmStop** relies on sending UCSI commands to PPM over the power-managed WDFQUEUE provided by the client driver, an attempt to call this function from [EVT_WDF_DEVICE_D0_EXIT](../wdfdevice/nc-wdfdevice-evt_wdf_device_d0_exit.md) callback results in a failure. That is because at this time, the dispatch gates for the queue are closed.
 


### PR DESCRIPTION
The page describes behavior for UcmUcsiCx class extension in RS5. In 19H1 we changed expectations from the client driver to call this DDI in response to issues around PnP re-balance.