### PR TITLE
Edit remarks of EnableEvents to align with actual behavior

### DIFF
--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionmanager-enableevents.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionmanager-enableevents.md
@@ -63,7 +63,7 @@ The printer extension should call this method when it is launched so that driver
 
 ## -remarks
 
-In the case of a driver event like, for example, Print Preferences or Printer Notifications, the app is expected to call <b>EnableEvents</b>. But if the app doesn't call <b>EnableEvents</b> within 30s, the print system assumes that a UI was  called but it's not being responsive so a standard UI is displayed instead.
+In the case of a driver event like, for example, Print Preferences or Printer Notifications, the app is expected to call <b>EnableEvents</b>. But if the app doesn't call <b>EnableEvents</b> within 5 seconds, the print system assumes that a UI was  called but it's not being responsive so a standard UI is displayed instead.
 
 ## -see-also
 


### PR DESCRIPTION
A Printer Extension app is expected to call IPrinterExtensionManager::EnableEvents before a certain timeout period, but that timeout period is "5 seconds" and not "30 seconds".  This is reinforced by actual behavior and also through the document below.  This proposal is to modify this page to reflect those.

https://docs.microsoft.com/en-us/windows-hardware/drivers/print/printer-extensions#enabling-events 
>If an app does not call EnableEvents within 5 seconds, Windows will timeout and launch a standard UI.