### PR TITLE
Note that these do not initialize allocated memory

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlallocatepoolwithquotatag.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlallocatepoolwithquotatag.md
@@ -85,6 +85,9 @@ The system associates the pool tag specified by the <i>Tag</i> parameter with th
 
 For more information about memory management, see <a href="https://docs.microsoft.com/windows-hardware/drivers/kernel/managing-memory-for-drivers">Memory Management</a>. 
 
+> [!NOTE]
+> Memory that **FsRtlAllocatePoolWithQuotaTag** allocates is uninitialized. A kernel-mode driver must first zero this memory if it is going to make it visible to user-mode software (to avoid leaking potentially privileged contents).
+
 Callers of <b>FsRtlAllocatePoolWithQuotaTag</b> must be running at IRQL <= DISPATCH_LEVEL. A caller at DISPATCH_LEVEL must specify a <b>NonPaged</b><i>XxxPoolType</i>. Otherwise, the caller must be running at IRQL < DISPATCH_LEVEL.
 
 ## -see-also

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlallocatepoolwithtag.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlallocatepoolwithtag.md
@@ -85,6 +85,9 @@ The system associates the pool tag specified by the <i>Tag</i> parameter with th
 
 For more information about memory management, see <a href="https://docs.microsoft.com/windows-hardware/drivers/kernel/managing-memory-for-drivers">Memory Management</a>. 
 
+> [!NOTE]
+> Memory that **FsRtlAllocatePoolWithTag** allocates is uninitialized. A kernel-mode driver must first zero this memory if it is going to make it visible to user-mode software (to avoid leaking potentially privileged contents).
+
 Callers of <b>FsRtlAllocatePoolWithTag</b> must be running at IRQL <= DISPATCH_LEVEL. A caller at DISPATCH_LEVEL must specify a <b>NonPaged</b><i>XxxPoolType</i>. Otherwise, the caller must be running at IRQL <= APC_LEVEL.
 
 ## -see-also


### PR DESCRIPTION
`FsRtlAllocatePoolWithTag` and `FsRtlAllocatePoolWithQuotaTag` are macros that call `ExAllocate...` routines that do not initialize memory. This change adds notes to that effect similar to the one at the bottom of [ExAllocatePoolWithTag](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepoolwithtag)'s Remarks section.