### PR TITLE
Add pipes to the left and right of table data

### DIFF
--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstream-allocateaudiobuffer.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstream-allocateaudiobuffer.md
@@ -72,11 +72,11 @@ Specifies the type of caching that the client requests for the audio buffer. Thi
 ## -returns
 
 This method returns NTSTATUS. AllocateAudioBuffer returns STATUS_SUCCESS if the call was successful. Otherwise, the method returns an appropriate error status code. The following table shows some of the possible error status codes.
-Return code | Description
-------------|-----------
-STATUS_UNSUCCESSFUL | The driver does not support the specified combination of buffer attributes.
-STATUS_INSUFFICIENT_RESOURCES | Insufficient memory is available to allocate the buffer.
-STATUS_DEVICE_NOT_READY | The device is not ready.
+| Return code                   | Description                                                                 |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| STATUS_UNSUCCESSFUL           | The driver does not support the specified combination of buffer attributes. |
+| STATUS_INSUFFICIENT_RESOURCES | Insufficient memory is available to allocate the buffer.                    |
+| STATUS_DEVICE_NOT_READY       | The device is not ready.                                                    |
 
 ## -remarks
 


### PR DESCRIPTION
The documentation on https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/portcls/nf-portcls-iminiportwavertstream-allocateaudiobuffer does not seem to be rendering that table correctly.

Looking at the table documentation, I see that tables have pipes to the left and right of columns, so I added those additional pipes to see if it renders correctly. Also aligned the whole table in source code to make it easier to read.