### PR TITLE
Add space after ObDereferenceObject in Remarks

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ioenumeratedeviceobjectlist.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ioenumeratedeviceobjectlist.md
@@ -135,7 +135,7 @@ The device objects created by the base file system, so the filter knows the numb
 
 In the latter case, the filter driver typically calls <b>IoEnumerateDeviceObjectList</b> twice: once to get the number of device objects in the list, and once to get the device object list itself. In the first call, the caller should set the <i>DeviceObjectList</i> parameter to <b>NULL</b> and <i>DeviceObjectListSize</i> to zero. In the second call, <i>DeviceObjectList</i> should contain a pointer to an appropriately-sized pointer array, and <i>DeviceObjectListSize</i> should contain the size, in bytes, of that array. 
 
-<b>IoEnumerateDeviceObjectList</b> increments the reference count on every device object in the list pointed to by <i>DeviceObjectList</i>. Thus every successful call to <b>IoEnumerateDeviceObjectList</b> must be matched by a subsequent call to <a href="https://docs.microsoft.com/windows-hardware/drivers/ddi/wdm/nf-wdm-obdereferenceobject">ObDereferenceObject</a>for each device object in the list. Failure to do so prevents the system from freeing or deleting these device objects because of an outstanding reference count. 
+<b>IoEnumerateDeviceObjectList</b> increments the reference count on every device object in the list pointed to by <i>DeviceObjectList</i>. Thus every successful call to <b>IoEnumerateDeviceObjectList</b> must be matched by a subsequent call to <a href="https://docs.microsoft.com/windows-hardware/drivers/ddi/wdm/nf-wdm-obdereferenceobject">ObDereferenceObject</a> for each device object in the list. Failure to do so prevents the system from freeing or deleting these device objects because of an outstanding reference count. 
 
 
 


### PR DESCRIPTION
Simple typo fix