### PR TITLE
Links: Windows driver ddi (2021-05)

### DIFF
--- a/wdk-ddi-src/content/ks/nf-ks-ksgetobjectfromfileobject.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksgetobjectfromfileobject.md
@@ -52,11 +52,11 @@ The **KsGetObjectFromFileObject** function returns the AVStream object cast to P
 ### -param FileObject
 
 [in]
-A pointer to the [FILE_OBJECT](/windows-hardware/drivers/ddi/wdm/ns-wdm-_file_object) structure for which to determine the associated AVStream object.
+A pointer to the [FILE_OBJECT](../wdm/ns-wdm-_file_object.md) structure for which to determine the associated AVStream object.
 
 ## -returns
 
-**KsGetObjectFromFileObject** returns a pointer to the AVStream object associated with *FileObject* (cast to PVOID). For example, this pointer may point to a [KSFILTER](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter) or a [KSPIN](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin).
+**KsGetObjectFromFileObject** returns a pointer to the AVStream object associated with *FileObject* (cast to PVOID). For example, this pointer may point to a [KSFILTER](./ns-ks-_ksfilter.md) or a [KSPIN](./ns-ks-_kspin.md).
 
 ## -remarks
 
@@ -64,10 +64,10 @@ The **KsGetObjectFromFileObject** function does not check that the file object i
 
 ## -see-also
 
-[KsGetFilterFromFileObject](/windows-hardware/drivers/ddi/ks/nf-ks-ksgetfilterfromfileobject)
+[KsGetFilterFromFileObject](./nf-ks-ksgetfilterfromfileobject.md)
 
-[KsGetObjectTypeFromFileObject](/windows-hardware/drivers/ddi/ks/nf-ks-ksgetobjecttypefromfileobject)
+[KsGetObjectTypeFromFileObject](./nf-ks-ksgetobjecttypefromfileobject.md)
 
-[KsGetPinFromFileObject](/windows-hardware/drivers/ddi/ks/nf-ks-ksgetpinfromfileobject)
+[KsGetPinFromFileObject](./nf-ks-ksgetpinfromfileobject.md)
 
-[KsPinGetConnectedPinFileObject](/windows-hardware/drivers/ddi/ks/nf-ks-kspingetconnectedpinfileobject)
+[KsPinGetConnectedPinFileObject](./nf-ks-kspingetconnectedpinfileobject.md)

--- a/wdk-ddi-src/content/ks/nf-ks-ksgetobjecttypefromfileobject.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksgetobjecttypefromfileobject.md
@@ -52,11 +52,11 @@ The **KsGetObjectTypeFromFileObject** function returns the AVStream object type 
 ### -param FileObject
 
 [in]
-A pointer to the [FILE_OBJECT](/windows-hardware/drivers/ddi/wdm/ns-wdm-_file_object) structure for which to determine the associated AVStream object type.
+A pointer to the [FILE_OBJECT](../wdm/ns-wdm-_file_object.md) structure for which to determine the associated AVStream object type.
 
 ## -returns
 
-**KsGetObjectTypeFromFileObject** returns the object type of the AVStream object associated with *FileObject* as a [KSOBJECTTYPE](/windows-hardware/drivers/ddi/ks/ne-ks-ksobjecttype) enumeration. This can be one of the following: **KsObjectTypeDevice**, **KsObjectTypeFilterFactory**, **KsObjectTypeFilter**, or **KsObjectTypePin**.
+**KsGetObjectTypeFromFileObject** returns the object type of the AVStream object associated with *FileObject* as a [KSOBJECTTYPE](./ne-ks-ksobjecttype.md) enumeration. This can be one of the following: **KsObjectTypeDevice**, **KsObjectTypeFilterFactory**, **KsObjectTypeFilter**, or **KsObjectTypePin**.
 
 ## -remarks
 
@@ -64,10 +64,10 @@ The **KsGetObjectTypeFromFileObject** function does not check that the file obje
 
 ## -see-also
 
-[KsGetFilterFromFileObject](/windows-hardware/drivers/ddi/ks/nf-ks-ksgetfilterfromfileobject)
+[KsGetFilterFromFileObject](./nf-ks-ksgetfilterfromfileobject.md)
 
