### PR TITLE
Add FLT_FILE_NAME_QUERY_ALWAYS_ALLOW_CACHE_LOOKUP

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltgetfilenameinformationunsafe.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltgetfilenameinformationunsafe.md
@@ -136,6 +136,16 @@ FLT_FILE_NAME_QUERY_FILESYSTEM_ONLY
 
 </td>
 </tr>
+<tr>
+<td>
+FLT_FILE_NAME_QUERY_ALWAYS_ALLOW_CACHE_LOOKUP
+
+</td>
+<td>
+<b>FltGetFileNameInformationUnsafe</b> queries the Filter Manager's name cache for the file name information. If the name is not found in the cache, and it is currently safe to do so, <b>FltGetFileNameInformationUnsafe</b> queries the file system for the file name information and caches the result.
+
+</td>
+</tr>
 </table>
 
 ### -param FileNameInformation [out]


### PR DESCRIPTION
Add FLT_FILE_NAME_QUERY_ALWAYS_ALLOW_CACHE_LOOKUP entry to the table of NameOptions parameter based on the comment from devs ("the fact that FLT_FILE_NAME_QUERY_ALWAYS_ALLOW_CACHE_LOOKUP is not documented for FltGetFileNameInformationUnsafe() appears to be an oversight.  There’s nothing in Filter Manager that would prevent using that flag with that API").