### PR TITLE
Add information about SecurityInformation

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntquerysecurityobject.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntquerysecurityobject.md
@@ -56,14 +56,14 @@ The **NtQuerySecurityObject** routine retrieves a copy of an object's security d
 
 ### -param SecurityInformation
 
-[in] A [**SECURITY_INFORMATION**](/windows-hardware/drivers/ifs/security-information) value specifying the information to be queried.
+[in] A [**SECURITY_INFORMATION**](/windows-hardware/drivers/ifs/security-information) value specifying the information to be queried as a combination of one or more of the following.
 
 | Value | Meaning |
 | ----- | ------- |
-| DACL_SECURITY_INFORMATION | The object's discretionary access control list (DACL) is being queried. Requires READ_CONTROL access. |
-| GROUP_SECURITY_INFORMATION | The object's primary group identifier is being queried. Requires READ_CONTROL access. |
 | OWNER_SECURITY_INFORMATION | The object's owner identifier is being queried. Requires READ_CONTROL access. |
+| GROUP_SECURITY_INFORMATION | The object's primary group identifier is being queried. Requires READ_CONTROL access. |
 | SACL_SECURITY_INFORMATION | The object's system ACL (SACL) is being queried. Requires ACCESS_SYSTEM_SECURITY access. |
+| DACL_SECURITY_INFORMATION | The object's discretionary access control list (DACL) is being queried. Requires READ_CONTROL access. |
 
 ### -param SecurityDescriptor
 
@@ -92,7 +92,7 @@ The **NtQuerySecurityObject** routine retrieves a copy of an object's security d
 
 Minifilters should call [**FltQuerySecurityObject**](/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltquerysecurityobject).
 
-A security descriptor can be in absolute or self-relative form. In self-relative form, all members of the structure are located contiguously in memory. In absolute form, the structure only contains pointers to the members.
+A security descriptor can be in absolute or self-relative form. In self-relative form, all members of the structure are located contiguously in memory. In absolute form, the structure only contains pointers to the members. For more information, see [Absolute and Self-Relative Security Descriptors](/windows/win32/secauthz/absolute-and-self-relative-security-descriptors). 
 
 The NTFS file system imposes a 64K limit on the size of the security descriptor that is written to disk for a file. (The FAT file system does not support security descriptors for files.) Thus a 64K **SecurityDescriptor** buffer is guaranteed to be large enough to hold the returned **SECURITY_DESCRIPTOR** structure.
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntquerysecurityobject.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntquerysecurityobject.md
@@ -67,7 +67,7 @@ The **NtQuerySecurityObject** routine retrieves a copy of an object's security d
 
 ### -param SecurityDescriptor
 
-[out] Caller-allocated buffer that **NtQuerySecurityObject** fills with a copy of the specified security descriptor. The [**SECURITY_DESCRIPTOR**](/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_security_descriptor) structure is returned in self-relative format.
+[out] Caller-allocated buffer that **NtQuerySecurityObject** fills with a copy of the specified security descriptor. The [**SECURITY_DESCRIPTOR**](ns-ntifs-_security_descriptor.md) structure is returned in self-relative format.
 
 ### -param Length
 
@@ -90,7 +90,7 @@ The **NtQuerySecurityObject** routine retrieves a copy of an object's security d
 
 ## -remarks
 
-Minifilters should call [**FltQuerySecurityObject**](/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltquerysecurityobject).
+Minifilters should call [**FltQuerySecurityObject**](../fltkernel/nf-fltkernel-fltquerysecurityobject.md).
 
 A security descriptor can be in absolute or self-relative form. In self-relative form, all members of the structure are located contiguously in memory. In absolute form, the structure only contains pointers to the members. For more information, see [Absolute and Self-Relative Security Descriptors](/windows/win32/secauthz/absolute-and-self-relative-security-descriptors). 
 
