### PR TITLE
Add note about IRQL restriction for non paging IO.

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltreissuesynchronousio.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltreissuesynchronousio.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: FltMgr.lib
 req.dll: Fltmgr.sys
-req.irql: <= APC_LEVEL
+req.irql: <= APC_LEVEL (non-paging IO can only be reissued at PASSIVE_LEVEL)
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
The SAL for `FltReissueSynchronousIo` states 

```
_When_(FlagOn(CallbackData->Iopb->IrpFlags, IRP_PAGING_IO), _IRQL_requires_max_(APC_LEVEL))
_When_(!FlagOn(CallbackData->Iopb->IrpFlags, IRP_PAGING_IO), _IRQL_requires_max_(PASSIVE_LEVEL))
```

(IOW: MUST be at PASSIVE unless for paging when it MAY be issued at APC_LEVEL).

This cumbersome change tries to do this.  But I am abusing the req.irql macro so it may not work - in which case it will need to go into remarks.