### PR TITLE
Add when this callback is invoked

### DIFF
--- a/wdk-ddi-src/content/wdm/nc-wdm-po_fx_directed_power_down_callback.md
+++ b/wdk-ddi-src/content/wdm/nc-wdm-po_fx_directed_power_down_callback.md
@@ -80,6 +80,8 @@ WDM drivers that register with PoFx for runtime idle power management support ne
 
 Register your implementation of this callback function by setting the appropriate member of the [**PO_FX_DEVICE_V3**](ns-wdm-po_fx_device_v3.md) structure and then calling [**PoFxRegisterDevice**](./nf-wdm-pofxregisterdevice.md).
 
+This callback is invoked after a DRIPS constraint device has been active for at least two consecutive minutes (driver-configurable timeout, default 2 minutes) when the system is in Modern Standby and there is no activator-brokered software activity running.
+
 When this callback is invoked, the driver typically performs the following high-level tasks:
 
 - Stop processing new work.

--- a/wdk-ddi-src/content/wdm/nc-wdm-po_fx_directed_power_down_callback.md
+++ b/wdk-ddi-src/content/wdm/nc-wdm-po_fx_directed_power_down_callback.md
@@ -80,7 +80,7 @@ WDM drivers that register with PoFx for runtime idle power management support ne
 
 Register your implementation of this callback function by setting the appropriate member of the [**PO_FX_DEVICE_V3**](ns-wdm-po_fx_device_v3.md) structure and then calling [**PoFxRegisterDevice**](./nf-wdm-pofxregisterdevice.md).
 
-This callback is invoked after a DRIPS constraint device has been active for at least two consecutive minutes (driver-configurable timeout, default 2 minutes) when the system is in Modern Standby and there is no activator-brokered software activity running.
+This callback is invoked when the system enters DRIPS, not Modern Standby. In other words, this callback is invoked after a DRIPS constraint device has been active for at least two consecutive minutes (driver-configurable timeout, default 2 minutes) when the system is in Modern Standby and there is no activator-brokered software activity running.
 
 When this callback is invoked, the driver typically performs the following high-level tasks:
 


### PR DESCRIPTION
This document doesn't tell about "when this callback is invoked." It is described in the following document, but there is some difficulty to tie these documents for non English native speakers.

Directed power management
https://docs.microsoft.com/en-us/windows-hardware/design/device-experiences/directed-power-management

DFx
DFx is an extension to PoFx that enables the power manager to direct a device to enter a lower power state. DFx takes effect after a DRIPS constraint device has been active for at least two consecutive minutes (driver-configurable timeout, default 2 minutes) when the system is in Modern Standby and there is no activator-brokered software activity running. DFx directs devices to enter their target D-state for Modern Standby with the ability to arm for wake as they may during a normal Modern Standby transition. It does not carry the assumptions associated with an S-IRP, e.g. device reset is not required. DFx will not power down paging or debug devices.