### PR TITLE
The ProcessId parameter to FsRtlFastCheckLockForXXX is a PEPROCESS

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastchecklockforread(pfile_lock,plarge_integer,plarge_integer,ulong,pfile_object,pvoid).md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastchecklockforread(pfile_lock,plarge_integer,plarge_integer,ulong,pfile_object,pvoid).md
@@ -82,7 +82,7 @@ A pointer to the file object for the file.
 
 ### -param ProcessId [in]
 
-A pointer to the process ID for the process.
+A pointer to the EPROCESS for the process.
 
 
 ## -returns

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastchecklockforread.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastchecklockforread.md
@@ -82,7 +82,7 @@ A pointer to the file object for the file.
 
 ### -param ProcessId [in]
 
-A pointer to the process ID for the process.
+A pointer to the EPROCESS for the process.
 
 
 ## -returns

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastchecklockforwrite(pfile_lock,plarge_integer,plarge_integer,ulong,pvoid,pvoid).md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastchecklockforwrite(pfile_lock,plarge_integer,plarge_integer,ulong,pvoid,pvoid).md
@@ -82,7 +82,7 @@ A pointer to the file object for the file.
 
 ### -param ProcessId [in]
 
-A pointer to the process ID for the process.
+A pointer to the EPROCESS for the process.
 
 
 ## -returns

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastchecklockforwrite.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastchecklockforwrite.md
@@ -82,7 +82,7 @@ A pointer to the file object for the file.
 
 ### -param ProcessId [in]
 
-A pointer to the process ID for the process.
+A pointer to the EPROCESS for the process.
 
 
 ## -returns


### PR DESCRIPTION
Empirically (and by checking all the way back to the definition of
FAST_IO_LOCK) the ProcessId paramketer is no a PID, rather it is
PEPROCESS.

The PR makes a first attempt at recitying that (although I'm unhappy
with the use of term "PEPROCESS")