### PR TITLE
typo: seperate -> separate

### DIFF
--- a/wdk-ddi-src/content/ntddmmc/ns-ntddmmc-_feature_data_cd_audio_analog_play.md
+++ b/wdk-ddi-src/content/ntddmmc/ns-ntddmmc-_feature_data_cd_audio_analog_play.md
@@ -57,11 +57,11 @@ The FEATURE_DATA_CD_AUDIO_ANALOG_PLAY structure holds information about the CD A
 
 Contains a <a href="/windows-hardware/drivers/ddi/ntddmmc/ns-ntddmmc-_feature_header">FEATURE_HEADER</a> structure with header information for this feature descriptor.
 
-### -field SeperateVolume
+### -field SeparateVolume
 
 Indicates, when set to zero, that all audio channels have the same volume level. When set to 1, it indicates that the volume of each audio channel can be set separately.
 
-### -field SeperateChannelMute
+### -field SeparateChannelMute
 
 Indicates, when set to zero, that all audio channels are muted simultaneously. When set to 1, it indicates that each audio channel can be muted independently.
 


### PR DESCRIPTION
This might be a product bug rather than a typo