### PR TITLE
Add the return value of RtlGenerate8dot3Name

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-rtlgenerate8dot3name.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-rtlgenerate8dot3name.md
@@ -80,7 +80,7 @@ Pointer to a caller-allocated buffer to receive the generated short file name. T
 
 
 
-None
+This routine returns STATUS_SUCCESS if a short name is successfully generated. It returns STATUS_FILE_SYSTEM_LIMITATION if the system can not generate a unique short name for a given file. It returns this error after 1 million retry attempts for a single given long name.
 
 
 


### PR DESCRIPTION
`RtlGenerate8dot3Name` returns NTSTATUS in Vista SP1 or later. The text is taken from the following comment in ntifs.h:
> //  In Vista SP1 and beyond this routine now returns
> //  STATUS_FILE_SYSTEM_LIMITATION if the system can not generate a unique
> //  shortname for a given file.  It returns this error after 1 million retry
> //  attempts for a single given longname.