### PR TITLE
Add details regarding when the callback function is invoked.

### DIFF
--- a/wdk-ddi-src/content/ntddk/nc-ntddk-pload_image_notify_routine.md
+++ b/wdk-ddi-src/content/ntddk/nc-ntddk-pload_image_notify_routine.md
@@ -48,7 +48,7 @@ req.typenames:
 ## -description
 
 
-Called by the operating system to notify the driver when a driver image or a user image (for example, a DLL or EXE) is mapped into virtual memory. 
+Called by the operating system to notify the driver when a driver image or a user image (for example, a DLL or EXE) is mapped into virtual memory. The operating system invokes this routine after an image has been mapped to memory, but before it's entrypoint is called.
 <div class="alert"><b>Warning</b>  The actions that  you can perform in this routine are restricted for safe calls. See <a href="https://docs.microsoft.com/windows-hardware/drivers/kernel/windows-kernel-mode-process-and-thread-manager#best">Best Practices</a>. </div><div> </div>
 
 ## -parameters

--- a/wdk-ddi-src/content/ntddk/nc-ntddk-pload_image_notify_routine.md
+++ b/wdk-ddi-src/content/ntddk/nc-ntddk-pload_image_notify_routine.md
@@ -48,7 +48,7 @@ req.typenames:
 ## -description
 
 
-Called by the operating system to notify the driver when a driver image or a user image (for example, a DLL or EXE) is mapped into virtual memory. The operating system invokes this routine after an image has been mapped to memory, but before it's entrypoint is called.
+Called by the operating system to notify the driver when a driver image or a user image (for example, a DLL or EXE) is mapped into virtual memory. The operating system invokes this routine after an image has been mapped to memory, but before its entrypoint is called.
 <div class="alert"><b>Warning</b>  The actions that  you can perform in this routine are restricted for safe calls. See <a href="https://docs.microsoft.com/windows-hardware/drivers/kernel/windows-kernel-mode-process-and-thread-manager#best">Best Practices</a>. </div><div> </div>
 
 ## -parameters


### PR DESCRIPTION
Developers (including me) think that this information would be useful to know, as it lets us know ahead of time whether or not `PsSetLoadImageNotifyRoutine` can catch image load(s) at the time we need it.