### PR TITLE
Update nf-fltkernel-fltsetsecurityobject.md

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsetsecurityobject.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsetsecurityobject.md
@@ -46,71 +46,32 @@ api_name:
 
 ## -description
 
-<b>FltSetSecurityObject</b> sets an object's security state.
+**FltSetSecurityObject** sets an object's security state.
 
 ## -parameters
 
 ### -param Instance 
 
 [in]
-Opaque instance pointer for the caller. This parameter is required and cannot be <b>NULL</b>.
+Opaque instance pointer for the caller. This parameter is required and cannot be **NULL**.
 
 ### -param FileObject 
 
 [in]
-File object pointer for the object whose security state is to be set. The caller must have the access specified in the Meaning column of the table shown in the description of the <i>SecurityInformation</i> parameter. This parameter is required and cannot be <b>NULL</b>.
+File object pointer for the object whose security state is to be set. The caller must have the access specified in the Meaning column of the table shown in the description of the *SecurityInformation* parameter. This parameter is required and cannot be **NULL**.
 
 ### -param SecurityInformation 
 
 [in]
-Pointer to a <a href="/windows-hardware/drivers/ifs/security-information">SECURITY_INFORMATION</a> value specifying the information to be set as a combination of one or more of the following. This parameter is required and cannot be <b>NULL</b>. 
+[SECURITY_INFORMATION](/windows-hardware/drivers/ifs/security-information) value specifying the information to be set as a combination of one or more of the following. 
 
-<table>
-<tr>
-<th>Value</th>
-<th>Meaning</th>
-</tr>
-<tr>
-<td>
-DACL_SECURITY_INFORMATION
+|Value|Meaning|
+|:-|:-|
+|OWNER_SECURITY_INFORMATION|Indicates the owner identifier of the object is to be set. Requires WRITE_OWNER access.|
+|GROUP_SECURITY_INFORMATION|Indicates the primary group identifier of the object is to be set. Requires WRITE_OWNER access.|
+|DACL_SECURITY_INFORMATION|Indicates the discretionary access control list (DACL) of the object is to be set. Requires WRITE_DAC access.|
+|SACL_SECURITY_INFORMATION|Indicates the system ACL (SACL) of the object is to be set. Requires ACCESS_SYSTEM_SECURITY access. |
 
-</td>
-<td>
-Indicates the discretionary access control list (DACL) of the object is to be set. Requires WRITE_DAC access. 
-
-</td>
-</tr>
-<tr>
-<td>
-GROUP_SECURITY_INFORMATION
-
-</td>
-<td>
-Indicates the primary group identifier of the object is to be set. Requires WRITE_OWNER access. 
-
-</td>
-</tr>
-<tr>
-<td>
-OWNER_SECURITY_INFORMATION
-
-</td>
-<td>
-Indicates the owner identifier of the object is to be set. Requires WRITE_OWNER access. 
-
-</td>
-</tr>
-<tr>
-<td>
-SACL_SECURITY_INFORMATION
-
-</td>
-<td>
-Indicates the system ACL (SACL) of the object is to be set. Requires ACCESS_SYSTEM_SECURITY access. 
-
-</td>
-</tr>
-</table>
 
 ### -param SecurityDescriptor 
 
@@ -119,127 +80,44 @@ Pointer to the security descriptor to be set for the object.
 
 ## -returns
 
-<b>FltSetSecurityObject</b> returns STATUS_SUCCESS or an appropriate NTSTATUS value such as one of the following: 
+**FltSetSecurityObject** returns STATUS_SUCCESS or an appropriate NTSTATUS value such as one of the following: 
 
