### PR TITLE
Update nf-wdm-rtlguidfromstring.md

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlguidfromstring.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlguidfromstring.md
@@ -54,7 +54,8 @@ The <b>RtlGUIDFromString</b> routine converts the given Unicode string to a GUID
 ### -param GuidString 
 
 [in]
-Pointer to the buffered Unicode string to be converted to a GUID.
+Pointer to the buffered Unicode string to be converted to a GUID. The string should be in the following form (including the braces):
+{00000000-0000-0000-0000-000000000000}
 
 ### -param Guid 
 


### PR DESCRIPTION
I was trying to use this API when I realized the input UNICODE_STRING needs to have included the braces too. I had to debug through the function to identify the issue. It will be good if the same is mentioned in the docs.