### PR TITLE
Update ExAllocatePoolQuota* Documentation

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolquotauninitialized.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolquotauninitialized.md
@@ -51,8 +51,6 @@ The **ExAllocatePoolQuotaUninitialized** routine allocates pool memory, charging
 
 The type of pool memory to allocate. For a description of the available pool memory types, see [**POOL_TYPE**](ne-wdm-_pool_type.md). 
 
-You can modify the enumeration value by performing a bitwise-OR with the **POOL_RAISE_IF_ALLOCATION_FAILURE** flag defined in `wdm.h`. This flag causes an exception to be raised if the request cannot be satisfied. Use of this flag is not recommended because it is costly. 
-
 Similarly, you can modify the *PoolType* value by bitwise-ORing this value with the **POOL_COLD_ALLOCATION** flag (also defined in `wdm.h`) as a hint to the kernel to allocate the memory from pages that are likely to be paged out quickly. To reduce the amount of resident pool memory as much as possible, you should not reference these allocations frequently. The **POOL_COLD_ALLOCATION** flag is only advisory. 
 
 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolquotazero.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolquotazero.md
@@ -52,8 +52,6 @@ This routine is a wrapper for and a recommended replacement option for [**ExAllo
 
 The type of pool memory to allocate. For a description of the available pool memory types, see [**POOL_TYPE**](ne-wdm-_pool_type.md). 
 
-You can modify the enumeration value by performing a bitwise-OR with the **POOL_RAISE_IF_ALLOCATION_FAILURE** flag defined in `wdm.h`. This flag causes an exception to be raised if the request cannot be satisfied. Use of this flag is not recommended because it is costly. 
-
 Similarly, you can modify the *PoolType* value by bitwise-ORing this value with the **POOL_COLD_ALLOCATION** flag (also defined in `wdm.h`) as a hint to the kernel to allocate the memory from pages that are likely to be paged out quickly. To reduce the amount of resident pool memory as much as possible, you should not reference these allocations frequently. The **POOL_COLD_ALLOCATION** flag is only advisory. 
 
 ### -param NumberOfBytes


### PR DESCRIPTION
Removed paragraphs about POOL_RAISE_IF_ALLOCATION_FAILURE because this is not a flag that can be passed to quota allocation functions.