### PR TITLE
Added Bias-Free Communications Note

### DIFF
--- a/wdk-ddi-src/content/pep_x/nf-pep_x-pep_acpi_initialize_spb_spi_resource.md
+++ b/wdk-ddi-src/content/pep_x/nf-pep_x-pep_acpi_initialize_spb_spi_resource.md
@@ -44,6 +44,9 @@ req.typenames:
 
 # PEP_ACPI_INITIALIZE_SPB_SPI_RESOURCE function
 
+> [!NOTE]
+> Bias-free Communication
+Microsoft supports a diverse and inclusionary environment.  Within this document, there are references to the word 'slave.' Microsoft's [Style Guide for Bias-Free Communications](https://github.com/MicrosoftDocs/microsoft-style-guide/blob/master/styleguide/bias-free-communication.md) recognizes this as an exclusionary word.  This wording is used as it is currently the wording used within the software. For consistency, this document contains this word. When this word is removed from the software, we will correct this document to be in alignment.
 
 ## -description
 


### PR DESCRIPTION
Added a note recognizing that there is wording within this document, which some may feel is exclusionary.  However, this is done only to remain in alignment with the text in the software.