### PR TITLE
Update ns-ndis-_ndis_oid_request.md

### DIFF
--- a/wdk-ddi-src/content/ndis/ns-ndis-_ndis_oid_request.md
+++ b/wdk-ddi-src/content/ndis/ns-ndis-_ndis_oid_request.md
@@ -301,7 +301,7 @@ A pointer to a buffer into which the underlying driver or NDIS returns the reque
 
 ### -field DATA.METHOD_INFORMATION.InputBufferLength
 
-The size, in bytes, of the buffer at
+The size, in bytes, of the readable data in the buffer at
        <b>InformationBuffer</b>. The value at
        <b>Oid</b> determines the value appropriate to this member.
 


### PR DESCRIPTION
`METHOD_INFORMATION.InputBufferLength` doesn't describe the *total* buffer size, but only the number of bytes that are readable as input from the buffer.  The buffer may be larger than `InputBufferLength`, if the `OutputBufferLength` is larger.