### PR TITLE
Fix code block formatting of example section

### DIFF
--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestprobeandlockuserbufferforread.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestprobeandlockuserbufferforread.md
@@ -189,6 +189,7 @@ Calls <b>WdfRequestProbeAndLockUserBufferForRead</b> and <a href="https://docs.m
 
 </li>
 </ol>
+
 ```cpp
 VOID
 NonPnpEvtIoInCallerContext(


### PR DESCRIPTION
Code block opening being next to the end of HTML tag seems to break the formatting. This is fixed by separating html and code block by a new line.