-<table>
-<tr>
-<th>Return code</th>
-<th>Description</th>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>STATUS_ACCESS_DENIED</b></dt>
-</dl>
-</td>
-<td width="60%">
-The caller did not have the required access. This is an error code. 
+|Return code|Description|
+|:-|:-|
+|**STATUS_ACCESS_DENIED**|The caller did not have the required access. This is an error code.|
+|**STATUS_ACCESS_VIOLATION**|*SecurityDescriptor* was a **NULL** pointer. This is an error code.|
+|**STATUS_INSUFFICIENT_RESOURCES**|The object's security descriptor could not be captured. This is an error code.|
+|**STATUS_INVALID_ACL**|The object's security descriptor contained an invalid ACL. This is an error code.|
+|**STATUS_INVALID_SECURITY_DESCR**|*SecurityDescriptor* did not point to a valid security descriptor. This is an error code.|
+|**STATUS_INVALID_SID**|The object's security descriptor contained an invalid SID. This is an error code.|
+|**STATUS_UNKNOWN_REVISION**|The revision level of the object's security descriptor was unknown or not supported. This is an error code.|
+|**STATUS_NOT_IMPLEMENTED**|The **FltSetSecurityObject** routine is present but not supported in the operating system environment in which it was called.|
 
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>STATUS_ACCESS_VIOLATION</b></dt>
-</dl>
-</td>
-<td width="60%">
-<i>SecurityDescriptor</i> was a <b>NULL</b> pointer. This is an error code. 
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>STATUS_INSUFFICIENT_RESOURCES</b></dt>
-</dl>
-</td>
-<td width="60%">
-The object's security descriptor could not be captured. This is an error code. 
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>STATUS_INVALID_ACL</b></dt>
-</dl>
-</td>
-<td width="60%">
-The object's security descriptor contained an invalid ACL. This is an error code. 
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>STATUS_INVALID_SECURITY_DESCR</b></dt>
-</dl>
-</td>
-<td width="60%">
-<i>SecurityDescriptor</i> did not point to a valid security descriptor. This is an error code. 
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>STATUS_INVALID_SID</b></dt>
-</dl>
-</td>
-<td width="60%">
-The object's security descriptor contained an invalid SID. This is an error code. 
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>STATUS_UNKNOWN_REVISION</b></dt>
-</dl>
-</td>
-<td width="60%">
-The revision level of the object's security descriptor was unknown or not supported. This is an error code. 
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>STATUS_NOT_IMPLEMENTED</b></dt>
-</dl>
-</td>
-<td width="60%">
-The <b>FltSetSecurityObject</b> routine is present but not supported in the operating system environment in which it was called.
-
-</td>
-</tr>
-</table>
 
 ## -remarks
 
-The <b>FltSetSecurityObject</b> routine is present and supported starting with Windows Vista.  In Windows 2000, Windows XP, and Server 2003 SP1, the routine is present but not supported, and will return STATUS_NOT_IMPLEMENTED if called in any of these environments.
+The **FltSetSecurityObject** routine is present and supported starting with Windows Vista.  In Windows 2000, Windows XP, and Server 2003 SP1, the routine is present but not supported, and will return STATUS_NOT_IMPLEMENTED if called in any of these environments.
 
-A security descriptor can be in absolute or self-relative form. In self-relative form, all members of the structure are located contiguously in memory. In absolute form, the structure only contains pointers to the members. For more information, see "Absolute and Self-Relative Security Descriptors" in the Security section of the Microsoft Windows SDK documentation. 
+A security descriptor can be in absolute or self-relative form. In self-relative form, all members of the structure are located contiguously in memory. In absolute form, the structure only contains pointers to the members. For more information, see [Absolute and Self-Relative Security Descriptors](/windows/win32/secauthz/absolute-and-self-relative-security-descriptors). 
 
 For more information about security and access control, see the documentation on these topics in the Windows SDK.
 
 ## -see-also
 
-<a href="/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltquerysecurityobject">FltQuerySecurityObject</a>
+[SECURITY_DESCRIPTOR](../ntifs/ns-ntifs-_security_descriptor.md)
 
 
 
-<a href="/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_security_descriptor">SECURITY_DESCRIPTOR</a>
+[SECURITY_INFORMATION](/windows-hardware/drivers/ifs/security-information)
 
 
 
-<a href="/windows-hardware/drivers/ifs/security-information">SECURITY_INFORMATION</a>
+[ZwQuerySecurityObject](../ntifs/nf-ntifs-zwquerysecurityobject.md)
 
 
 
-<a href="/previous-versions/ff567066(v=vs.85)">ZwQuerySecurityObject</a>
+[ZwSetSecurityObject](../ntifs/nf-ntifs-zwsetsecurityobject.md)
 
 
 