-[KsGetObjectFromFileObject](/windows-hardware/drivers/ddi/ks/nf-ks-ksgetobjectfromfileobject)
+[KsGetObjectFromFileObject](./nf-ks-ksgetobjectfromfileobject.md)
 
-[KsGetPinFromFileObject](/windows-hardware/drivers/ddi/ks/nf-ks-ksgetpinfromfileobject)
+[KsGetPinFromFileObject](./nf-ks-ksgetpinfromfileobject.md)
 
-[KsPinGetConnectedPinFileObject](/windows-hardware/drivers/ddi/ks/nf-ks-kspingetconnectedpinfileobject)
+[KsPinGetConnectedPinFileObject](./nf-ks-kspingetconnectedpinfileobject.md)

--- a/wdk-ddi-src/content/ks/nf-ks-ksgetobjecttypefromirp.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksgetobjecttypefromirp.md
@@ -52,11 +52,11 @@ The **KsGetObjectTypeFromIrp** function returns the AVStream object type that is
 ### -param Irp
 
 [in]
-A pointer to the [IRP](/windows-hardware/drivers/ddi/wdm/ns-wdm-_irp) structure for which to find the associated AVStream object type.
+A pointer to the [IRP](../wdm/ns-wdm-_irp.md) structure for which to find the associated AVStream object type.
 
 ## -returns
 
-**KsGetObjectTypeFromIrp** returns the type of AVStream object associated with the given IRP as a [KSOBJECTTYPE](/windows-hardware/drivers/ddi/ks/ne-ks-ksobjecttype) enumeration. This is one of the following: **KsObjectTypeDevice**, **KsObjectTypeFilterFactory**, **KsObjectTypeFilter**, **KsObjectTypePin**.
+**KsGetObjectTypeFromIrp** returns the type of AVStream object associated with the given IRP as a [KSOBJECTTYPE](./ne-ks-ksobjecttype.md) enumeration. This is one of the following: **KsObjectTypeDevice**, **KsObjectTypeFilterFactory**, **KsObjectTypeFilter**, **KsObjectTypePin**.
 
 ## -remarks
 
@@ -64,10 +64,10 @@ The **KsGetObjectTypeFromIrp** function does not check that the I/O request pack
 
 ## -see-also
 
-[IRP](/windows-hardware/drivers/ddi/wdm/ns-wdm-_irp)
+[IRP](../wdm/ns-wdm-_irp.md)
 
-[KsAddIrpToCancelableQueue](/windows-hardware/drivers/ddi/ks/nf-ks-ksaddirptocancelablequeue)
+[KsAddIrpToCancelableQueue](./nf-ks-ksaddirptocancelablequeue.md)
 
-[KsDispatchIrp](/windows-hardware/drivers/ddi/ks/nf-ks-ksdispatchirp)
+[KsDispatchIrp](./nf-ks-ksdispatchirp.md)
 
-[KsForwardIrp](/windows-hardware/drivers/ddi/ks/nf-ks-ksforwardirp)
+[KsForwardIrp](./nf-ks-ksforwardirp.md)

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-pssetcreateprocessnotifyroutine.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-pssetcreateprocessnotifyroutine.md
@@ -98,7 +98,7 @@ Highest-level drivers can call <b>PsSetCreateProcessNotifyRoutine</b> to set up 
 
 An IFS or highest-level system-profiling driver might register a process-creation callback to track the system-wide creation and deletion of processes against the driver's internal state. For Windows Vista and later versions of Windows, the system can register up to 64 process-creation callback routines.
 
