### PR TITLE
Correct href for ZwFsControlFile

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltfscontrolfile.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltfscontrolfile.md
@@ -96,7 +96,7 @@ Pointer to a caller-allocated variable that receives the size, in bytes, of the 
 
 ## -remarks
 
-Minifilter drivers should call this routine instead of <a href="/previous-versions/ff566462(v=vs.85)">ZwFsControlFile</a>. 
+Minifilter drivers should call this routine instead of <a href="/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwfscontrolfile">ZwFsControlFile</a>.
 
 The following FSCTL codes are currently documented for kernel-mode drivers: 
 
@@ -152,4 +152,4 @@ For more information about the system-defined FSCTL_<i>XXX</i> codes, see the Re
 
 
 
-<a href="/previous-versions/ff566462(v=vs.85)">ZwFsControlFile</a>
+<a href="/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwfscontrolfile">ZwFsControlFile</a>

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltfscontrolfile.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltfscontrolfile.md
@@ -96,7 +96,7 @@ Pointer to a caller-allocated variable that receives the size, in bytes, of the 
 
 ## -remarks
 
-Minifilter drivers should call this routine instead of <a href="/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwfscontrolfile">ZwFsControlFile</a>.
+Minifilter drivers should call this routine instead of <a href="/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwfscontrolfile">ZwFsControlFile</a>.
 
 The following FSCTL codes are currently documented for kernel-mode drivers: 
 
@@ -152,4 +152,4 @@ For more information about the system-defined FSCTL_<i>XXX</i> codes, see the Re
 
 
 
-<a href="/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwfscontrolfile">ZwFsControlFile</a>
+<a href="/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwfscontrolfile">ZwFsControlFile</a>


### PR DESCRIPTION
Notes: 

-  Git seems to think that I removed a <CR> from the original.  After analysis (I read the binary) this looks innocuous.
- I found the link via <F1> in VS.  Looks OK but better check
- Happy (belated) Thanksgiving