### PR TITLE
Fix wrong links in WSK doc

### DIFF
--- a/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_accept.md
+++ b/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_accept.md
@@ -238,7 +238,7 @@ When the
     <b>WskAccept</b> function successfully accepts an incoming connection, all of the event callback functions
     on the accepted socket are disabled by default. For more information about enabling any of the accepted
     socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/windows/desktop/api/evntprov/nc-evntprov-penablecallback">Enabling and
+    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 If a WSK application specifies a non-<b>NULL</b> pointer in the 

--- a/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_accept.md
+++ b/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_accept.md
@@ -238,7 +238,7 @@ When the
     <b>WskAccept</b> function successfully accepts an incoming connection, all of the event callback functions
     on the accepted socket are disabled by default. For more information about enabling any of the accepted
     socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
+    <a href="https://docs.microsoft.com/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 If a WSK application specifies a non-<b>NULL</b> pointer in the 

--- a/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_accept_event.md
+++ b/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_accept_event.md
@@ -193,7 +193,7 @@ The WSK subsystem calls a WSK application's
     socket only if the event callback function was previously enabled with the 
     <a href="https://docs.microsoft.com/windows-hardware/drivers/network/so-wsk-event-callback">SO_WSK_EVENT_CALLBACK</a> socket option.
     For more information about enabling a socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
+    <a href="https://docs.microsoft.com/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 If a WSK application's 

--- a/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_accept_event.md
+++ b/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_accept_event.md
@@ -193,7 +193,7 @@ The WSK subsystem calls a WSK application's
     socket only if the event callback function was previously enabled with the 
     <a href="https://docs.microsoft.com/windows-hardware/drivers/network/so-wsk-event-callback">SO_WSK_EVENT_CALLBACK</a> socket option.
     For more information about enabling a socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/windows/desktop/api/evntprov/nc-evntprov-penablecallback">Enabling and
+    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 If a WSK application's 

--- a/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_disconnect_event.md
+++ b/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_disconnect_event.md
@@ -133,7 +133,7 @@ The WSK subsystem calls a WSK application's
     remote application only if the event callback function was previously enabled with the 
     <a href="https://docs.microsoft.com/windows-hardware/drivers/network/so-wsk-event-callback">SO_WSK_EVENT_CALLBACK</a> socket option.
     For more information about enabling a socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/windows/desktop/api/evntprov/nc-evntprov-penablecallback">Enabling and
+    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 If the remote application performed a graceful disconnect of the socket, no further data will be

--- a/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_disconnect_event.md
+++ b/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_disconnect_event.md
@@ -133,7 +133,7 @@ The WSK subsystem calls a WSK application's
     remote application only if the event callback function was previously enabled with the 
     <a href="https://docs.microsoft.com/windows-hardware/drivers/network/so-wsk-event-callback">SO_WSK_EVENT_CALLBACK</a> socket option.
     For more information about enabling a socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
+    <a href="https://docs.microsoft.com/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 If the remote application performed a graceful disconnect of the socket, no further data will be

--- a/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_send_backlog_event.md
+++ b/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_send_backlog_event.md
@@ -115,7 +115,7 @@ The WSK subsystem calls a WSK application's
     connection-oriented socket only if the event callback function was previously enabled with the 
     <a href="https://docs.microsoft.com/windows-hardware/drivers/network/so-wsk-event-callback">SO_WSK_EVENT_CALLBACK</a> socket option.
     For more information about enabling a socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/windows/desktop/api/evntprov/nc-evntprov-penablecallback">Enabling and
+    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 The ideal send backlog size for a connection-oriented socket is the optimal amount of send data that

--- a/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_send_backlog_event.md
+++ b/wdk-ddi-src/content/wsk/nc-wsk-pfn_wsk_send_backlog_event.md
@@ -115,7 +115,7 @@ The WSK subsystem calls a WSK application's
     connection-oriented socket only if the event callback function was previously enabled with the 
     <a href="https://docs.microsoft.com/windows-hardware/drivers/network/so-wsk-event-callback">SO_WSK_EVENT_CALLBACK</a> socket option.
     For more information about enabling a socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
+    <a href="https://docs.microsoft.com/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 The ideal send backlog size for a connection-oriented socket is the optimal amount of send data that

--- a/wdk-ddi-src/content/wsk/ns-wsk-_wsk_event_callback_control.md
+++ b/wdk-ddi-src/content/wsk/ns-wsk-_wsk_event_callback_control.md
@@ -94,7 +94,7 @@ For more information about statically enabling certain event callback functions 
     WSK_SET_STATIC_EVENT_CALLBACKS</a>.
 
 For more information about enabling and disabling a socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/windows/desktop/api/evntprov/nc-evntprov-penablecallback">Enabling and
+    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 

--- a/wdk-ddi-src/content/wsk/ns-wsk-_wsk_event_callback_control.md
+++ b/wdk-ddi-src/content/wsk/ns-wsk-_wsk_event_callback_control.md
@@ -94,7 +94,7 @@ For more information about statically enabling certain event callback functions 
     WSK_SET_STATIC_EVENT_CALLBACKS</a>.
 
 For more information about enabling and disabling a socket's event callback functions, see 
-    <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
+    <a href="https://docs.microsoft.com/windows-hardware/drivers/network/enabling-and-disabling-event-callback-functions">Enabling and
     Disabling Event Callback Functions</a>.
 
 


### PR DESCRIPTION
The link for "Enabling and Disabling Event Callback Functions" is wrong in these pages. This PR fixes them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoftdocs/windows-driver-docs-ddi/908)
<!-- Reviewable:end -->
