### PR TITLE
Escape backslashes for <b>

### DIFF
--- a/wdk-ddi-src/content/irb/nf-irb-ataportregistrychannelsubkeyread.md
+++ b/wdk-ddi-src/content/irb/nf-irb-ataportregistrychannelsubkeyread.md
@@ -48,7 +48,7 @@ req.typenames:
 ## -description
 
 
-The <b>AtaPortRegistryChannelSubKeyRead</b> routine reads the data that is associated with the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\</b><i><service name></i><b>\Controller</b><i>N</i>\<b>Channel</b><i>M</i>, where <i>N </i>is the number of the controller and <i>M </i>is the number of the channel. 
+The <b>AtaPortRegistryChannelSubKeyRead</b> routine reads the data that is associated with the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\\</b><i><service name></i><b>\Controller</b><i>N</i>\\<b>Channel</b><i>M</i>, where <i>N </i>is the number of the controller and <i>M </i>is the number of the channel. 
 <div class="alert"><b>Note</b>  The ATA port driver and ATA miniport driver models may be altered or unavailable in the future. Instead, we recommend using the <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-driver">Storport driver</a> and <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-miniport-drivers">Storport miniport</a> driver models.</div><div> </div>
 
 ## -parameters

--- a/wdk-ddi-src/content/irb/nf-irb-ataportregistrychannelsubkeywrite.md
+++ b/wdk-ddi-src/content/irb/nf-irb-ataportregistrychannelsubkeywrite.md
@@ -48,7 +48,7 @@ req.typenames:
 ## -description
 
 
-The <b>AtaPortRegistryChannelSubKeyWrite</b> routine writes data to the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\</b><i><service name></i><b>\Controller</b><i>N</i>\<b>Channel</b><i>M</i>, where <i>N </i>is the number of the controller and <i>M </i>is the number of the channel. 
+The <b>AtaPortRegistryChannelSubKeyWrite</b> routine writes data to the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\\</b><i><service name></i><b>\Controller</b><i>N</i>\\<b>Channel</b><i>M</i>, where <i>N </i>is the number of the controller and <i>M </i>is the number of the channel. 
 <div class="alert"><b>Note</b>  The ATA port driver and ATA miniport driver models may be altered or unavailable in the future. Instead, we recommend using the <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-driver">Storport driver</a> and <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-miniport-drivers">Storport miniport</a> driver models.</div><div> </div>
 
 ## -parameters

--- a/wdk-ddi-src/content/irb/nf-irb-ataportregistrychannelsubkeywritedeferred.md
+++ b/wdk-ddi-src/content/irb/nf-irb-ataportregistrychannelsubkeywritedeferred.md
@@ -48,7 +48,7 @@ req.typenames:
 ## -description
 
 
-The <b>AtaPortRegistryChannelSubKeyWriteDeferred</b> routine writes data asynchronously to the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\</b><i><service name></i><b>\Controller</b><i>N</i>\<b>Channel</b><i>M</i>, where <i>N </i>is the number of the controller and <i>M </i>is the number of the channel.
+The <b>AtaPortRegistryChannelSubKeyWriteDeferred</b> routine writes data asynchronously to the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\\</b><i><service name></i><b>\Controller</b><i>N</i>\\<b>Channel</b><i>M</i>, where <i>N </i>is the number of the controller and <i>M </i>is the number of the channel.
 <div class="alert"><b>Note</b>  The ATA port driver and ATA miniport driver models may be altered or unavailable in the future. Instead, we recommend using the <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-driver">Storport driver</a> and <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-miniport-drivers">Storport miniport</a> driver models.</div><div> </div>
 
 ## -parameters

--- a/wdk-ddi-src/content/irb/nf-irb-ataportregistrycontrollerkeyread.md
+++ b/wdk-ddi-src/content/irb/nf-irb-ataportregistrycontrollerkeyread.md
@@ -48,7 +48,7 @@ req.typenames:
 ## -description
 
 
