### PR TITLE
Add some further remarks for PsImpersonateClient routine

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-psimpersonateclient.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-psimpersonateclient.md
@@ -119,8 +119,13 @@ Otherwise, to end the impersonation and return the server thread to its original
 
 The <b>PsImpersonateClient</b> routine can fail to successfully return the server thread to the previous impersonation if the thread is already impersonating or there are job restrictions.
 
-The routine ensures if client impersonation can actually occur. It does that by checking if the token passed by the caller doesn't have an anonymous authentication ID, that the process' token referenced from the server thread and the given token have equal security identifiers (SIDs) and that neither of the tokens must be restricted.
-If none of these conditions are met the routine makes a copy of the existing token passed to the call and assigns the newly copied token as impersonation token albeit with limited security impersonation level, that is, the server thread can only obtain information about the client. If token copying is not possible even, the routine outright fails with a NTSTATUS code.
+The routine ensures whether client impersonation can actually occur by checking various conditions, including the following:
+
+* The token passed by the caller doesn't have an anonymous authentication ID
+* The process's token referenced from the server thread and the given token have equal security identifiers (SIDs)
+* Neither of the tokens are restricted
+
+If none of the conditions are met, the routine makes a copy of the existing token passed to the call and assigns the newly copied token as impersonation token albeit with limited security impersonation level; that is, the server thread can only obtain information about the client. If token copying is not possible, the routine fails with a NTSTATUS code.
 
 It is extremely unsafe to raise the privilege state of an untrusted user thread (take a user's thread and impersonate LocalSystem, for example). If an untrusted user thread had its privilege raised, the user could grab the thread token after it has been elevated and subvert the security of the entire system. 
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-psimpersonateclient.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-psimpersonateclient.md
@@ -119,6 +119,9 @@ Otherwise, to end the impersonation and return the server thread to its original
 
 The <b>PsImpersonateClient</b> routine can fail to successfully return the server thread to the previous impersonation if the thread is already impersonating or there are job restrictions.
 
+The routine ensures if client impersonation can actually occur. It does that by checking if the token passed by the caller doesn't have an anonymous authentication ID, that the process' token referenced from the server thread and the given token have equal security identifiers (SIDs) and that neither of the tokens must be restricted.
+If none of these conditions are met the routine makes a copy of the existing token passed to the call and assigns the newly copied token as impersonation token albeit with limited security impersonation level, that is, the server thread can only obtain information about the client. If token copying is not possible even, the routine outright fails with a NTSTATUS code.
+
 It is extremely unsafe to raise the privilege state of an untrusted user thread (take a user's thread and impersonate LocalSystem, for example). If an untrusted user thread had its privilege raised, the user could grab the thread token after it has been elevated and subvert the security of the entire system. 
 
 In cases where a higher privilege state is required, the task should be dispatched to a work queue where the task can be safely handled by system worker thread . This way no impersonation is necessary.


### PR DESCRIPTION
`PsImpersonateClient` impersonates the client, the server thread has impersonated security context properties from the impersonated token and everyone's happy. What the documentation doesn't actually tell you is that `PsImpersonateClient` has to make sure that client impersonation can actually occur in the first place.

Otherwise in a scenario where impersonation is not possible directly, the routine has to make a copy of the token as the last resort with a security impersonation level as `security identification`. If the function can't even copy the token, the function outright fails.