### PR TITLE
Add restrictions on the use of CcZeroData

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-cczerodata.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-cczerodata.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:ntifs.CcZeroData
 title: CcZeroData function (ntifs.h)
-description: The CcZeroData routine zeros the specified range of bytes in a cached or noncached file.
+description: The CcZeroData routine zeros the specified range of bytes in a cached or noncached file.  This routine should <b>ONLY</b> be called as part of valid data length maintenance.
 old-location: ifsk\cczerodata.htm
 tech.root: ifsk
 ms.date: 04/16/2018
@@ -100,10 +100,13 @@ If <i>EndOffset</i> is not aligned, it will be rounded up to the next sector siz
 </li>
 </ul>
 
+Under certain circumstances (which may involved the Cache Manager's copy of the ValidDataLength) this routine has to effect.  For all operations involving zeroing of previously written data File Systems should call <a href="/windows-hardware/drivers/ddi/ntifs/nf-ntifs-cccopywrite">CcCopyWrite</a> with appropriate parameterizatiion.
+
 ## -see-also
 
 <a href="/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ccinitializecachemap">CcInitializeCacheMap</a>
 
+<a href="/windows-hardware/drivers/ddi/ntifs/nf-ntifs-cccopywrite">CcCopyWrite</a>
 
 
 <a href="/previous-versions/ff539143(v=vs.85)">CcIsFileCached</a>


### PR DESCRIPTION
We have not been able to ascertain the exact circumstances under
which this doesn't work.  Hence the slightly flippant wording in
the second change - which will require significant rework.

(We spotted this when trying to use CcZeroData as part of
FSCTL_SET_ZERO_DATA processing)