@@ -105,9 +105,9 @@ For calls from kernel-mode drivers, the **Nt*Xxx*** and **Zw*Xxx*** versions of 
 
 ## -see-also
 
-[**FltQuerySecurityObject**](/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltquerysecurityobject)
+[**FltQuerySecurityObject**](../fltkernel/nf-fltkernel-fltquerysecurityobject.md)
 
-[**SECURITY_DESCRIPTOR**](/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_security_descriptor)
+[**SECURITY_DESCRIPTOR**](ns-ntifs-_security_descriptor.md)
 
 [**SECURITY_INFORMATION**](/windows-hardware/drivers/ifs/security-information)
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-zwquerysecurityobject.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-zwquerysecurityobject.md
@@ -56,14 +56,14 @@ The **ZwQuerySecurityObject** routine retrieves a copy of an object's security d
 
 ### -param SecurityInformation
 
-[in] A [**SECURITY_INFORMATION**](/windows-hardware/drivers/ifs/security-information) value specifying the information to be queried.
+[in] A [**SECURITY_INFORMATION**](/windows-hardware/drivers/ifs/security-information) value specifying the information to be queried as a combination of one or more of the following.
 
 | Value | Meaning |
 | ----- | ------- |
-| DACL_SECURITY_INFORMATION | The object's discretionary access control list (DACL) is being queried. Requires READ_CONTROL access. |
-| GROUP_SECURITY_INFORMATION | The object's primary group identifier is being queried. Requires READ_CONTROL access. |
 | OWNER_SECURITY_INFORMATION | The object's owner identifier is being queried. Requires READ_CONTROL access. |
+| GROUP_SECURITY_INFORMATION | The object's primary group identifier is being queried. Requires READ_CONTROL access. |
 | SACL_SECURITY_INFORMATION | The object's system ACL (SACL) is being queried. Requires ACCESS_SYSTEM_SECURITY access. |
+| DACL_SECURITY_INFORMATION | The object's discretionary access control list (DACL) is being queried. Requires READ_CONTROL access. |
 
 ### -param SecurityDescriptor
 
@@ -90,7 +90,7 @@ The **ZwQuerySecurityObject** routine retrieves a copy of an object's security d
 
 ## -remarks
 
-A security descriptor can be in absolute or self-relative form. In self-relative form, all members of the structure are located contiguously in memory. In absolute form, the structure only contains pointers to the members.
+A security descriptor can be in absolute or self-relative form. In self-relative form, all members of the structure are located contiguously in memory. In absolute form, the structure only contains pointers to the members. For more information, see [Absolute and Self-Relative Security Descriptors](/windows/win32/secauthz/absolute-and-self-relative-security-descriptors).
 
 The NTFS file system imposes a 64K limit on the size of the security descriptor that is written to disk for a file. (The FAT file system does not support security descriptors for files.) Thus a 64K **SecurityDescriptor** buffer is guaranteed to be large enough to hold the returned **SECURITY_DESCRIPTOR** structure.
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-zwquerysecurityobject.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-zwquerysecurityobject.md
@@ -67,7 +67,7 @@ The **ZwQuerySecurityObject** routine retrieves a copy of an object's security d
 
 ### -param SecurityDescriptor
 
-[out] Caller-allocated buffer that **ZwQuerySecurityObject** fills with a copy of the specified security descriptor. The [**SECURITY_DESCRIPTOR**](/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_security_descriptor) structure is returned in self-relative format.
+[out] Caller-allocated buffer that **ZwQuerySecurityObject** fills with a copy of the specified security descriptor. The [**SECURITY_DESCRIPTOR**](ns-ntifs-_security_descriptor.md) structure is returned in self-relative format.
 
 ### -param Length
 
@@ -96,7 +96,7 @@ The NTFS file system imposes a 64K limit on the size of the security descriptor 
 
 For more information about security and access control, see the documentation on these topics in the Windows SDK.
 
