### PR TITLE
Update nc-ucxusbdevice-evt_ucx_usbdevice_default_endpoint_add.md

### DIFF
--- a/wdk-ddi-src/content/ucxusbdevice/nc-ucxusbdevice-evt_ucx_usbdevice_default_endpoint_add.md
+++ b/wdk-ddi-src/content/ucxusbdevice/nc-ucxusbdevice-evt_ucx_usbdevice_default_endpoint_add.md
@@ -120,8 +120,7 @@ Endpoint_EvtUcxUsbDeviceDefaultEndpointAdd(
                                               Endpoint_EvtUcxEndpointStart,
                                               Endpoint_EvtUcxEndpointAbort,
                                               Endpoint_EvtUcxEndpointOkToCancelTransfers,
-                                              Endpoint_EvtUcxDefaultEndpointUpdate,
-                                              Endpoint_EvtUcxEndpointEnableForwardProgress);
+                                              Endpoint_EvtUcxDefaultEndpointUpdate);
 
     UcxDefaultEndpointInitSetEventCallbacks(EndpointInit, &ucxDefaultEndpointEventCallbacks);
 


### PR DESCRIPTION
UCX_DEFAULT_ENDPOINT_EVENT_CALLBACKS_INIT doesn't have the 7th parameter in WDK.