-A driver must remove any callbacks that it registers before it unloads. You can remove the callback by calling <b>PsSetCreateProcessNotify</b> with <i>Remove</i> = <b>TRUE</b>. A driver must not make this call from its implementation of the [*PCREATE_PROCESS_NOTIFY_ROUTINE*](/windows-hardware/drivers/ddi/ntddk/nc-ntddk-pcreate_process_notify_routine) callback routine.
+A driver must remove any callbacks that it registers before it unloads. You can remove the callback by calling <b>PsSetCreateProcessNotify</b> with <i>Remove</i> = <b>TRUE</b>. A driver must not make this call from its implementation of the [*PCREATE_PROCESS_NOTIFY_ROUTINE*](./nc-ntddk-pcreate_process_notify_routine.md) callback routine.
 
 After a driver-supplied routine is registered, it is called with <i>Create</i> set to <b>TRUE</b> just after the initial thread is created within the newly created process designated by the input <i>ProcessId</i> handle. The input <i>ParentId</i> handle identifies the parent process of the newly-created process (this is the parent used for priority, affinity, quota, token, and handle inheritance, among others).
 

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-pssetcreateprocessnotifyroutineex.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-pssetcreateprocessnotifyroutineex.md
@@ -107,7 +107,7 @@ The image that contains the callback routine pointer did not have IMAGE_DLLCHARA
 
 Highest-level drivers can call <b>PsSetCreateProcessNotifyRoutineEx</b> to register a <a href="/windows-hardware/drivers/ddi/ntddk/nc-ntddk-pcreate_process_notify_routine_ex">PCREATE_PROCESS_NOTIFY_ROUTINE_EX</a> routine. An installable file system (IFS) or highest-level system-profiling driver might register a process-creation callback routine to track which processes are created and deleted against the driver's internal state across the system. 
 
-A driver must remove any callback routines that it registers before it unloads. You can remove the callback routine by calling <b>PsSetCreateProcessNotifyRoutineEx</b> with <i>Remove</i> set to <b>TRUE</b>. A driver must not make this call from its implementation of the [*PCREATE_PROCESS_NOTIFY_ROUTINE_EX*](/windows-hardware/drivers/ddi/ntddk/nc-ntddk-pcreate_process_notify_routine_ex) callback routine. 
+A driver must remove any callback routines that it registers before it unloads. You can remove the callback routine by calling <b>PsSetCreateProcessNotifyRoutineEx</b> with <i>Remove</i> set to <b>TRUE</b>. A driver must not make this call from its implementation of the [*PCREATE_PROCESS_NOTIFY_ROUTINE_EX*](./nc-ntddk-pcreate_process_notify_routine_ex.md) callback routine. 
 
 The operating system calls the driver's process-notify routine at PASSIVE_LEVEL inside a critical region with <a href="/windows-hardware/drivers/kernel/types-of-apcs">normal kernel APCs</a> disabled. When a process is created, the process-notify routine runs in the context of the thread that created the new process. When a process is deleted, the process-notify routine runs in the context of the last thread to exit from the process.
 

--- a/wdk-ddi-src/content/wdfmemory/nf-wdfmemory-wdfmemorycreate.md
+++ b/wdk-ddi-src/content/wdfmemory/nf-wdfmemory-wdfmemorycreate.md
@@ -139,8 +139,8 @@ It is good practice to zero memory for memory allocation, especially for allocat
 
 Based on the driver's usage pattern of the allocated memory, the recommendation for driver writers is to consider:
 
-* Using a zero-allocation API ([**ExAllocatePool2**](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2), [**ExAllocatePoolZero**](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepoolzero) for kernel mode; [**HeapAlloc**](/windows/win32/api/heapapi/nf-heapapi-heapalloc) with the **HEAP_ZERO_MEMORY** flag for user mode), followed by [**WdfMemoryCreatePreallocated**](/windows-hardware/drivers/ddi/wdfmemory/nf-wdfmemory-wdfmemorycreatepreallocated)
-* Or, [**RtlZeroMemory**](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlzeromemory) immediately after calling **WdfMemoryCreate**
+* Using a zero-allocation API ([**ExAllocatePool2**](../wdm/nf-wdm-exallocatepool2.md), [**ExAllocatePoolZero**](../wdm/nf-wdm-exallocatepoolzero.md) for kernel mode; [**HeapAlloc**](/windows/win32/api/heapapi/nf-heapapi-heapalloc) with the **HEAP_ZERO_MEMORY** flag for user mode), followed by [**WdfMemoryCreatePreallocated**](./nf-wdfmemory-wdfmemorycreatepreallocated.md)
+* Or, [**RtlZeroMemory**](../wdm/nf-wdm-rtlzeromemory.md) immediately after calling **WdfMemoryCreate**
 
 The default parent object for each memory object is the framework driver object that represents the driver that called <b>WdfMemoryCreate</b>. If your driver creates a memory object that it uses with a specific device object, request object, or other framework object, it should set the memory object's parent appropriately. The memory object and its buffer will be deleted when the parent object is deleted. If you do not change the default parent object, the memory object and its buffer will remain until the I/O manager unloads your driver. 
 

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcompletewithinformation.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcompletewithinformation.md
@@ -95,7 +95,7 @@ A bug check occurs if the driver supplies an invalid object handle.
 
 For read, write and IOCTL requests, it is necessary for the driver to call **WdfRequestCompleteWithInformation**
 
