### PR TITLE
Updated description of THREAD field

### DIFF
--- a/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_callback_data.md
+++ b/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_callback_data.md
@@ -211,7 +211,7 @@ The Filter Manager sets this flag to indicate that it is currently calling regis
 
 ### -field Thread
 
-Pointer to the thread that initiated the I/O operation. 
+Pointer to the thread that initiated the I/O operation. This field may be NULL.
 
 
 ### -field Iopb


### PR DESCRIPTION
Per a discussion with a 3rd party filter developer there has been some confusion around if the THREAD field can be NULL or not.  It can and I have updated the document to indicate this.