### PR TITLE
Explain thoroughly in which condition the handle is not closable in N…

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntclose.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntclose.md
@@ -56,7 +56,9 @@ Handle to an object of any type.
 
 ## -returns
 
-<b>NtClose</b> returns STATUS_SUCCESS on success, or the appropriate NTSTATUS error code on failure. In particular, it returns STATUS_INVALID_HANDLE if <i>Handle</i> is not a valid handle, or STATUS_HANDLE_NOT_CLOSABLE if the calling thread does not have permission to close the handle.
+<b>NtClose</b> returns STATUS_SUCCESS on success, or the appropriate NTSTATUS error code on failure. In particular, it returns STATUS_INVALID_HANDLE if <i>Handle</i> is not a valid handle, or STATUS_HANDLE_NOT_CLOSABLE if the calling thread does not have permission to close the handle, that is, the said object handle is protected from closing from any instance attempts of NtClose.
+
+An example where the latter NTSTATUS code occurs is when a call of <a href="/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwduplicateobject">ZwDuplicateObject</a> has been invoked with <b>OBJ_PROTECT_CLOSE</b> passed to the handle attributes parameter argument. The kernel ensures that the handle cannot be closed in that case.
 
 ## -remarks
 


### PR DESCRIPTION
…tClose

Whilst the documentation says that when `STATUS_HANDLE_NOT_CLOSABLE` is returned to the caller due to the lack of permission(s) to invalidate the handle in question, it doesn't actually tell you in which condition the caller can't close the handle.

This PR further adds some explanation and a little example to make it clear why a handle can't be closed under any circumstances.