### PR TITLE
Update nf-wdm-exallocatepoolwithtag.md

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolwithtag.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolwithtag.md
@@ -72,6 +72,7 @@ The number of bytes to allocate.
 
 The pool tag to use for the allocated memory. Specify the pool tag as a character literal of up to four characters delimited by single quotation marks (for example, 'Tag1'). The string is usually specified in reverse order (for example, '1gaT'). Each ASCII character in the tag must be a value in the range 0x20 (space) to 0x7E (tilde). Each allocation code path should use a unique pool tag to help debuggers and verifiers identify the code path.
 
+**Windows 10 1903 and later:** Memory allocation fails if the pool tag is set to zero.
 
 ## -returns
 


### PR DESCRIPTION
The change is mentioned in #442. However, I got the failed allocation with zero pool tag on Windows 10 1903 (not 1909 as stated in the issue). 