### PR TITLE
Add URB function codes to GET STATUS request

### DIFF
--- a/wdk-ddi-src/content/usb/ns-usb-_urb_control_get_status_request.md
+++ b/wdk-ddi-src/content/usb/ns-usb-_urb_control_get_status_request.md
@@ -58,6 +58,11 @@ The _URB_CONTROL_GET_STATUS_REQUEST structure is used by USB client drivers to r
 
 Pointer to a <a href="https://msdn.microsoft.com/library/windows/hardware/ff540409">_URB_HEADER</a> structure that specifies the URB header information. <b>Hdr.Length</b> must be <code>sizeof(_URB_CONTROL_GET_STATUS_REQUEST)</code>, and <b>Hdr.Function</b> must be one of the following values:
 
+* URB_FUNCTION_GET_STATUS_FROM_DEVICE
+* URB_FUNCTION_GET_STATUS_FROM_INTERFACE
+* URB_FUNCTION_GET_STATUS_FROM_ENDPOINT
+* URB_FUNCTION_GET_STATUS_FROM_OTHER
+
 
 ### -field Reserved
 


### PR DESCRIPTION
URB function codes were removed in 1e8d1e599b8fc38d4b586c5c86533449accea7d5
This might not be the only thing that got removed in error. I didn't check the
whole commit.