### PR TITLE
Update nf-fltkernel-fltwritefileex.md

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltwritefileex.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltwritefileex.md
@@ -85,6 +85,7 @@ If the file object that <i>FileObject</i> points to was opened for asynchronous 
 
 The length, in bytes, of the data to be written to the file.
 
+
 ### -param Buffer [in]
 
 A pointer to a buffer that contains the data to be written to the file. If the file is opened for noncached I/O, this buffer be must be aligned in accordance with the alignment requirement of the underlying storage device. Minifilter drivers can allocate such an aligned buffer by calling <a href="https://docs.microsoft.com/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltallocatepoolalignedwithtag">FltAllocatePoolAlignedWithTag</a>. 

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltwritefileex.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltwritefileex.md
@@ -83,8 +83,7 @@ If the file object that <i>FileObject</i> points to was opened for asynchronous 
 
 ### -param Length [in]
 
-The size, in bytes, of the buffer that the <i>Buffer</i> parameter points to. 
-
+The length, in bytes, of the data to be written to the file.
 
 ### -param Buffer [in]
 


### PR DESCRIPTION
FltWriteFileEx uses `Length` to get the length of the data in `Mdl` when `Buffer` is NULL.