### PR TITLE
Update nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlmdlreadex.md

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlmdlreadex.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlmdlreadex.md
@@ -80,7 +80,7 @@ A value that is associated with the byte range to lock. If the range to lock ove
 
 ### -param MdlChain [out]
 
-An address of a variable that receives a pointer to a linked list of memory descriptor lists (MDLs). *\*MdlChain* must be initialized to **NULL** before the call to **FsRtlMdlReadEx**.
+An address of a variable that receives a pointer to a linked list of memory descriptor lists (MDLs). *MdlChain* must be initialized to **NULL** before the call to **FsRtlMdlReadEx**.
 
 
 ### -param IoStatus [out]

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlmdlreadex.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlmdlreadex.md
@@ -80,7 +80,7 @@ A value that is associated with the byte range to lock. If the range to lock ove
 
 ### -param MdlChain [out]
 
-On output, a pointer to a linked list of memory descriptor lists (MDLs).
+An address of a variable that receives a pointer to a linked list of memory descriptor lists (MDLs). *\*MdlChain* must be initialized to **NULL** before the call to **FsRtlMdlReadEx**.
 
 
 ### -param IoStatus [out]


### PR DESCRIPTION
*MdlChain must be initialized to NULL before the call to FsRtlMdlReadEx.

#745