-<a href="/previous-versions/ff567106(v=vs.85)">ZwSetSecurityObject</a>
+[FltQuerySecurityObject](./nf-fltkernel-fltquerysecurityobject.md)

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsetsecurityobject.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsetsecurityobject.md
@@ -43,7 +43,6 @@ api_name:
 
 # FltSetSecurityObject function
 
-
 ## -description
 
 **FltSetSecurityObject** sets an object's security state.
@@ -52,47 +51,41 @@ api_name:
 
 ### -param Instance 
 
-[in]
-Opaque instance pointer for the caller. This parameter is required and cannot be **NULL**.
+[in] Opaque instance pointer for the caller. This parameter is required and cannot be **NULL**.
 
 ### -param FileObject 
 
-[in]
-File object pointer for the object whose security state is to be set. The caller must have the access specified in the Meaning column of the table shown in the description of the *SecurityInformation* parameter. This parameter is required and cannot be **NULL**.
+[in] File object pointer for the object whose security state is to be set. The caller must have the access specified in the Meaning column of the table shown in the description of the **SecurityInformation** parameter. This parameter is required and cannot be **NULL**.
 
 ### -param SecurityInformation 
 
-[in]
-[SECURITY_INFORMATION](/windows-hardware/drivers/ifs/security-information) value specifying the information to be set as a combination of one or more of the following. 
+[in] [**SECURITY_INFORMATION**](/windows-hardware/drivers/ifs/security-information) value specifying the information to be set as a combination of one or more of the following. 
 
-|Value|Meaning|
-|:-|:-|
-|OWNER_SECURITY_INFORMATION|Indicates the owner identifier of the object is to be set. Requires WRITE_OWNER access.|
-|GROUP_SECURITY_INFORMATION|Indicates the primary group identifier of the object is to be set. Requires WRITE_OWNER access.|
-|DACL_SECURITY_INFORMATION|Indicates the discretionary access control list (DACL) of the object is to be set. Requires WRITE_DAC access.|
-|SACL_SECURITY_INFORMATION|Indicates the system ACL (SACL) of the object is to be set. Requires ACCESS_SYSTEM_SECURITY access. |
-
+| Value | Meaning |
+| ----- | ------- |
+| OWNER_SECURITY_INFORMATION | Indicates the owner identifier of the object is to be set. Requires WRITE_OWNER access. |
+| GROUP_SECURITY_INFORMATION | Indicates the primary group identifier of the object is to be set. Requires WRITE_OWNER access. |
+| DACL_SECURITY_INFORMATION | Indicates the discretionary access control list (DACL) of the object is to be set. Requires WRITE_DAC access. |
+| SACL_SECURITY_INFORMATION | Indicates the system ACL (SACL) of the object is to be set. Requires ACCESS_SYSTEM_SECURITY access. |
 
 ### -param SecurityDescriptor 
 
-[in]
-Pointer to the security descriptor to be set for the object.
+[in] Pointer to the security descriptor to be set for the object.
 
 ## -returns
 
 **FltSetSecurityObject** returns STATUS_SUCCESS or an appropriate NTSTATUS value such as one of the following: 
 