-For a non-data transfer request, calling [**WdfRequestComplete**](/windows-hardware/drivers/ddi/wdfrequest/nf-wdfrequest-wdfrequestcomplete) instead is an option.
+For a non-data transfer request, calling [**WdfRequestComplete**](./nf-wdfrequest-wdfrequestcomplete.md) instead is an option.
 
 Calling <b>WdfRequestCompleteWithInformation</b> is equivalent to calling <a href="/windows-hardware/drivers/ddi/wdfrequest/nf-wdfrequest-wdfrequestsetinformation">WdfRequestSetInformation</a> and then calling <a href="/windows-hardware/drivers/ddi/wdfrequest/nf-wdfrequest-wdfrequestcomplete">WdfRequestComplete</a>.
 

--- a/wdk-ddi-src/content/wdm/nc-wdm-po_fx_directed_power_up_callback.md
+++ b/wdk-ddi-src/content/wdm/nc-wdm-po_fx_directed_power_up_callback.md
@@ -80,7 +80,7 @@ WDM drivers that register with PoFx for runtime idle power management support ne
 
 Register your implementation of this callback function by setting the appropriate member of the [**PO_FX_DEVICE_V3**](ns-wdm-po_fx_device_v3.md) structure and then calling [**PoFxRegisterDevice**](./nf-wdm-pofxregisterdevice.md).
 
-This callback is invoked when the system determines the device needs to power up after having previously being powered down in the [*PO_FX_DIRECTED_POWER_DOWN_CALLBACK*](/windows-hardware/drivers/ddi/wdm/nc-wdm-po_fx_directed_power_down_callback) callback function.
+This callback is invoked when the system determines the device needs to power up after having previously being powered down in the [*PO_FX_DIRECTED_POWER_DOWN_CALLBACK*](./nc-wdm-po_fx_directed_power_down_callback.md) callback function.
 
 When this callback is invoked, the driver typically performs the following high-level tasks:
 

--- a/wdk-ddi-src/content/winsplp/ns-winsplp-_monitorui.md
+++ b/wdk-ddi-src/content/winsplp/ns-winsplp-_monitorui.md
@@ -60,20 +60,20 @@ Size, in bytes, of the **MONITORUI** structure.
 
 ### -field pfnAddPortUI
 
-Pointer to the port monitor UI DLL [AddPortUI](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-addportui) function that adds a printer port, then obtains port configuration information from the user and sends it to the port monitor server DLL.
+Pointer to the port monitor UI DLL [AddPortUI](./nf-winsplp-addportui.md) function that adds a printer port, then obtains port configuration information from the user and sends it to the port monitor server DLL.
 
 ### -field pfnConfigurePortUI
 
-Pointer to the port monitor UI DLL [ConfigurePortUI](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-configureportui) function that obtains port configuration information from the user and sends it to the port monitor server DLL.
+Pointer to the port monitor UI DLL [ConfigurePortUI](./nf-winsplp-configureportui.md) function that obtains port configuration information from the user and sends it to the port monitor server DLL.
 
 ### -field pfnDeletePortUI
 
-Pointer to the port monitor UI DLL [DeletePortUI](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-deleteportui) function that deletes a printer port.
+Pointer to the port monitor UI DLL [DeletePortUI](./nf-winsplp-deleteportui.md) function that deletes a printer port.
 
 ## -remarks
 
-All structure members must be initialized by the port monitor UI DLL. The structure's address is passed to the print spooler as the return value for the [InitializePrintMonitorUI](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-initializeprintmonitorui) function.
+All structure members must be initialized by the port monitor UI DLL. The structure's address is passed to the print spooler as the return value for the [InitializePrintMonitorUI](./nf-winsplp-initializeprintmonitorui.md) function.
 
 ## -see-also
 
-[InitializePrintMonitorUI](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-initializeprintmonitorui)
+[InitializePrintMonitorUI](./nf-winsplp-initializeprintmonitorui.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to cleanup links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```