### PR TITLE
fix "Cancel" links in IoSetCancelRoutine

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-iosetcancelroutine.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iosetcancelroutine.md
@@ -45,7 +45,7 @@ api_name:
 
 ## -description
 
-The <b>IoSetCancelRoutine</b> routine sets up a driver-supplied <a href="/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensionrequest-cancel">Cancel</a> routine to be called if a given IRP is canceled.
+The <b>IoSetCancelRoutine</b> routine sets up a driver-supplied <a href="/windows-hardware/drivers/ddi/wdm/nc-wdm-driver_cancel">Cancel</a> routine to be called if a given IRP is canceled.
 
 ## -parameters
 
@@ -57,7 +57,7 @@ Pointer to the IRP being put into or removed from a cancelable state.
 ### -param CancelRoutine 
 
 [in]
-Specifies the entry point of the caller-supplied <a href="/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensionrequest-cancel">Cancel</a> routine to be called if the specified IRP is canceled or is <b>NULL</b> if the given IRP is being removed from the cancelable state. This routine is declared as follows:
+Specifies the entry point of the caller-supplied <a href="/windows-hardware/drivers/ddi/wdm/nc-wdm-driver_cancel">Cancel</a> routine to be called if the specified IRP is canceled or is <b>NULL</b> if the given IRP is being removed from the cancelable state. This routine is declared as follows:
 
 
 ```


### PR DESCRIPTION
These docs should link to `DRIVER_CANCEL` and not `IPrinterExtensionRequest::Cancel`