-|Return code|Description|
-|:-|:-|
-|**STATUS_ACCESS_DENIED**|The caller did not have the required access. This is an error code.|
-|**STATUS_ACCESS_VIOLATION**|*SecurityDescriptor* was a **NULL** pointer. This is an error code.|
-|**STATUS_INSUFFICIENT_RESOURCES**|The object's security descriptor could not be captured. This is an error code.|
-|**STATUS_INVALID_ACL**|The object's security descriptor contained an invalid ACL. This is an error code.|
-|**STATUS_INVALID_SECURITY_DESCR**|*SecurityDescriptor* did not point to a valid security descriptor. This is an error code.|
-|**STATUS_INVALID_SID**|The object's security descriptor contained an invalid SID. This is an error code.|
-|**STATUS_UNKNOWN_REVISION**|The revision level of the object's security descriptor was unknown or not supported. This is an error code.|
-|**STATUS_NOT_IMPLEMENTED**|The **FltSetSecurityObject** routine is present but not supported in the operating system environment in which it was called.|
-
+| Return code | Description |
+| ----------- | ----------- |
+| **STATUS_ACCESS_DENIED** | The caller did not have the required access. This is an error code. |
+| **STATUS_ACCESS_VIOLATION**| *SecurityDescriptor* was a **NULL** pointer. This is an error code. |
+| **STATUS_INSUFFICIENT_RESOURCES** | The object's security descriptor could not be captured. This is an error code. |
+| **STATUS_INVALID_ACL** | The object's security descriptor contained an invalid ACL. This is an error code. |
+| **STATUS_INVALID_SECURITY_DESCR** | *SecurityDescriptor* did not point to a valid security descriptor. This is an error code. |
+| **STATUS_INVALID_SID** | The object's security descriptor contained an invalid SID. This is an error code. |
+| **STATUS_UNKNOWN_REVISION** | The revision level of the object's security descriptor was unknown or not supported. This is an error code. |
+| **STATUS_NOT_IMPLEMENTED** | The **FltSetSecurityObject** routine is present but not supported in the operating system environment in which it was called. |
 
 ## -remarks
 
@@ -106,18 +99,10 @@ For more information about security and access control, see the documentation on
 
 [SECURITY_DESCRIPTOR](../ntifs/ns-ntifs-_security_descriptor.md)
 
-
-
 [SECURITY_INFORMATION](/windows-hardware/drivers/ifs/security-information)
-
-
 
 [ZwQuerySecurityObject](../ntifs/nf-ntifs-zwquerysecurityobject.md)
 
-
-
 [ZwSetSecurityObject](../ntifs/nf-ntifs-zwsetsecurityobject.md)
-
-
 
 [FltQuerySecurityObject](./nf-fltkernel-fltquerysecurityobject.md)

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsetsecurityobject.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsetsecurityobject.md
@@ -78,14 +78,14 @@ api_name:
 
 | Return code | Description |
 | ----------- | ----------- |
-| **STATUS_ACCESS_DENIED** | The caller did not have the required access. This is an error code. |
-| **STATUS_ACCESS_VIOLATION**| *SecurityDescriptor* was a **NULL** pointer. This is an error code. |
-| **STATUS_INSUFFICIENT_RESOURCES** | The object's security descriptor could not be captured. This is an error code. |
-| **STATUS_INVALID_ACL** | The object's security descriptor contained an invalid ACL. This is an error code. |
-| **STATUS_INVALID_SECURITY_DESCR** | *SecurityDescriptor* did not point to a valid security descriptor. This is an error code. |
-| **STATUS_INVALID_SID** | The object's security descriptor contained an invalid SID. This is an error code. |
-| **STATUS_UNKNOWN_REVISION** | The revision level of the object's security descriptor was unknown or not supported. This is an error code. |
-| **STATUS_NOT_IMPLEMENTED** | The **FltSetSecurityObject** routine is present but not supported in the operating system environment in which it was called. |
+| STATUS_ACCESS_DENIED | The caller did not have the required access. This is an error code. |
+| STATUS_ACCESS_VIOLATION| *SecurityDescriptor* was a **NULL** pointer. This is an error code. |
+| STATUS_INSUFFICIENT_RESOURCES | The object's security descriptor could not be captured. This is an error code. |
+| STATUS_INVALID_ACL | The object's security descriptor contained an invalid ACL. This is an error code. |
+| STATUS_INVALID_SECURITY_DESCR | *SecurityDescriptor* did not point to a valid security descriptor. This is an error code. |
+| STATUS_INVALID_SID | The object's security descriptor contained an invalid SID. This is an error code. |
+| STATUS_UNKNOWN_REVISION | The revision level of the object's security descriptor was unknown or not supported. This is an error code. |
+| STATUS_NOT_IMPLEMENTED | The **FltSetSecurityObject** routine is present but not supported in the operating system environment in which it was called. |
 
 ## -remarks
 


### PR DESCRIPTION
* Fix description of `SecurityInformation
* Fix link to ZwSetSecurityObject
* Fix link to ZwQuerySecurityObject
* Reorder SECURITY_INFORMATION value table
* Add link to Absolute and Self-Relative Security Descriptors