-Minifilters should call [**FltQuerySecurityObject**](/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltquerysecurityobject) instead of **ZwQuerySecurityObject**.
+Minifilters should call [**FltQuerySecurityObject**](../fltkernel/nf-fltkernel-fltquerysecurityobject.md) instead of **ZwQuerySecurityObject**.
 
 > [!NOTE]
 > If the call to the **ZwQuerySecurityObject** function occurs in user mode, you should use the name "**NtQuerySecurityObject**" instead of "**ZwQuerySecurityObject**".
@@ -105,10 +105,10 @@ For calls from kernel-mode drivers, the **Nt*Xxx*** and **Zw*Xxx*** versions of 
 
 ## -see-also
 
-[**FltQuerySecurityObject**](/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltquerysecurityobject)
+[**FltQuerySecurityObject**](../fltkernel/nf-fltkernel-fltquerysecurityobject.md)
 
-[**SECURITY_DESCRIPTOR**](/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_security_descriptor)
+[**SECURITY_DESCRIPTOR**](ns-ntifs-_security_descriptor.md)
 
 [**SECURITY_INFORMATION**](/windows-hardware/drivers/ifs/security-information)
 
-[**ZwSetSecurityObject**](https://msdn.microsoft.com/library/windows/hardware/ff567106)
+[**ZwSetSecurityObject**](nf-ntifs-zwsetsecurityobject.md)


### PR DESCRIPTION
`FltSetSecurityObject` page describes that `SecurityInformation` can be a combination of one or more `SECURITY_INFORMATION` value.

I confirmed that it is also valid for `ZwQuerySecurityObject` in Windows 7 ~ Windows 10.

This my test code
```c
status = FltCreateFileEx(
	gFileFltHandle,
	instance,
	&fileHandle,
	&fileObject,
	GENERIC_ALL | FILE_READ_ATTRIBUTES | READ_CONTROL | ACCESS_SYSTEM_SECURITY,
	&objectAttribute,
	&statusBlock,
	&fileSize,
	FILE_ATTRIBUTE_NORMAL,
	0,
	FILE_CREATE,
	FILE_NON_DIRECTORY_FILE,
	NULL,
	0,
	0);

if (NT_SUCCESS(status))
{
	length = 0;
	securityInformation = OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION;
	status = ZwQuerySecurityObject(fileHandle, securityInformation, NULL, 0, &length);
	if (status == STATUS_BUFFER_TOO_SMALL)
	{
		securityDescriptor = ExAllocatePoolWithTag(PagedPool, length, CSFLT_POOL_TAG);
		RtlZeroBytes(securityDescriptor, length);
		if (securityDescriptor)
		{
			status = ZwQuerySecurityObject(fileHandle, securityInformation, securityDescriptor, length, &length);
			if (NT_SUCCESS(status))
			{
				PSID owner = NULL;
				PSID group = NULL;
				PACL dacl = NULL;
				PACL sacl = NULL;
				BOOLEAN dcalPresent = FALSE, daclDefault = FALSE;
				BOOLEAN scalPresent = FALSE, saclDefault = FALSE;
				BOOLEAN ownerDefault = FALSE;
				BOOLEAN groupDefault = FALSE;
				RtlGetOwnerSecurityDescriptor(securityDescriptor, &owner, &ownerDefault);
				RtlGetGroupSecurityDescriptor(securityDescriptor, &group, &groupDefault);
				RtlGetDaclSecurityDescriptor(securityDescriptor, &dcalPresent, &dacl, &daclDefault);
				RtlGetSaclSecurityDescriptor(securityDescriptor, &scalPresent, &sacl, &saclDefault);
				if (owner != NULL && group == NULL && sacl == NULL && dacl != NULL)
				{
					KdPrint(("Successd.\n"));
				}
			}
			ExFreePoolWithTag(securityDescriptor, CSFLT_POOL_TAG);
		}
	}
	ObDereferenceObject(fileObject);
	FltClose(fileHandle);
}
```