-The <b>AtaPortRegistryControllerKeyRead</b> routine reads the data that is associated with the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\</b><i><service name></i><b>\Controller</b><i>N</i>, where <i>N </i>is the number of the controller.
+The <b>AtaPortRegistryControllerKeyRead</b> routine reads the data that is associated with the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\\</b><i><service name></i><b>\Controller</b><i>N</i>, where <i>N </i>is the number of the controller.
 <div class="alert"><b>Note</b>  The ATA port driver and ATA miniport driver models may be altered or unavailable in the future. Instead, we recommend using the <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-driver">Storport driver</a> and <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-miniport-drivers">Storport miniport</a> driver models.</div><div> </div>
 
 ## -parameters

--- a/wdk-ddi-src/content/irb/nf-irb-ataportregistrycontrollerkeywrite.md
+++ b/wdk-ddi-src/content/irb/nf-irb-ataportregistrycontrollerkeywrite.md
@@ -48,7 +48,7 @@ req.typenames:
 ## -description
 
 
-The <b>AtaPortRegistryControllerKeyWrite</b> routine writes the data to the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\</b><i><service name></i><b>\Controller</b><i>N</i>, where <i>N </i>is the number of the controller. 
+The <b>AtaPortRegistryControllerKeyWrite</b> routine writes the data to the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\\</b><i><service name></i><b>\Controller</b><i>N</i>, where <i>N </i>is the number of the controller. 
 <div class="alert"><b>Note</b>  The ATA port driver and ATA miniport driver models may be altered or unavailable in the future. Instead, we recommend using the <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-driver">Storport driver</a> and <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-miniport-drivers">Storport miniport</a> driver models.</div><div> </div>
 
 ## -parameters

--- a/wdk-ddi-src/content/irb/nf-irb-ataportregistrycontrollerkeywritedeferred.md
+++ b/wdk-ddi-src/content/irb/nf-irb-ataportregistrycontrollerkeywritedeferred.md
@@ -48,7 +48,7 @@ req.typenames:
 ## -description
 
 
-The <b>AtaPortRegistryControllerKeyWriteDeferred</b> routine writes the data asynchronously to the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\</b><i><service name></i><b>\Controller</b><i>N</i>, where <i>N </i>is the number of the controller. 
+The <b>AtaPortRegistryControllerKeyWriteDeferred</b> routine writes the data asynchronously to the indicated value name under the registry key <b>HKLM\CurrentControlSet\Services\\</b><i><service name></i><b>\Controller</b><i>N</i>, where <i>N </i>is the number of the controller. 
 <div class="alert"><b>Note</b>  The ATA port driver and ATA miniport driver models may be altered or unavailable in the future. Instead, we recommend using the <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-driver">Storport driver</a> and <a href="https://docs.microsoft.com/windows-hardware/drivers/storage/storport-miniport-drivers">Storport miniport</a> driver models.</div><div> </div>
 
 ## -parameters

--- a/wdk-ddi-src/content/usbioctl/ni-usbioctl-ioctl_usb_hub_cycle_port.md
+++ b/wdk-ddi-src/content/usbioctl/ni-usbioctl-ioctl_usb_hub_cycle_port.md
@@ -110,7 +110,7 @@ The USB stack sets <b>Irp->IoStatus.Status</b> to STATUS_SUCCESS if the request 
 
 You can also power cycle the port by using the <b>Device Manager</b>'s <b>Enable</b>/<b>Disable</b> feature. This feature causes the bus driver to reset the device. Alternatively, you can use DevCon to enable or disable the device. 
 
-The executable for DevCon can be found in the <i><install_path></i><b>\WinDDK\</b><i>build_number</i><b>\tools\devcon\</b><i><arch></i><b>\devcon.exe</b> folder.
+The executable for DevCon can be found in the <i><install_path></i><b>\WinDDK\\</b><i>build_number</i><b>\tools\devcon\\</b><i><arch></i><b>\devcon.exe</b> folder.
 
 
 


### PR DESCRIPTION
Do you plan to migrate to Markdown syntax? There are too many angle brackets to fix like these.