### PR TITLE
LinkFix: Windows Driver docs DDI (2021-05)

### DIFF
--- a/wdk-ddi-src/content/bthddi/ns-bthddi-_brb_l2ca_open_channel.md
+++ b/wdk-ddi-src/content/bthddi/ns-bthddi-_brb_l2ca_open_channel.md
@@ -50,7 +50,7 @@ The _BRB_L2CA_OPEN_CHANNEL structure describes a L2CAP channel to open to a remo
 
 ### -field Hdr
 
-A [BRB\_HEADER](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_brb_header) structure that contains information about the current BRB.
+A [BRB\_HEADER](./ns-bthddi-_brb_header.md) structure that contains information about the current BRB.
 
 ### -field ChannelHandle
 
@@ -170,7 +170,7 @@ A flag that specifies which events should generate a callback routine to notify 
 
 ### -field Callback
 
-The [L2CAP Callback Function](/windows-hardware/drivers/ddi/bthddi/nc-bthddi-pfnbthport_indication_callback) implemented by the profile driver, that the Bluetooth driver stack should call to notify the profile driver about any changes to the L2CAP connection.
+The [L2CAP Callback Function](./nc-bthddi-pfnbthport_indication_callback.md) implemented by the profile driver, that the Bluetooth driver stack should call to notify the profile driver about any changes to the L2CAP connection.
 
 ### -field CallbackContext
 
@@ -178,11 +178,11 @@ The context to pass to the callback function specified in the **Callback** membe
 
 ### -field ReferenceObject
 
-A pointer to an object to pass to [ObReferenceObject](/windows-hardware/drivers/ddi/wdm/nf-wdm-obfreferenceobject) and [ObDereferenceObject](/windows-hardware/drivers/ddi/wdm/nf-wdm-obdereferenceobject) for which to maintain a reference count of.
+A pointer to an object to pass to [ObReferenceObject](../wdm/nf-wdm-obfreferenceobject.md) and [ObDereferenceObject](../wdm/nf-wdm-obdereferenceobject.md) for which to maintain a reference count of.
 
 ### -field OutResults
 
-A [CHANNEL\_CONFIG\_RESULTS](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_channel_config_results) structure that contains configuration parameters for the outbound request.
+A [CHANNEL\_CONFIG\_RESULTS](./ns-bthddi-_channel_config_results.md) structure that contains configuration parameters for the outbound request.
 
 ### -field InResults
 
@@ -194,7 +194,7 @@ Specifies the incoming queue length in message transfer units (MTUs).
 
 #### - ( unnamed struct )
 
-A [BRB\_HEADER](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_brb_header) structure that contains information about the current BRB.
+A [BRB\_HEADER](./ns-bthddi-_brb_header.md) structure that contains information about the current BRB.
 
 #### Response
 
@@ -237,13 +237,13 @@ If the **BRB_L2CA_OPEN_CHANNEL** request completes successfully, a variety of in
 
 Several of the configuration parameters passed in this structure, such as the **Mtu** member, are ranges used for negotiation with the remote radio. Clients should provide as wide a range as possible to increase the chances of successful channel negotiation. Specifying a minimum MTU size greater than the basic Bluetooth minimum MTU size should only be done when absolutely necessary. If negotiation fails, the connection will fail.
 
-Profile drivers must allocate the memory to store the array that is stored in the **ExtraOptions** member and should not free this memory until the callback function defined in the **Callback** member returns with an **IndicationFreeExtraOptions** notification [INDICATION\_CODE](/windows-hardware/drivers/ddi/bthddi/ne-bthddi-_indication_code) value passed in its *Indication* parameter.
+Profile drivers must allocate the memory to store the array that is stored in the **ExtraOptions** member and should not free this memory until the callback function defined in the **Callback** member returns with an **IndicationFreeExtraOptions** notification [INDICATION\_CODE](./ne-bthddi-_indication_code.md) value passed in its *Indication* parameter.
 
 The **IncomingQueueDepth** member of the _BRB_L2CA_OPEN_CHANNEL structure specifies the maximum number of MTUs that the Bluetooth driver stack will receive and queue on the connection before it begins to discard them. Setting this value to a very small number increases the chances of data loss, while setting it to a very large number can increase memory usage. Setting this member to 10 is an effective compromise.
 
 To accept or reject an incoming L2CAP connection request initiated by a remote device, profile drivers should [build and send](/previous-versions/ff536657(v=vs.85)) a [ BRB\_L2CA\_OPEN\_CHANNEL\_RESPONSE](/previous-versions/ff536616(v=vs.85)) request.
 
-A profile driver should build and send a **BRB_L2CA_OPEN_CHANNEL_RESPONSE** request when the Bluetooth driver stack calls the profile driver's [L2CAP Callback Function](/windows-hardware/drivers/ddi/bthddi/nc-bthddi-pfnbthport_indication_callback) and passes **IndicationRemoteConnect** in the callback function's *Indication* parameter.
+A profile driver should build and send a **BRB_L2CA_OPEN_CHANNEL_RESPONSE** request when the Bluetooth driver stack calls the profile driver's [L2CAP Callback Function](./nc-bthddi-pfnbthport_indication_callback.md) and passes **IndicationRemoteConnect** in the callback function's *Indication* parameter.
 
 Based on the value of the **Response** member of this structure, the Bluetooth driver stack will then accept or reject the connection request.
 
@@ -255,7 +255,7 @@ Profile drivers must allocate the memory to store the array that is stored in th
 
 ## -see-also
 
-[BRB\_HEADER](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_brb_header)
+[BRB\_HEADER](./ns-bthddi-_brb_header.md)
 
 [BRB\_L2CA\_OPEN\_CHANNEL](/previous-versions/ff536615(v=vs.85))
 
@@ -263,16 +263,16 @@ Profile drivers must allocate the memory to store the array that is stored in th
 
 [BRB\_L2CA\_REGISTER\_SERVER](/previous-versions/ff536618(v=vs.85))
 
-[CHANNEL\_CONFIG\_RESULTS](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_channel_config_results)
+[CHANNEL\_CONFIG\_RESULTS](./ns-bthddi-_channel_config_results.md)
 
-[INDICATION\_CODE](/windows-hardware/drivers/ddi/bthddi/ne-bthddi-_indication_code)
+[INDICATION\_CODE](./ne-bthddi-_indication_code.md)
 
-[INDICATION\_PARAMETERS](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_indication_parameters)
+[INDICATION\_PARAMETERS](./ns-bthddi-_indication_parameters.md)
 
-[L2CAP Callback Function](/windows-hardware/drivers/ddi/bthddi/nc-bthddi-pfnbthport_indication_callback)
+[L2CAP Callback Function](./nc-bthddi-pfnbthport_indication_callback.md)
 
-[L2CAP\_CONFIG\_OPTION](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_l2cap_config_option)
+[L2CAP\_CONFIG\_OPTION](./ns-bthddi-_l2cap_config_option.md)
 
-[ObDereferenceObject](/windows-hardware/drivers/ddi/wdm/nf-wdm-obdereferenceobject)
+[ObDereferenceObject](../wdm/nf-wdm-obdereferenceobject.md)
 
-[ObReferenceObject](/windows-hardware/drivers/ddi/wdm/nf-wdm-obfreferenceobject)
+[ObReferenceObject](../wdm/nf-wdm-obfreferenceobject.md)

--- a/wdk-ddi-src/content/bthddi/ns-bthddi-_brb_l2ca_open_enhanced_channel.md
+++ b/wdk-ddi-src/content/bthddi/ns-bthddi-_brb_l2ca_open_enhanced_channel.md
@@ -50,7 +50,7 @@ The _BRB_L2CA_OPEN_ENHANCED_CHANNEL structure is used to open an enhanced L2CAP 
 
 ### -field Hdr
 
-A [BRB_HEADER](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_brb_header) structure that contains information about the current BRB.
+A [BRB_HEADER](./ns-bthddi-_brb_header.md) structure that contains information about the current BRB.
 
 ### -field ChannelHandle
 
@@ -205,7 +205,7 @@ A flag that specifies which events should generate a callback routine to notify 
 
 ### -field Callback
 
-The [Enhanced L2CAP Callback Function](/windows-hardware/drivers/ddi/bthddi/nc-bthddi-pfnbthport_indication_callback_enhanced) implemented by the profile driver, that the Bluetooth driver stack should call to notify the profile driver about any changes to the enhanced L2CAP connection.
+The [Enhanced L2CAP Callback Function](./nc-bthddi-pfnbthport_indication_callback_enhanced.md) implemented by the profile driver, that the Bluetooth driver stack should call to notify the profile driver about any changes to the enhanced L2CAP connection.
 
 ### -field CallbackContext
 
@@ -213,11 +213,11 @@ The context to pass to the callback function specified in the **Callback** membe
 
 ### -field ReferenceObject
 
-A pointer to an object to pass to [ObReferenceObject](/windows-hardware/drivers/ddi/wdm/nf-wdm-obfreferenceobject) and [ObDereferenceObject](/windows-hardware/drivers/ddi/wdm/nf-wdm-obdereferenceobject) for which to maintain a reference count.
+A pointer to an object to pass to [ObReferenceObject](../wdm/nf-wdm-obfreferenceobject.md) and [ObDereferenceObject](../wdm/nf-wdm-obdereferenceobject.md) for which to maintain a reference count.
 
 ### -field OutResults
 
-A [CHANNEL_CONFIG_RESULTS_ENHANCED](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_channel_config_results_enhanced) structure that contains configuration parameters negotiated for the outbound request.
+A [CHANNEL_CONFIG_RESULTS_ENHANCED](./ns-bthddi-_channel_config_results_enhanced.md) structure that contains configuration parameters negotiated for the outbound request.
 
 ### -field InResults
 
@@ -233,7 +233,7 @@ Reserved member. Do not use.
 
 #### - ( unnamed struct )
 
-A [BRB_HEADER](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_brb_header) structure that contains information about the current BRB.
+A [BRB_HEADER](./ns-bthddi-_brb_header.md) structure that contains information about the current BRB.
 
 #### Response
 

--- a/wdk-ddi-src/content/bthddi/ns-bthddi-_brb_sco_transfer.md
+++ b/wdk-ddi-src/content/bthddi/ns-bthddi-_brb_sco_transfer.md
@@ -50,7 +50,7 @@ The _BRB_SCO_TRANSFER structure describes a buffer to read isochronous data from
 
 ### -field Hdr
 
-A [BRB\_HEADER](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_brb_header) structure that contains information about the current BRB.
+A [BRB\_HEADER](./ns-bthddi-_brb_header.md) structure that contains information about the current BRB.
 
 ### -field BtAddress
 
@@ -99,7 +99,7 @@ If both **Buffer** and **BufferMDL** contain non-**NULL** values, then **BufferM
 
 ## -see-also
 
-[BRB\_HEADER](/windows-hardware/drivers/ddi/bthddi/ns-bthddi-_brb_header)
+[BRB\_HEADER](./ns-bthddi-_brb_header.md)
 
 [BRB\_SCO\_OPEN\_CHANNEL](/previous-versions/ff536626(v=vs.85))
 

--- a/wdk-ddi-src/content/bthddi/ns-bthddi-_sco_indication_parameters.md
+++ b/wdk-ddi-src/content/bthddi/ns-bthddi-_sco_indication_parameters.md
@@ -76,7 +76,7 @@ The structure that contains the parameters for the SCO connection request.
 
 ### -field Parameters.Connect.Request.LinkType
 
-A value from the [SCO\_LINK\_TYPE](/windows-hardware/drivers/ddi/bthddi/ne-bthddi-_sco_link_type) enumeration that indicates the type of incoming connection.
+A value from the [SCO\_LINK\_TYPE](./ne-bthddi-_sco_link_type.md) enumeration that indicates the type of incoming connection.
 
 ### -field Parameters.Disconnect
 
@@ -84,7 +84,7 @@ The structure that contains parameters for the **ScoIndicationRemoteDisconnectSC
 
 ### -field Parameters.Disconnect.Reason
 
-A [SCO\_DISCONNECT\_REASON](/windows-hardware/drivers/ddi/bthddi/ne-bthddi-_sco_disconnect_reason) value that indicates why the SCO connection was terminated.
+A [SCO\_DISCONNECT\_REASON](./ne-bthddi-_sco_disconnect_reason.md) value that indicates why the SCO connection was terminated.
 
 ### -field Parameters.Disconnect.CloseNow
 
@@ -92,7 +92,7 @@ A Boolean value that a profile driver can set to indicate whether the SCO connec
 
 ## -remarks
 
-A profile driver's [SCO Callback Function](/windows-hardware/drivers/ddi/bthddi/nc-bthddi-pfnsco_indication_callback) should process a notification differently depending upon the value that the Bluetooth driver stack passes in the *Indication* parameter of the callback function.
+A profile driver's [SCO Callback Function](./nc-bthddi-pfnsco_indication_callback.md) should process a notification differently depending upon the value that the Bluetooth driver stack passes in the *Indication* parameter of the callback function.
 
 When the Bluetooth driver stack passes **ScoIndicationRemoteConnect**, the callback function should use the **Connect** member of the **Parameters** union.
 
@@ -100,6 +100,6 @@ When the Bluetooth driver stack passes **ScoIndicationRemoteDisconnect**, the ca
 
 ## -see-also
 
-[SCO Callback Function](/windows-hardware/drivers/ddi/bthddi/nc-bthddi-pfnsco_indication_callback)
+[SCO Callback Function](./nc-bthddi-pfnsco_indication_callback.md)
 
-[SCO\_DISCONNECT\_REASON](/windows-hardware/drivers/ddi/bthddi/ne-bthddi-_sco_disconnect_reason)
+[SCO\_DISCONNECT\_REASON](./ne-bthddi-_sco_disconnect_reason.md)

--- a/wdk-ddi-src/content/bthioctl/ns-bthioctl-_bth_sdp_service_attribute_search_request.md
+++ b/wdk-ddi-src/content/bthioctl/ns-bthioctl-_bth_sdp_service_attribute_search_request.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-The BTH_SDP_SERVICE_ATTRIBUTE_SEARCH_REQUEST structure contains information pertinent to a combined SDP service and attribute search. This structure is passed as the input buffer to the [IOCTL_BTH_SDP_SERVICE_ATTRIBUTE_SEARCH](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_service_attribute_search) IOCTL.
+The BTH_SDP_SERVICE_ATTRIBUTE_SEARCH_REQUEST structure contains information pertinent to a combined SDP service and attribute search. This structure is passed as the input buffer to the [IOCTL_BTH_SDP_SERVICE_ATTRIBUTE_SEARCH](./ni-bthioctl-ioctl_bth_sdp_service_attribute_search.md) IOCTL.
 
 ## -struct-fields
 
@@ -72,7 +72,7 @@ A variable-length array of [SdpAttributeRange](/windows/win32/api/bthsdpdef/ns-b
 
 #### - hConnection
 
-A handle to the remote SDP server that is returned by the [IOCTL_BTH_SDP_CONNECT](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_connect) IOCTL.
+A handle to the remote SDP server that is returned by the [IOCTL_BTH_SDP_CONNECT](./ni-bthioctl-ioctl_bth_sdp_connect.md) IOCTL.
 
 ## -remarks
 
@@ -80,8 +80,8 @@ The Bluetooth driver stack determines the number of array items in the **range**
 
 ## -see-also
 
-[IOCTL_BTH_SDP_CONNECT](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_connect)
+[IOCTL_BTH_SDP_CONNECT](./ni-bthioctl-ioctl_bth_sdp_connect.md)
 
-[IOCTL_BTH_SDP_SERVICE_ATTRIBUTE_SEARCH](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_service_attribute_search)
+[IOCTL_BTH_SDP_SERVICE_ATTRIBUTE_SEARCH](./ni-bthioctl-ioctl_bth_sdp_service_attribute_search.md)
 
 [SdpAttributeRange](/windows/win32/api/bthsdpdef/ns-bthsdpdef-sdpattributerange)

--- a/wdk-ddi-src/content/bthioctl/ns-bthioctl-_bth_sdp_service_search_request.md
+++ b/wdk-ddi-src/content/bthioctl/ns-bthioctl-_bth_sdp_service_search_request.md
@@ -64,14 +64,14 @@ An array of UUIDs that represent the services for which to query. Each entry can
 
 #### - hConnection
 
-A handle to the remote SDP server that is returned by the [IOCTL_BTH_SDP_CONNECT](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_connect) IOCTL.
+A handle to the remote SDP server that is returned by the [IOCTL_BTH_SDP_CONNECT](./ni-bthioctl-ioctl_bth_sdp_connect.md) IOCTL.
 
 ## -remarks
 
-This structure is passed as the input buffer to the [IOCTL_BTH_SDP_SERVICE_SEARCH](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_service_search) IOCTL.
+This structure is passed as the input buffer to the [IOCTL_BTH_SDP_SERVICE_SEARCH](./ni-bthioctl-ioctl_bth_sdp_service_search.md) IOCTL.
 
 ## -see-also
 
-[IOCTL_BTH_SDP_CONNECT](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_connect)
+[IOCTL_BTH_SDP_CONNECT](./ni-bthioctl-ioctl_bth_sdp_connect.md)
 
-[IOCTL_BTH_SDP_SERVICE_SEARCH](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_service_search)
+[IOCTL_BTH_SDP_SERVICE_SEARCH](./ni-bthioctl-ioctl_bth_sdp_service_search.md)

--- a/wdk-ddi-src/content/d3dkmddi/ne-d3dkmddi-dxgk_physical_memory_type.md
+++ b/wdk-ddi-src/content/d3dkmddi/ne-d3dkmddi-dxgk_physical_memory_type.md
@@ -43,15 +43,15 @@ dev_langs:
 
 ### -field DXGK_PHYSICAL_MEMORY_TYPE_MDL
 
-Allocate nonpageable memory in the form of an MDL. This is functionally equivalent to calling [**MmAllocatePagesForMdl**](/windows-hardware/drivers/ddi/wdm/nf-wdm-mmallocatepagesformdl).
+Allocate nonpageable memory in the form of an MDL. This is functionally equivalent to calling [**MmAllocatePagesForMdl**](../wdm/nf-wdm-mmallocatepagesformdl.md).
 
 ### -field DXGK_PHYSICAL_MEMORY_TYPE_CONTIGUOUS_MEMORY
 
-Allocate contiguous nonpageable memory. This is functionally equivalent to calling [**MmAllocateContiguousMemory**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-mmallocatecontiguousmemory).
+Allocate contiguous nonpageable memory. This is functionally equivalent to calling [**MmAllocateContiguousMemory**](../ntddk/nf-ntddk-mmallocatecontiguousmemory.md).
 
 ### -field DXGK_PHYSICAL_MEMORY_TYPE_SECTION
 
-Allocate memory that can be mapped into one or more processes. This represents memory that would normally be allocated from [**ZwCreateSection**](/windows-hardware/drivers/ddi/wdm/nf-wdm-zwcreatesection).
+Allocate memory that can be mapped into one or more processes. This represents memory that would normally be allocated from [**ZwCreateSection**](../wdm/nf-wdm-zwcreatesection.md).
 
 ### -field DXGK_PHYSICAL_MEMORY_TYPE_IO_SPACE
 

--- a/wdk-ddi-src/content/d3dkmddi/ns-d3dkmddi-dxgkargcb_create_physical_memory_object.md
+++ b/wdk-ddi-src/content/d3dkmddi/ns-d3dkmddi-dxgkargcb_create_physical_memory_object.md
@@ -71,19 +71,19 @@ Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_MDL**.
 
 ### -field Mdl.LowAddress
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_MDL**. See [**MmAllocatePagesForMdlEx**](/windows-hardware/drivers/ddi/wdm/nf-wdm-mmallocatepagesformdlex) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_MDL**. See [**MmAllocatePagesForMdlEx**](../wdm/nf-wdm-mmallocatepagesformdlex.md) for details.
 
 ### -field Mdl.HighAddress
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_MDL**. See [**MmAllocatePagesForMdlEx**](/windows-hardware/drivers/ddi/wdm/nf-wdm-mmallocatepagesformdlex) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_MDL**. See [**MmAllocatePagesForMdlEx**](../wdm/nf-wdm-mmallocatepagesformdlex.md) for details.
 
 ### -field Mdl.SkipBytes
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_MDL**. See [**MmAllocatePagesForMdlEx**](/windows-hardware/drivers/ddi/wdm/nf-wdm-mmallocatepagesformdlex) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_MDL**. See [**MmAllocatePagesForMdlEx**](../wdm/nf-wdm-mmallocatepagesformdlex.md) for details.
 
 ### -field Mdl.Flags
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_MDL**. See [**MmAllocatePagesForMdlEx**](/windows-hardware/drivers/ddi/wdm/nf-wdm-mmallocatepagesformdlex) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_MDL**. See [**MmAllocatePagesForMdlEx**](../wdm/nf-wdm-mmallocatepagesformdlex.md) for details.
 
 ### -field ContiguousMemory
 
@@ -91,15 +91,15 @@ Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_CONTIGUOUS_MEMORY**.
 
 ### -field ContiguousMemory.LowestAcceptableAddress
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_CONTIGUOUS_MEMORY**. See [**MmAllocateContiguousMemorySpecifyCache**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycache) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_CONTIGUOUS_MEMORY**. See [**MmAllocateContiguousMemorySpecifyCache**](../ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycache.md) for details.
 
 ### -field ContiguousMemory.HighestAcceptableAddress
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_CONTIGUOUS_MEMORY**. See [**MmAllocateContiguousMemorySpecifyCache**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycache) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_CONTIGUOUS_MEMORY**. See [**MmAllocateContiguousMemorySpecifyCache**](../ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycache.md) for details.
 
 ### -field ContiguousMemory.BoundaryAddressMultiple
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_CONTIGUOUS_MEMORY**. See [**MmAllocateContiguousMemorySpecifyCache**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycache) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_CONTIGUOUS_MEMORY**. See [**MmAllocateContiguousMemorySpecifyCache**](../ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycache.md) for details.
 
 ### -field Section
 
@@ -107,19 +107,19 @@ Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_SECTION**.
 
 ### -field Section.DesiredAccess
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_SECTION**. See [**ZwCreateSection**](/windows-hardware/drivers/ddi/wdm/nf-wdm-zwcreatesection) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_SECTION**. See [**ZwCreateSection**](../wdm/nf-wdm-zwcreatesection.md) for details.
 
 ### -field Section.ObjectAttributes
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_SECTION**. See [**ZwCreateSection**](/windows-hardware/drivers/ddi/wdm/nf-wdm-zwcreatesection) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_SECTION**. See [**ZwCreateSection**](../wdm/nf-wdm-zwcreatesection.md) for details.
 
 ### -field Section.PageProtection
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_SECTION**. This value should be one of the following values: PAGE_READONLY, PAGE_READWRITE, PAGE_EXECUTE, or PAGE_WRITECOPY. Do not specify cache attributes (e.g. SEC_WRITECOMBINED) in this field. The allocated attributes of the section object are always SEC_COMMIT (PF-mapped section), and the cache type is determines by **CacheType**. See [**ZwCreateSection**](/windows-hardware/drivers/ddi/wdm/nf-wdm-zwcreatesection) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_SECTION**. This value should be one of the following values: PAGE_READONLY, PAGE_READWRITE, PAGE_EXECUTE, or PAGE_WRITECOPY. Do not specify cache attributes (e.g. SEC_WRITECOMBINED) in this field. The allocated attributes of the section object are always SEC_COMMIT (PF-mapped section), and the cache type is determines by **CacheType**. See [**ZwCreateSection**](../wdm/nf-wdm-zwcreatesection.md) for details.
 
 ### -field Section.AllocationAttributes
 
-Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_SECTION**. See [**ZwCreateSection**](/windows-hardware/drivers/ddi/wdm/nf-wdm-zwcreatesection) for details.
+Used only when **Type** is **DXGK_PHYSICAL_MEMORY_TYPE_SECTION**. See [**ZwCreateSection**](../wdm/nf-wdm-zwcreatesection.md) for details.
 
 ### -field IOSpace
 
@@ -155,8 +155,8 @@ The *hAdapter* field is optional when creating a physical memory object, but tha
 
 [**DxgkCbOpenPhysicalMemoryObject**](nc-d3dkmddi-dxgkcb_openphysicalmemoryobject.md)
 
-[**MmAllocateContiguousMemorySpecifyCache**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycache)
+[**MmAllocateContiguousMemorySpecifyCache**](../ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycache.md)
 
-[**MmAllocatePagesForMdlEx**](/windows-hardware/drivers/ddi/wdm/nf-wdm-mmallocatepagesformdlex)
+[**MmAllocatePagesForMdlEx**](../wdm/nf-wdm-mmallocatepagesformdlex.md)
 
-[**ZwCreateSection**](/windows-hardware/drivers/ddi/wdm/nf-wdm-zwcreatesection)
+[**ZwCreateSection**](../wdm/nf-wdm-zwcreatesection.md)

--- a/wdk-ddi-src/content/minitape/ns-minitape-_scsi_request_block.md
+++ b/wdk-ddi-src/content/minitape/ns-minitape-_scsi_request_block.md
@@ -77,15 +77,15 @@ Specifies the operation to be performed, which can be one of the following value
 | SRB_FUNCTION_RECEIVE_EVENT (0x03) | The HBA should be prepared to receive an asynchronous event notification from the addressed target. The SRB **DataBuffer** member indicates where the data should be placed. |
 | SRB_FUNCTION_SHUTDOWN (0x07) | The system is being shut down. This request is sent to a miniport driver only if it set **CachesData** to **TRUE** in the PORT_CONFIGURATION_INFORMATION for the HBA. Such a miniport driver can receive several of these notifications before all system activity actually stops. However, the last shutdown notification will occur after the last start I/O. Only the SRB **Function**, **PathId**, **TargetId** and **Lun** members are valid. |
 | SRB_FUNCTION_FLUSH (0x08) | The miniport driver should flush any cached data for the target device. This request is sent to the miniport driver only if it set **CachesData** to **TRUE** in the PORT_CONFIGURATION_INFORMATION for the HBA. Only the SRB **Function**, **PathId**, **TargetId** and **Lun** members are valid. |
-| SRB_FUNCTION_IO_CONTROL (0x02) | The request is an I/O control request, originating in a user-mode application with a dedicated HBA. The SRB **DataBuffer** points to an SRB_IO_CONTROL header followed by the data area. The value in **DataBuffer** can be used by the driver, regardless of the value of **MapBuffers**. Only the SRB **Function**, **SrbFlags**, **TimeOutValue**, **DataBuffer**, and **DataTransferLength** members are valid, along with the **SrbExtension** member if the miniport driver requested SRB extensions when it initialized. If a miniport driver controls an application-dedicated HBA so it supports this request, the miniport driver should execute the request and notify the OS-specific port driver when the SRB has completed, using the normal mechanism of calls to [**ScsiPortNotification**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportnotification) with **RequestComplete** and **NextRequest**. |
+| SRB_FUNCTION_IO_CONTROL (0x02) | The request is an I/O control request, originating in a user-mode application with a dedicated HBA. The SRB **DataBuffer** points to an SRB_IO_CONTROL header followed by the data area. The value in **DataBuffer** can be used by the driver, regardless of the value of **MapBuffers**. Only the SRB **Function**, **SrbFlags**, **TimeOutValue**, **DataBuffer**, and **DataTransferLength** members are valid, along with the **SrbExtension** member if the miniport driver requested SRB extensions when it initialized. If a miniport driver controls an application-dedicated HBA so it supports this request, the miniport driver should execute the request and notify the OS-specific port driver when the SRB has completed, using the normal mechanism of calls to [**ScsiPortNotification**](../srb/nf-srb-scsiportnotification.md) with **RequestComplete** and **NextRequest**. |
 | SRB_FUNCTION_LOCK_QUEUE (0x18) | Holds requests queued by the port driver for a particular logical unit, typically while a power request is being processed. Only the SRB **Length**, **Function**, **SrbFlags**, and **OriginalRequest** members are valid. When the queue is locked, only requests with **SrbFlags** ORed with SRB_FLAGS_BYPASS_LOCKED_QUEUE will be processed. SCSI miniport drivers do not process SRB_FUNCTION_LOCK_QUEUE requests. |
 | SRB_FUNCTION_UNLOCK_QUEUE (0x19) | Releases the port driver's queue for a logical unit that was previously locked with SRB_FUNCTION_LOCK_QUEUE. The **SrbFlags** of the unlock request must be ORed with SRB_FLAGS_BYPASS_LOCKED_QUEUE. Only the SRB **Length**, **Function**, **SrbFlags**, and **OriginalRequest** members are valid. SCSI miniport drivers do not process SRB_FUNCTION_UNLOCK_QUEUE requests. |
-| SRB_FUNCTION_DUMP_POINTERS (0x26) | A request with this function is sent to a Storport miniport driver that is used to control the disk that holds the crash dump data. The request collects information needed from the miniport driver to support crash dump and hibernation. See the **MINIPORT_DUMP_POINTERS** structure. A physical miniport driver must set the STOR_FEATURE_DUMP_POINTERS flag in the **FeatureSupport** member of its [**HW_INITIALIZATION_DATA**](/windows-hardware/drivers/ddi/srb/ns-srb-_hw_initialization_data) to receive a request with this function. |
+| SRB_FUNCTION_DUMP_POINTERS (0x26) | A request with this function is sent to a Storport miniport driver that is used to control the disk that holds the crash dump data. The request collects information needed from the miniport driver to support crash dump and hibernation. See the **MINIPORT_DUMP_POINTERS** structure. A physical miniport driver must set the STOR_FEATURE_DUMP_POINTERS flag in the **FeatureSupport** member of its [**HW_INITIALIZATION_DATA**](../srb/ns-srb-_hw_initialization_data.md) to receive a request with this function. |
 | SRB_FUNCTION_FREE_DUMP_POINTERS (0x27) | A request with this function is sent to a Storport miniport driver to release any resources allocated during a previous request for SRB_FUNCTION_DUMP_POINTERS. |
 
 ### -field SrbStatus
 
-Returns the status of the completed request. This member should be set by the miniport driver before it notifies the OS-specific driver that the request has completed by calling [**ScsiPortNotification**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportnotification) with **RequestComplete**. The value of this member can be one of the following:
+Returns the status of the completed request. This member should be set by the miniport driver before it notifies the OS-specific driver that the request has completed by calling [**ScsiPortNotification**](../srb/nf-srb-scsiportnotification.md) with **RequestComplete**. The value of this member can be one of the following:
 
 | Value | Meaning |
 | ----- | ------- |
@@ -160,15 +160,15 @@ Indicates various parameters and options about the request. **SrbFlags** is read
 | SRB_FLAGS_DISABLE_AUTOSENSE | Indicates that request-sense information should not be returned. |
 | SRB_FLAGS_DATA_IN | Indicates data will be transferred from the device to the system. |
 | SRB_FLAGS_DATA_OUT | Indicates data will be transferred from the system to the device. |
-| SRB_FLAGS_UNSPECIFIED_DIRECTION | Defined for backward compatibility with the ASPI/CAM SCSI interfaces, this flag indicates that the transfer direction could be either of the preceding because both of the preceding flags are set. If this flag is set, a miniport driver should determine the transfer direction by examining the data phase for the target on the SCSI bus. If its HBA is a subordinate DMA device, such a miniport driver must update SRB_FLAGS_DATA_OUT or SRB_FLAGS_DATA_IN to the correct value before it calls [**ScsiPortIoMapTransfer**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportiomaptransfer). |
+| SRB_FLAGS_UNSPECIFIED_DIRECTION | Defined for backward compatibility with the ASPI/CAM SCSI interfaces, this flag indicates that the transfer direction could be either of the preceding because both of the preceding flags are set. If this flag is set, a miniport driver should determine the transfer direction by examining the data phase for the target on the SCSI bus. If its HBA is a subordinate DMA device, such a miniport driver must update SRB_FLAGS_DATA_OUT or SRB_FLAGS_DATA_IN to the correct value before it calls [**ScsiPortIoMapTransfer**](../srb/nf-srb-scsiportiomaptransfer.md). |
 | SRB_FLAGS_NO_DATA_TRANSFER | Indicates no data transfer with this request. If this is set, the flags SRB_FLAGS_DATA_OUT, SRB_FLAGS_DATA_IN, and SRB_FLAGS_UNSPECIFIED_DIRECTION are clear. |
 | SRB_FLAGS_DISABLE_SYNCH_TRANSFER | Indicates the HBA, if possible, should perform asynchronous I/O for this transfer request. If synchronous I/O was negotiated previously, the HBA must renegotiate for asynchronous I/O before performing the transfer. |
 | SRB_FLAGS_DISABLE_DISCONNECT | Indicates the HBA should not allow the target to disconnect from the SCSI bus during processing of this request. |
 | SRB_FLAGS_BYPASS_FROZEN_QUEUE | Is irrelevant to miniport drivers. |
 | SRB_FLAGS_NO_QUEUE_FREEZE | Is irrelevant to miniport drivers. |
 | SRB_FLAGS_IS_ACTIVE | Is irrelevant to miniport drivers. |
-| SRB_FLAGS_ALLOCATED_FROM_ZONE | Is irrelevant to miniport drivers and is obsolete to current Windows class drivers. To a Windows legacy class driver, this indicates whether the SRB was allocated from a zone buffer. If this flag is set, the class driver must call [**ExInterlockedFreeToZone**](/windows-hardware/drivers/kernel/mmcreatemdl) to release the SRB; otherwise, it must call [**ExFreePool**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-exfreepool). New class drivers should use lookaside lists rather than zone buffers. |
-| SRB_FLAGS_SGLIST_FROM_POOL | Is irrelevant to miniport drivers. To a Windows class driver, this indicates that memory for a scatter/gather list was allocated from nonpaged pool. If this flag is set, the class driver must call [**ExFreePool**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-exfreepool) to release the memory after the SRB is completed. |
+| SRB_FLAGS_ALLOCATED_FROM_ZONE | Is irrelevant to miniport drivers and is obsolete to current Windows class drivers. To a Windows legacy class driver, this indicates whether the SRB was allocated from a zone buffer. If this flag is set, the class driver must call [**ExInterlockedFreeToZone**](/windows-hardware/drivers/kernel/mmcreatemdl) to release the SRB; otherwise, it must call [**ExFreePool**](../ntddk/nf-ntddk-exfreepool.md). New class drivers should use lookaside lists rather than zone buffers. |
+| SRB_FLAGS_SGLIST_FROM_POOL | Is irrelevant to miniport drivers. To a Windows class driver, this indicates that memory for a scatter/gather list was allocated from nonpaged pool. If this flag is set, the class driver must call [**ExFreePool**](../ntddk/nf-ntddk-exfreepool.md) to release the memory after the SRB is completed. |
 | SRB_FLAGS_BYPASS_LOCKED_QUEUE | Is irrelevant to miniport drivers. To the port driver, this flag indicates that the request should be processed whether the logical-unit queue is locked. A higher-level driver must set this flag to send an SRB_FUNCTION_UNLOCK_QUEUE request. |
 | SRB_FLAGS_NO_KEEP_AWAKE | Is irrelevant to miniport drivers. A Windows  class driver uses this flag to indicate to the port driver to report idle rather than powering up the device to handle this request. |
 | SRB_FLAGS_FREE_SENSE_BUFFER | Indicates that either the port or the miniport driver has allocated a buffer for sense data. This informs the class driver that it must free the sense data buffer after extracting the data. |
@@ -199,7 +199,7 @@ Points to the IRP for this request. This member is irrelevant to miniport driver
 
 ### -field SrbExtension
 
-Points to the Srb extension. A miniport driver must not use this member if it set **SrbExtensionSize** to zero in the SCSI_HW_INITIALIZATION_DATA. The memory at **SrbExtension** is not initialized by the OS-specific port driver, and the miniport driver-determined data can be accessed directly by the HBA. The corresponding physical address can be obtained by calling [**ScsiPortGetPhysicalAddress**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportgetphysicaladdress) with the **SrbExtension** pointer.
+Points to the Srb extension. A miniport driver must not use this member if it set **SrbExtensionSize** to zero in the SCSI_HW_INITIALIZATION_DATA. The memory at **SrbExtension** is not initialized by the OS-specific port driver, and the miniport driver-determined data can be accessed directly by the HBA. The corresponding physical address can be obtained by calling [**ScsiPortGetPhysicalAddress**](../srb/nf-srb-scsiportgetphysicaladdress.md) with the **SrbExtension** pointer.
 
 ### -field InternalStatus
 
@@ -231,22 +231,22 @@ The preceding SRB_FUNCTION_*XXX* are never set in SRBs sent to SCSI miniport dri
 
 ## -see-also
 
-[**ExFreePool**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-exfreepool)
+[**ExFreePool**](../ntddk/nf-ntddk-exfreepool.md)
 
 [**ExInterlockedFreeToZone**](/windows-hardware/drivers/kernel/mmcreatemdl)
 
-[**HW_INITIALIZATION_DATA (SCSI)**](/windows-hardware/drivers/ddi/srb/ns-srb-_hw_initialization_data)
+[**HW_INITIALIZATION_DATA (SCSI)**](../srb/ns-srb-_hw_initialization_data.md)
 
-[**PORT_CONFIGURATION_INFORMATION (SCSI)**](/windows-hardware/drivers/ddi/srb/ns-srb-_port_configuration_information)
+[**PORT_CONFIGURATION_INFORMATION (SCSI)**](../srb/ns-srb-_port_configuration_information.md)
 
-[**SCSI_WMI_REQUEST_BLOCK**](/windows-hardware/drivers/ddi/srb/ns-srb-_scsi_wmi_request_block)
+[**SCSI_WMI_REQUEST_BLOCK**](../srb/ns-srb-_scsi_wmi_request_block.md)
 
-[**SRB_IO_CONTROL**](/windows-hardware/drivers/ddi/ntddscsi/ns-ntddscsi-_srb_io_control)
+[**SRB_IO_CONTROL**](../ntddscsi/ns-ntddscsi-_srb_io_control.md)
 
-[**ScsiPortGetPhysicalAddress**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportgetphysicaladdress)
+[**ScsiPortGetPhysicalAddress**](../srb/nf-srb-scsiportgetphysicaladdress.md)
 
-[**ScsiPortGetSrb**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportgetsrb)
+[**ScsiPortGetSrb**](../srb/nf-srb-scsiportgetsrb.md)
 
-[**ScsiPortIoMapTransfer**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportiomaptransfer)
+[**ScsiPortIoMapTransfer**](../srb/nf-srb-scsiportiomaptransfer.md)
 
-[**ScsiPortNotification**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportnotification)
+[**ScsiPortNotification**](../srb/nf-srb-scsiportnotification.md)

--- a/wdk-ddi-src/content/ndkpi/nc-ndkpi-ndk_fn_accept_ex.md
+++ b/wdk-ddi-src/content/ndkpi/nc-ndkpi-ndk_fn_accept_ex.md
@@ -49,22 +49,22 @@ The *NdkAcceptEx* (*NDK_FN_ACCEPT_EX*) function accepts an incoming connection r
 ### -param pNdkConnector 
 
 [in]
-A pointer to an NDK connector object ([NDK_CONNECTOR](/windows-hardware/drivers/ddi/ndkpi/ns-ndkpi-_ndk_connector)).
+A pointer to an NDK connector object ([NDK_CONNECTOR](./ns-ndkpi-_ndk_connector.md)).
 
 ### -param pNdkQp 
 
 [in]
-A pointer to an NDK queue pair (QP) object ([NDK_QP](/windows-hardware/drivers/ddi/ndkpi/ns-ndkpi-_ndk_qp)) to associate with the connection.
+A pointer to an NDK queue pair (QP) object ([NDK_QP](./ns-ndkpi-_ndk_qp.md)) to associate with the connection.
 
 ### -param InboundReadLimit 
 
 [in]
-The consumer-supplied maximum number of incoming in-progress read operations to allow on the QP. If the underlying provider has a lower **MaxInboundReadLimit** value in the [NDK_ADAPTER_INFO](/windows/win32/api/ndkinfo/ns-ndkinfo-ndk_adapter_info) structure, then the provider will cap the consumer-supplied value to the provider maximum. If the peer has a lower *OutboundReadLimit* value, then the provider will use that value as the effective *InboundReadLimit*. The consumer can retrieve the effective *InboundReadLimit* by calling the *NdkGetConnectionData* function ([NDK_FN_GET_CONNECTION_DATA](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_get_connection_data)).
+The consumer-supplied maximum number of incoming in-progress read operations to allow on the QP. If the underlying provider has a lower **MaxInboundReadLimit** value in the [NDK_ADAPTER_INFO](/windows/win32/api/ndkinfo/ns-ndkinfo-ndk_adapter_info) structure, then the provider will cap the consumer-supplied value to the provider maximum. If the peer has a lower *OutboundReadLimit* value, then the provider will use that value as the effective *InboundReadLimit*. The consumer can retrieve the effective *InboundReadLimit* by calling the *NdkGetConnectionData* function ([NDK_FN_GET_CONNECTION_DATA](./nc-ndkpi-ndk_fn_get_connection_data.md)).
 
 ### -param OutboundReadLimit 
 
 [in]
-The consumer-supplied maximum number of outgoing in-progress read operations to allow on the QP. If the underlying provider has a lower **MaxOutboundReadLimit** value  in the [NDK_ADAPTER_INFO](/windows/win32/api/ndkinfo/ns-ndkinfo-ndk_adapter_info) structure, then the provider will cap the consumer supplied value to the provider maximum. If the peer has a lower *InboundReadLimit*, then the provider will use that value as the effective *OutboundReadLimit*. The consumer can retrieve the effective *OutboundReadLimit* by calling the *NdkGetConnectionData* function ([NDK_FN_GET_CONNECTION_DATA](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_get_connection_data)).
+The consumer-supplied maximum number of outgoing in-progress read operations to allow on the QP. If the underlying provider has a lower **MaxOutboundReadLimit** value  in the [NDK_ADAPTER_INFO](/windows/win32/api/ndkinfo/ns-ndkinfo-ndk_adapter_info) structure, then the provider will cap the consumer supplied value to the provider maximum. If the peer has a lower *InboundReadLimit*, then the provider will use that value as the effective *OutboundReadLimit*. The consumer can retrieve the effective *OutboundReadLimit* by calling the *NdkGetConnectionData* function ([NDK_FN_GET_CONNECTION_DATA](./nc-ndkpi-ndk_fn_get_connection_data.md)).
 
 ### -param PVOID
 
@@ -88,7 +88,7 @@ A context value to pass to the *DisconnectEventContext* parameter of the  callba
 ### -param RequestCompletion 
 
 [in]
-A pointer to a request completion callback routine *NdkRequestCompletion* ([NDK_FN_REQUEST_COMPLETION](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_request_completion)).
+A pointer to a request completion callback routine *NdkRequestCompletion* ([NDK_FN_REQUEST_COMPLETION](./nc-ndkpi-ndk_fn_request_completion.md)).
 
 ### -param RequestContext 
 
@@ -102,7 +102,7 @@ The *NDK_FN_ACCEPT_EX* function returns one of the following NTSTATUS codes.
 |Return code|Description|
 |--- |--- |
 |**STATUS_SUCCESS**|The operation completed successfully.|
-|**STATUS_PENDING**|The operation is pending and will be completed later. The driver will call the specified _RequestCompletion_ ([NDK_FN_REQUEST_COMPLETION](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_request_completion)) function to complete the pending operation.|
+|**STATUS_PENDING**|The operation is pending and will be completed later. The driver will call the specified _RequestCompletion_ ([NDK_FN_REQUEST_COMPLETION](./nc-ndkpi-ndk_fn_request_completion.md)) function to complete the pending operation.|
 |**STATUS_CONNECTION_ABORTED**|The connecting peer abandoned the pending connection establishment.|
 |**STATUS_IO_TIMEOUT**|The peer did not call the CompleteConnect ([NDK_FN_COMPLETE_CONNECT_EX](nc-ndkpi-ndk_fn_complete_connect_ex.md)) function to complete the pending connection request.|
 |**Other status codes**|An error occurred.|
@@ -112,7 +112,7 @@ The *NDK_FN_ACCEPT_EX* function returns one of the following NTSTATUS codes.
 
 The NDK consumer calls *NdkAcceptEx* to accept an incoming connection request over a listener object.
 
-The *NdkCreateListener* ([NDK_FN_CREATE_LISTENER](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_create_listener)) function creates an NDK listener object and provides an *NdkConnectEventCallback* function ([NDK_FN_CONNECT_EVENT_CALLBACK](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_connect_event_callback)).
+The *NdkCreateListener* ([NDK_FN_CREATE_LISTENER](./nc-ndkpi-ndk_fn_create_listener.md)) function creates an NDK listener object and provides an *NdkConnectEventCallback* function ([NDK_FN_CONNECT_EVENT_CALLBACK](./nc-ndkpi-ndk_fn_connect_event_callback.md)).
 
 The *NdkConnectEventCallback* function is used by the NDK provider to notify the consumer about each incoming connection request.
 
@@ -130,32 +130,32 @@ The *NdkConnectEventCallback* function is used by the NDK provider to notify the
 
 
 
-[NDK_CONNECTOR](/windows-hardware/drivers/ddi/ndkpi/ns-ndkpi-_ndk_connector)
+[NDK_CONNECTOR](./ns-ndkpi-_ndk_connector.md)
 
 
 
-[NDK_CONNECTOR_DISPATCH](/windows-hardware/drivers/ddi/ndkpi/ns-ndkpi-_ndk_connector_dispatch)
+[NDK_CONNECTOR_DISPATCH](./ns-ndkpi-_ndk_connector_dispatch.md)
 
 
 
-[NDK_FN_CONNECT_EVENT_CALLBACK](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_connect_event_callback)
+[NDK_FN_CONNECT_EVENT_CALLBACK](./nc-ndkpi-ndk_fn_connect_event_callback.md)
 
 
 
-[NDK_FN_CREATE_LISTENER](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_create_listener)
+[NDK_FN_CREATE_LISTENER](./nc-ndkpi-ndk_fn_create_listener.md)
 
 
 
-[NDK_FN_GET_CONNECTION_DATA](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_get_connection_data)
+[NDK_FN_GET_CONNECTION_DATA](./nc-ndkpi-ndk_fn_get_connection_data.md)
 
 
 
-[NDK_FN_REJECT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_reject)
+[NDK_FN_REJECT](./nc-ndkpi-ndk_fn_reject.md)
 
 
 
-[NDK_FN_REQUEST_COMPLETION](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_request_completion)
+[NDK_FN_REQUEST_COMPLETION](./nc-ndkpi-ndk_fn_request_completion.md)
 
 
 
-[NDK_QP](/windows-hardware/drivers/ddi/ndkpi/ns-ndkpi-_ndk_qp)
+[NDK_QP](./ns-ndkpi-_ndk_qp.md)

--- a/wdk-ddi-src/content/ndkpi/nc-ndkpi-ndk_fn_complete_connect_ex.md
+++ b/wdk-ddi-src/content/ndkpi/nc-ndkpi-ndk_fn_complete_connect_ex.md
@@ -49,7 +49,7 @@ The *NdkCompleteConnectEx* (*NDK_FN_COMPLETE_CONNECT_EX*) function completes an 
 ### -param pNdkConnector
 
 [in]
-A pointer to an NDK connector object ([NDK_CONNECTOR](/windows-hardware/drivers/ddi/ndkpi/ns-ndkpi-_ndk_connector)).
+A pointer to an NDK connector object ([NDK_CONNECTOR](./ns-ndkpi-_ndk_connector.md)).
 
 ### -param DisconnectEvent
 
@@ -64,7 +64,7 @@ A context value to pass back to the *NdkDisconnectEventCallback* function that i
 ### -param RequestCompletion 
 
 [in]
-A pointer to a request completion callback *NdkRequestCompletion* function ([NDK_FN_REQUEST_COMPLETION](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_request_completion)).
+A pointer to a request completion callback *NdkRequestCompletion* function ([NDK_FN_REQUEST_COMPLETION](./nc-ndkpi-ndk_fn_request_completion.md)).
 
 ### -param RequestContext 
 
@@ -86,7 +86,7 @@ The *NDK_FN_COMPLETE_CONNECT* function returns one of the following NTSTATUS cod
 
 ## -remarks
 
-The *NdkCompleteConnectEx* function completes a connection request that was  initiated by a previous call to the *NdkConnect* ([NDK_FN_CONNECT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_connect)) function. The NDK consumer calls *NdkCompleteConnectEx* after the peer accepts the connection request.
+The *NdkCompleteConnectEx* function completes a connection request that was  initiated by a previous call to the *NdkConnect* ([NDK_FN_CONNECT](./nc-ndkpi-ndk_fn_connect.md)) function. The NDK consumer calls *NdkCompleteConnectEx* after the peer accepts the connection request.
 
 ## -see-also
 
@@ -96,14 +96,14 @@ The *NdkCompleteConnectEx* function completes a connection request that was  ini
 
 [NDKPI Object Lifetime Requirements](/windows-hardware/drivers/network/ndkpi-object-lifetime-requirements)
 
-[NDK_CONNECTOR](/windows-hardware/drivers/ddi/ndkpi/ns-ndkpi-_ndk_connector)
+[NDK_CONNECTOR](./ns-ndkpi-_ndk_connector.md)
 
-[NDK_CONNECTOR_DISPATCH](/windows-hardware/drivers/ddi/ndkpi/ns-ndkpi-_ndk_connector_dispatch)
-
-
-
-[NDK_FN_CONNECT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_connect)
+[NDK_CONNECTOR_DISPATCH](./ns-ndkpi-_ndk_connector_dispatch.md)
 
 
 
-[NDK_FN_REQUEST_COMPLETION](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_request_completion)
+[NDK_FN_CONNECT](./nc-ndkpi-ndk_fn_connect.md)
+
+
+
+[NDK_FN_REQUEST_COMPLETION](./nc-ndkpi-ndk_fn_request_completion.md)

--- a/wdk-ddi-src/content/ndkpi/ns-ndkpi-_ndk_connector_dispatch.md
+++ b/wdk-ddi-src/content/ndkpi/ns-ndkpi-_ndk_connector_dispatch.md
@@ -114,49 +114,48 @@ The <b>NDK_CONNECTOR_DISPATCH</b> structure is used in the <a href="/windows-har
 
 [NDK_FN_COMPLETE_CONNECT_EX](nc-ndkpi-ndk_fn_complete_connect_ex.md)
 
-[NDK_CONNECTOR](/windows-hardware/drivers/ddi/ndkpi/ns-ndkpi-_ndk_connector)
+[NDK_CONNECTOR](./ns-ndkpi-_ndk_connector.md)
 
 
 
-[NDK_FN_ACCEPT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_accept)
+[NDK_FN_ACCEPT](./nc-ndkpi-ndk_fn_accept.md)
 
 
 
-[NDK_FN_CLOSE_OBJECT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_close_object)
+[NDK_FN_CLOSE_OBJECT](./nc-ndkpi-ndk_fn_close_object.md)
 
 
 
-[NDK_FN_COMPLETE_CONNECT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_complete_connect)
+[NDK_FN_COMPLETE_CONNECT](./nc-ndkpi-ndk_fn_complete_connect.md)
 
 
 
-[NDK_FN_CONNECT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_connect)
+[NDK_FN_CONNECT](./nc-ndkpi-ndk_fn_connect.md)
 
 
 
-[NDK_FN_CONNECT_WITH_SHARED_ENDPOINT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_connect_with_shared_endpoint)
+[NDK_FN_CONNECT_WITH_SHARED_ENDPOINT](./nc-ndkpi-ndk_fn_connect_with_shared_endpoint.md)
 
 
 
-[NDK_FN_DISCONNECT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_disconnect)
+[NDK_FN_DISCONNECT](./nc-ndkpi-ndk_fn_disconnect.md)
 
 
 
-[NDK_FN_GET_CONNECTION_DATA](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_get_connection_data)
+[NDK_FN_GET_CONNECTION_DATA](./nc-ndkpi-ndk_fn_get_connection_data.md)
 
 
 
-[NDK_FN_GET_LOCAL_ADDRESS](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_get_local_address)
+[NDK_FN_GET_LOCAL_ADDRESS](./nc-ndkpi-ndk_fn_get_local_address.md)
 
 
 
-[NDK_FN_GET_PEER_ADDRESS](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_get_peer_address)
+[NDK_FN_GET_PEER_ADDRESS](./nc-ndkpi-ndk_fn_get_peer_address.md)
 
 
 
-[NDK_FN_QUERY_EXTENSION_INTERFACE](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_query_extension_interface)
+[NDK_FN_QUERY_EXTENSION_INTERFACE](./nc-ndkpi-ndk_fn_query_extension_interface.md)
 
 
 
-[NDK_FN_REJECT](/windows-hardware/drivers/ddi/ndkpi/nc-ndkpi-ndk_fn_reject)
-
+[NDK_FN_REJECT](./nc-ndkpi-ndk_fn_reject.md)

--- a/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_nic_switch_vport_parameters.md
+++ b/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_nic_switch_vport_parameters.md
@@ -149,7 +149,7 @@ The switch identifier is an integer between zero and the number of switches that
 
 An NDIS_NIC_SWITCH_VPORT_ID value that specifies the identifier of a VPort  on the network adapter. The value is allocated by NDIS,  and is unique across the network adapter. 
 
-The **VPortId** value is within the range from zero to (**NumVPorts** - 1), where **NumVPorts** is the number of VPorts that the miniport driver has configured on the network adapter. The driver specifies this number in the **NumVPorts** member of the [NDIS_NIC_SWITCH_INFO](/windows-hardware/drivers/ddi/ntddndis/ns-ntddndis-_ndis_nic_switch_info) structure. The driver returns this structure through an OID query request of [OID_NIC_SWITCH_ENUM_SWITCHES](/windows-hardware/drivers/network/oid-nic-switch-enum-switches). 
+The **VPortId** value is within the range from zero to (**NumVPorts** - 1), where **NumVPorts** is the number of VPorts that the miniport driver has configured on the network adapter. The driver specifies this number in the **NumVPorts** member of the [NDIS_NIC_SWITCH_INFO](./ns-ntddndis-_ndis_nic_switch_info.md) structure. The driver returns this structure through an OID query request of [OID_NIC_SWITCH_ENUM_SWITCHES](/windows-hardware/drivers/network/oid-nic-switch-enum-switches). 
 
 
 > [!NOTE]
@@ -172,11 +172,11 @@ One or more queue pairs are configured on a nondefault VPort through an OID meth
 
 ### -field InterruptModeration
 
-An [NDIS_NIC_SWITCH_VPORT_INTERRUPT_MODERATION](/windows-hardware/drivers/ddi/ntddndis/ne-ntddndis-_ndis_nic_switch_vport_interrupt_moderation) value that specifies the interrupt moderation setting of the VPort.
+An [NDIS_NIC_SWITCH_VPORT_INTERRUPT_MODERATION](./ne-ntddndis-_ndis_nic_switch_vport_interrupt_moderation.md) value that specifies the interrupt moderation setting of the VPort.
 
 ### -field VPortState
 
-An [NDIS_NIC_SWITCH_VPORT_STATE](/windows-hardware/drivers/ddi/ntddndis/ne-ntddndis-_ndis_nic_switch_vport_state) value that specifies the current state of the VPort.
+An [NDIS_NIC_SWITCH_VPORT_STATE](./ne-ntddndis-_ndis_nic_switch_vport_state.md) value that specifies the current state of the VPort.
 
 ### -field ProcessorAffinity
 
@@ -205,15 +205,14 @@ For more information about the SR-IOV interface, see [Overview of Single Root I/
 
 ## -see-also
 
-[NDIS_NIC_SWITCH_INFO](/windows-hardware/drivers/ddi/ntddndis/ns-ntddndis-_ndis_nic_switch_info)
+[NDIS_NIC_SWITCH_INFO](./ns-ntddndis-_ndis_nic_switch_info.md)
 
-[NDIS_NIC_SWITCH_VF_INFO](/windows-hardware/drivers/ddi/ntddndis/ns-ntddndis-_ndis_nic_switch_vf_info)
+[NDIS_NIC_SWITCH_VF_INFO](./ns-ntddndis-_ndis_nic_switch_vf_info.md)
 
-[NDIS_OBJECT_HEADER](/windows-hardware/drivers/ddi/objectheader/ns-objectheader-ndis_object_header)
+[NDIS_OBJECT_HEADER](../objectheader/ns-objectheader-ndis_object_header.md)
 
 [OID_NIC_SWITCH_CREATE_VPORT](/windows-hardware/drivers/network/oid-nic-switch-create-vport)
 
 [OID_NIC_SWITCH_ENUM_SWITCHES](/windows-hardware/drivers/network/oid-nic-switch-enum-switches)
 
 [OID_NIC_SWITCH_VPORT_PARAMETERS](/windows-hardware/drivers/network/oid-nic-switch-vport-parameters)
-

--- a/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_receive_queue_parameters.md
+++ b/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_receive_queue_parameters.md
@@ -58,7 +58,7 @@ The **NDIS_RECEIVE_QUEUE_PARAMETERS** structure contains the configuration param
 
 ### -field Header
 
-The type, revision, and size of the **NDIS_RECEIVE_QUEUE_PARAMETERS** structure. This member is formatted as an [NDIS_OBJECT_HEADER](/windows-hardware/drivers/ddi/objectheader/ns-objectheader-ndis_object_header) structure.
+The type, revision, and size of the **NDIS_RECEIVE_QUEUE_PARAMETERS** structure. This member is formatted as an [NDIS_OBJECT_HEADER](../objectheader/ns-objectheader-ndis_object_header.md) structure.
 
 The miniport driver must set the **Type** member of **Header** to NDIS_OBJECT_TYPE_DEFAULT. To specify the version of the **NDIS_NIC_SWITCH_CAPABILITIES** structure, the driver must set the **Revision** member of **Header** to one of the following values:
 
@@ -89,7 +89,7 @@ A **ULONG** value that contains a bitwise **OR** of the following flags. The fol
 
 #### NDIS_RECEIVE_QUEUE_PARAMETERS_PER_QUEUE_RECEIVE_INDICATION
 
-The miniport driver must not mix network packets for other receive queues with the packets for this queue in a single call to the [NdisMIndicateReceiveNetBufferLists](/windows-hardware/drivers/ddi/ndis/nf-ndis-ndismindicatereceivenetbufferlists) function.
+The miniport driver must not mix network packets for other receive queues with the packets for this queue in a single call to the [NdisMIndicateReceiveNetBufferLists](../ndis/nf-ndis-ndismindicatereceivenetbufferlists.md) function.
 
 
 
@@ -129,7 +129,7 @@ The setting in the **QueueName** member changed.
 
 ### -field QueueType
 
-An [NDIS_RECEIVE_QUEUE_TYPE](/windows-hardware/drivers/ddi/ntddndis/ne-ntddndis-_ndis_receive_queue_type) enumeration value that specifies the type of the receive queue.
+An [NDIS_RECEIVE_QUEUE_TYPE](./ne-ntddndis-_ndis_receive_queue_type.md) enumeration value that specifies the type of the receive queue.
 
 ### -field QueueId
 
@@ -191,11 +191,11 @@ In NDIS 6.30, the **NDIS_RECEIVE_QUEUE_PARAMETERS** structure is also used in [N
 
 ## -see-also
 
-[NDIS_OBJECT_HEADER](/windows-hardware/drivers/ddi/objectheader/ns-objectheader-ndis_object_header)
+[NDIS_OBJECT_HEADER](../objectheader/ns-objectheader-ndis_object_header.md)
 
 
 
-[NDIS_RECEIVE_QUEUE_TYPE](/windows-hardware/drivers/ddi/ntddndis/ne-ntddndis-_ndis_receive_queue_type)
+[NDIS_RECEIVE_QUEUE_TYPE](./ne-ntddndis-_ndis_receive_queue_type.md)
 
 
 
@@ -203,7 +203,7 @@ In NDIS 6.30, the **NDIS_RECEIVE_QUEUE_PARAMETERS** structure is also used in [N
 
 
 
-[NdisMIndicateReceiveNetBufferLists](/windows-hardware/drivers/ddi/ndis/nf-ndis-ndismindicatereceivenetbufferlists)
+[NdisMIndicateReceiveNetBufferLists](../ndis/nf-ndis-ndismindicatereceivenetbufferlists.md)
 
 
 
@@ -212,4 +212,3 @@ In NDIS 6.30, the **NDIS_RECEIVE_QUEUE_PARAMETERS** structure is also used in [N
 
 
 [OID_RECEIVE_FILTER_QUEUE_PARAMETERS](/windows-hardware/drivers/network/oid-receive-filter-queue-parameters)
-

--- a/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_timestamp_capabilities.md
+++ b/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_timestamp_capabilities.md
@@ -101,7 +101,7 @@ For more information, see [Reporting timestamping capabilities and current confi
 
 [OID_TIMESTAMP_GET_CROSSTIMESTAMP](/windows-hardware/drivers/network/oid-timestamp-get-crosstimestamp)
 
-[**MiniportInitializeEx**](/windows-hardware/drivers/ddi/ndis/nc-ndis-miniport_initialize)
+[**MiniportInitializeEx**](../ndis/nc-ndis-miniport_initialize.md)
 
 [NDIS_OBJECT_HEADER](../objectheader/ns-objectheader-ndis_object_header.md)
 

--- a/wdk-ddi-src/content/sidebandaudio/index.md
+++ b/wdk-ddi-src/content/sidebandaudio/index.md
@@ -22,7 +22,6 @@ api_name:
 
 ## -description
 
-DDI for enabling Sideband Audio for specific bus types ([USB Audio 1.0](/windows-hardware/drivers/ddi/usbsidebandaudio/), A2DP, etc.).
+DDI for enabling Sideband Audio for specific bus types ([USB Audio 1.0](../usbsidebandaudio/index.md), A2DP, etc.).
 
 [Audio](../_audio/index.md)
-

--- a/wdk-ddi-src/content/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_device_descriptor.md
+++ b/wdk-ddi-src/content/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_device_descriptor.md
@@ -36,7 +36,7 @@ api_name:
 
 ## -description
 
-Gets the [Audio device descriptor](/windows-hardware/drivers/ddi/sidebandaudio/ns-sidebandaudio-_sidebandaudio_device_descriptor).
+Gets the [Audio device descriptor](./ns-sidebandaudio-_sidebandaudio_device_descriptor.md).
 The audio driver issues the IOCTL_SBAUD_GET_DEVICE_DESCRIPTOR to get information about an enabled Sideband Audio device interface.
 Specifically this returns the number of Audio endpoints available on a device that supports Sideband.
 
@@ -52,7 +52,7 @@ NULL.
 
 ### -output-buffer
 
-A buffer containing a [SIDEBANDAUDIO_DEVICE_DESCRIPTOR](/windows-hardware/drivers/ddi/sidebandaudio/ns-sidebandaudio-_sidebandaudio_device_descriptor) structure.
+A buffer containing a [SIDEBANDAUDIO_DEVICE_DESCRIPTOR](./ns-sidebandaudio-_sidebandaudio_device_descriptor.md) structure.
 
 ### -output-buffer-length 
 
@@ -70,6 +70,6 @@ The audio driver sends this request to obtain information about an enabled Audio
 
 The audio driver sends this request once with an output buffer size of zero (0) in order to determine the required output buffer size. In this case, the request will complete with Status STATUS_BUFFER_TOO_SMALL and set the <i>Information</i> member to the required buffer size. The audio driver then allocates the necessary storage space and sends the request again. Typically an audio driver will store a pointer to this storage location in its device context for reference during later activity.
 
-The audio driver can then iteratively determine each endpoints capability with the IOCTL [IOCTL_SBAUD_GET_ENDPOINT_DESCRIPTOR](/windows-hardware/drivers/ddi/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_endpoint_descriptor).
+The audio driver can then iteratively determine each endpoints capability with the IOCTL [IOCTL_SBAUD_GET_ENDPOINT_DESCRIPTOR](./ni-sidebandaudio-ioctl_sbaud_get_endpoint_descriptor.md).
 
 ## -see-also

--- a/wdk-ddi-src/content/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_endpoint_descriptor.md
+++ b/wdk-ddi-src/content/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_endpoint_descriptor.md
@@ -76,4 +76,4 @@ The audio driver sends this request once with an output buffer size of zero (0) 
 
 ## -see-also
 
-[SIDEBANDAUDIO_ENDPOINT_DESCRIPTOR](/windows-hardware/drivers/ddi/sidebandaudio/ns-sidebandaudio-_sidebandaudio_endpoint_descriptor)
+[SIDEBANDAUDIO_ENDPOINT_DESCRIPTOR](./ns-sidebandaudio-_sidebandaudio_endpoint_descriptor.md)

--- a/wdk-ddi-src/content/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_mutepropertyvalues.md
+++ b/wdk-ddi-src/content/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_mutepropertyvalues.md
@@ -45,7 +45,7 @@ Audio driver can call this IOCTL to query the mute stepped data ranges and min/m
 
 ### -input-buffer
 
-A 0 based index value based on the number of Audio endpoints as reported by the [IOCTL_SBAUD_GET_DEVICE_DESCRIPTOR](/windows-hardware/drivers/ddi/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_device_descriptor). This is a ULONG value from 0 to (N-1) where N is the number of Endpoints for the device.
+A 0 based index value based on the number of Audio endpoints as reported by the [IOCTL_SBAUD_GET_DEVICE_DESCRIPTOR](./ni-sidebandaudio-ioctl_sbaud_get_device_descriptor.md). This is a ULONG value from 0 to (N-1) where N is the number of Endpoints for the device.
 
 ### -input-buffer-length 
 
@@ -53,7 +53,7 @@ Size of ULONG.
 
 ### -output-buffer
 
-KSPROPERTY_DESCRIPTION followed by KSPROPERTY_MEMBERSHEADER and Mute stepped data ranges as documented in [KSPROPERTY_DESCRIPTION](/windows-hardware/drivers/ddi/ks/ns-ks-ksproperty_description) and [KSPROPERTY_MEMBERSHEADER](/windows-hardware/drivers/ddi/ks/ns-ks-ksproperty_membersheader).
+KSPROPERTY_DESCRIPTION followed by KSPROPERTY_MEMBERSHEADER and Mute stepped data ranges as documented in [KSPROPERTY_DESCRIPTION](../ks/ns-ks-ksproperty_description.md) and [KSPROPERTY_MEMBERSHEADER](../ks/ns-ks-ksproperty_membersheader.md).
 
 If NULL, Irp->IoStatus.Information will be set to the number of bytes required for output buffer.
 
@@ -78,4 +78,4 @@ Audio drivers that implement sideband audio should advertise endpoint Mute throu
 
 [KSNODEPROPERTY_AUDIO_CHANNEL](../ksmedia/ns-ksmedia-ksnodeproperty_audio_channel.md)
 
-[IMiniportAudioEngineNode::GetDeviceChannelCount](/windows-hardware/drivers/ddi/portcls/nf-portcls-iminiportaudioenginenode-getdevicechannelcount)
+[IMiniportAudioEngineNode::GetDeviceChannelCount](../portcls/nf-portcls-iminiportaudioenginenode-getdevicechannelcount.md)

--- a/wdk-ddi-src/content/srb/ns-srb-_scsi_request_block.md
+++ b/wdk-ddi-src/content/srb/ns-srb-_scsi_request_block.md
@@ -77,11 +77,11 @@ Specifies the operation to be performed, which can be one of the following value
 | SRB_FUNCTION_RECEIVE_EVENT (0x03) | The HBA should be prepared to receive an asynchronous event notification from the addressed target. The SRB **DataBuffer** member indicates where the data should be placed. |
 | SRB_FUNCTION_SHUTDOWN (0x07) | The system is being shut down. This request is sent to a miniport driver only if it set **CachesData** to **TRUE** in the PORT_CONFIGURATION_INFORMATION for the HBA. Such a miniport driver can receive several of these notifications before all system activity actually stops. However, the last shutdown notification will occur after the last start I/O. Only the SRB **Function**, **PathId**, **TargetId** and **Lun** members are valid. |
 | SRB_FUNCTION_FLUSH (0x08) | The miniport driver should flush any cached data for the target device. This request is sent to the miniport driver only if it set **CachesData** to **TRUE** in the PORT_CONFIGURATION_INFORMATION for the HBA. Only the SRB **Function**, **PathId**, **TargetId** and **Lun** members are valid. |
-| SRB_FUNCTION_IO_CONTROL (0x02) | The request is an I/O control request, originating in a user-mode application with a dedicated HBA. The SRB **DataBuffer** points to an SRB_IO_CONTROL header followed by the data area. The value in **DataBuffer** can be used by the driver, regardless of the value of **MapBuffers**. Only the SRB **Function**, **SrbFlags**, **TimeOutValue**, **DataBuffer**, and **DataTransferLength** members are valid, along with the **SrbExtension** member if the miniport driver requested SRB extensions when it initialized. If a miniport driver controls an application-dedicated HBA so it supports this request, the miniport driver should execute the request and notify the OS-specific port driver when the SRB has completed, using the normal mechanism of calls to [**ScsiPortNotification**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportnotification) with **RequestComplete** and **NextRequest**. |
+| SRB_FUNCTION_IO_CONTROL (0x02) | The request is an I/O control request, originating in a user-mode application with a dedicated HBA. The SRB **DataBuffer** points to an SRB_IO_CONTROL header followed by the data area. The value in **DataBuffer** can be used by the driver, regardless of the value of **MapBuffers**. Only the SRB **Function**, **SrbFlags**, **TimeOutValue**, **DataBuffer**, and **DataTransferLength** members are valid, along with the **SrbExtension** member if the miniport driver requested SRB extensions when it initialized. If a miniport driver controls an application-dedicated HBA so it supports this request, the miniport driver should execute the request and notify the OS-specific port driver when the SRB has completed, using the normal mechanism of calls to [**ScsiPortNotification**](./nf-srb-scsiportnotification.md) with **RequestComplete** and **NextRequest**. |
 | SRB_FUNCTION_LOCK_QUEUE (0x18) | Holds requests queued by the port driver for a particular logical unit, typically while a power request is being processed. Only the SRB **Length**, **Function**, **SrbFlags**, and **OriginalRequest** members are valid. When the queue is locked, only requests with **SrbFlags** ORed with SRB_FLAGS_BYPASS_LOCKED_QUEUE will be processed. SCSI miniport drivers do not process SRB_FUNCTION_LOCK_QUEUE requests. |
 | SRB_FUNCTION_UNLOCK_QUEUE (0x19) | Releases the port driver's queue for a logical unit that was previously locked with SRB_FUNCTION_LOCK_QUEUE. The **SrbFlags** of the unlock request must be ORed with SRB_FLAGS_BYPASS_LOCKED_QUEUE. Only the SRB **Length**, **Function**, **SrbFlags**, and **OriginalRequest** members are valid. SCSI miniport drivers do not process SRB_FUNCTION_UNLOCK_QUEUE requests. |
 | SRB_FUNCTION_UNLOCK_QUEUE (0x19) | Releases the port driver's queue for a logical unit that was previously locked with SRB_FUNCTION_LOCK_QUEUE. The **SrbFlags** of the unlock request must be ORed with SRB_FLAGS_BYPASS_LOCKED_QUEUE. Only the SRB **Length**, **Function**, **SrbFlags**, and **OriginalRequest** members are valid. SCSI miniport drivers do not process SRB_FUNCTION_UNLOCK_QUEUE requests. |
-| SRB_FUNCTION_DUMP_POINTERS (0x26) | A request with this function is sent to a Storport miniport driver that is used to control the disk that holds the crash dump data. The request collects information needed from the miniport driver to support crash dump and hibernation. See the **MINIPORT_DUMP_POINTERS** structure. A physical miniport driver must set the STOR_FEATURE_DUMP_POINTERS flag in the **FeatureSupport** member of its [**HW_INITIALIZATION_DATA**](/windows-hardware/drivers/ddi/srb/ns-srb-_hw_initialization_data) to receive a request with this function. |
+| SRB_FUNCTION_DUMP_POINTERS (0x26) | A request with this function is sent to a Storport miniport driver that is used to control the disk that holds the crash dump data. The request collects information needed from the miniport driver to support crash dump and hibernation. See the **MINIPORT_DUMP_POINTERS** structure. A physical miniport driver must set the STOR_FEATURE_DUMP_POINTERS flag in the **FeatureSupport** member of its [**HW_INITIALIZATION_DATA**](./ns-srb-_hw_initialization_data.md) to receive a request with this function. |
 | SRB_FUNCTION_FREE_DUMP_POINTERS (0x27) | A request with this function is sent to a Storport miniport driver to release any resources allocated during a previous request for SRB_FUNCTION_DUMP_POINTERS. |
 
 ### -field SrbStatus
@@ -161,15 +161,15 @@ Indicates various parameters and options about the request. **SrbFlags** is read
 | SRB_FLAGS_DISABLE_AUTOSENSE | Indicates that request-sense information should not be returned. |
 | SRB_FLAGS_DATA_IN | Indicates data will be transferred from the device to the system. |
 | SRB_FLAGS_DATA_OUT | Indicates data will be transferred from the system to the device. |
-| SRB_FLAGS_UNSPECIFIED_DIRECTION | Defined for backward compatibility with the ASPI/CAM SCSI interfaces, this flag indicates that the transfer direction could be either of the preceding because both of the preceding flags are set. If this flag is set, a miniport driver should determine the transfer direction by examining the data phase for the target on the SCSI bus. If its HBA is a subordinate DMA device, such a miniport driver must update SRB_FLAGS_DATA_OUT or SRB_FLAGS_DATA_IN to the correct value before it calls [**ScsiPortIoMapTransfer**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportiomaptransfer). |
+| SRB_FLAGS_UNSPECIFIED_DIRECTION | Defined for backward compatibility with the ASPI/CAM SCSI interfaces, this flag indicates that the transfer direction could be either of the preceding because both of the preceding flags are set. If this flag is set, a miniport driver should determine the transfer direction by examining the data phase for the target on the SCSI bus. If its HBA is a subordinate DMA device, such a miniport driver must update SRB_FLAGS_DATA_OUT or SRB_FLAGS_DATA_IN to the correct value before it calls [**ScsiPortIoMapTransfer**](./nf-srb-scsiportiomaptransfer.md). |
 | SRB_FLAGS_NO_DATA_TRANSFER | Indicates no data transfer with this request. If this is set, the flags SRB_FLAGS_DATA_OUT, SRB_FLAGS_DATA_IN, and SRB_FLAGS_UNSPECIFIED_DIRECTION are clear. |
 | SRB_FLAGS_DISABLE_SYNCH_TRANSFER | Indicates the HBA, if possible, should perform asynchronous I/O for this transfer request. If synchronous I/O was negotiated previously, the HBA must renegotiate for asynchronous I/O before performing the transfer. |
 | SRB_FLAGS_DISABLE_DISCONNECT | Indicates the HBA should not allow the target to disconnect from the SCSI bus during processing of this request. |
 | SRB_FLAGS_BYPASS_FROZEN_QUEUE | Is irrelevant to miniport drivers. |
 | SRB_FLAGS_NO_QUEUE_FREEZE | Is irrelevant to miniport drivers. |
 | SRB_FLAGS_IS_ACTIVE | Is irrelevant to miniport drivers. |
-| SRB_FLAGS_ALLOCATED_FROM_ZONE | Is irrelevant to miniport drivers and is obsolete to current Windows class drivers. To a Windows legacy class driver, this indicates whether the SRB was allocated from a zone buffer. If this flag is set, the class driver must call [**ExInterlockedFreeToZone**](/windows-hardware/drivers/kernel/mmcreatemdl) to release the SRB; otherwise, it must call [**ExFreePool**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-exfreepool). New class drivers should use lookaside lists rather than zone buffers. |
-| SRB_FLAGS_SGLIST_FROM_POOL | Is irrelevant to miniport drivers. To a Windows class driver, this indicates that memory for a scatter/gather list was allocated from nonpaged pool. If this flag is set, the class driver must call [**ExFreePool**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-exfreepool) to release the memory after the SRB is completed. |
+| SRB_FLAGS_ALLOCATED_FROM_ZONE | Is irrelevant to miniport drivers and is obsolete to current Windows class drivers. To a Windows legacy class driver, this indicates whether the SRB was allocated from a zone buffer. If this flag is set, the class driver must call [**ExInterlockedFreeToZone**](/windows-hardware/drivers/kernel/mmcreatemdl) to release the SRB; otherwise, it must call [**ExFreePool**](../ntddk/nf-ntddk-exfreepool.md). New class drivers should use lookaside lists rather than zone buffers. |
+| SRB_FLAGS_SGLIST_FROM_POOL | Is irrelevant to miniport drivers. To a Windows class driver, this indicates that memory for a scatter/gather list was allocated from nonpaged pool. If this flag is set, the class driver must call [**ExFreePool**](../ntddk/nf-ntddk-exfreepool.md) to release the memory after the SRB is completed. |
 | SRB_FLAGS_BYPASS_LOCKED_QUEUE | Is irrelevant to miniport drivers. To the port driver, this flag indicates that the request should be processed whether the logical-unit queue is locked. A higher-level driver must set this flag to send an SRB_FUNCTION_UNLOCK_QUEUE request. |
 | SRB_FLAGS_NO_KEEP_AWAKE | Is irrelevant to miniport drivers. A Windows  class driver uses this flag to indicate to the port driver to report idle rather than powering up the device to handle this request. |
 | SRB_FLAGS_FREE_SENSE_BUFFER | Indicates that either the port or the miniport driver has allocated a buffer for sense data. This informs the class driver that it must free the sense data buffer after extracting the data. |
@@ -200,7 +200,7 @@ Points to the IRP for this request. This member is irrelevant to miniport driver
 
 ### -field SrbExtension
 
-Points to the Srb extension. A miniport driver must not use this member if it set **SrbExtensionSize** to zero in the SCSI_HW_INITIALIZATION_DATA. The memory at **SrbExtension** is not initialized by the OS-specific port driver, and the miniport driver-determined data can be accessed directly by the HBA. The corresponding physical address can be obtained by calling [**ScsiPortGetPhysicalAddress**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportgetphysicaladdress) with the **SrbExtension** pointer.
+Points to the Srb extension. A miniport driver must not use this member if it set **SrbExtensionSize** to zero in the SCSI_HW_INITIALIZATION_DATA. The memory at **SrbExtension** is not initialized by the OS-specific port driver, and the miniport driver-determined data can be accessed directly by the HBA. The corresponding physical address can be obtained by calling [**ScsiPortGetPhysicalAddress**](./nf-srb-scsiportgetphysicaladdress.md) with the **SrbExtension** pointer.
 
 ### -field InternalStatus
 
@@ -236,22 +236,22 @@ The preceding SRB_FUNCTION_*XXX*  are never set in SRBs sent to SCSI miniport dr
 
 ## -see-also
 
-[**ExFreePool**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-exfreepool)
+[**ExFreePool**](../ntddk/nf-ntddk-exfreepool.md)
 
 [**ExInterlockedFreeToZone**](/windows-hardware/drivers/kernel/mmcreatemdl)
 
-[**HW_INITIALIZATION_DATA (SCSI)**](/windows-hardware/drivers/ddi/srb/ns-srb-_hw_initialization_data)
+[**HW_INITIALIZATION_DATA (SCSI)**](./ns-srb-_hw_initialization_data.md)
 
-[**PORT_CONFIGURATION_INFORMATION (SCSI)**](/windows-hardware/drivers/ddi/srb/ns-srb-_port_configuration_information)
+[**PORT_CONFIGURATION_INFORMATION (SCSI)**](./ns-srb-_port_configuration_information.md)
 
-[**SCSI_WMI_REQUEST_BLOCK**](/windows-hardware/drivers/ddi/srb/ns-srb-_scsi_wmi_request_block)
+[**SCSI_WMI_REQUEST_BLOCK**](./ns-srb-_scsi_wmi_request_block.md)
 
-[**SRB_IO_CONTROL**](/windows-hardware/drivers/ddi/ntddscsi/ns-ntddscsi-_srb_io_control)
+[**SRB_IO_CONTROL**](../ntddscsi/ns-ntddscsi-_srb_io_control.md)
 
-[**ScsiPortGetPhysicalAddress**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportgetphysicaladdress)
+[**ScsiPortGetPhysicalAddress**](./nf-srb-scsiportgetphysicaladdress.md)
 
-[**ScsiPortGetSrb**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportgetsrb)
+[**ScsiPortGetSrb**](./nf-srb-scsiportgetsrb.md)
 
-[**ScsiPortIoMapTransfer**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportiomaptransfer)
+[**ScsiPortIoMapTransfer**](./nf-srb-scsiportiomaptransfer.md)
 
-[**ScsiPortNotification**](/windows-hardware/drivers/ddi/srb/nf-srb-scsiportnotification)
+[**ScsiPortNotification**](./nf-srb-scsiportnotification.md)

--- a/wdk-ddi-src/content/storport/nf-storport-storportsetsystemgroupaffinitythread.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportsetsystemgroupaffinitythread.md
@@ -98,7 +98,7 @@ If **StorPortSetSystemGroupAffinityThread** is called at IRQL <= APC_LEVEL and t
 
 ## -see-also
 
-[**KeSetSystemGroupAffinityThread **](/windows-hardware/drivers/ddi/wdm/nf-wdm-kesetsystemgroupaffinitythread)
+[**KeSetSystemGroupAffinityThread **](../wdm/nf-wdm-kesetsystemgroupaffinitythread.md)
 
 [**STOR_GROUP_AFFINITY**](ns-storport-stor_group_affinity.md)
 

--- a/wdk-ddi-src/content/usbsidebandaudio/index.md
+++ b/wdk-ddi-src/content/usbsidebandaudio/index.md
@@ -26,10 +26,9 @@ The header defines the types, constants, and functions that are exposed to devic
 Audio drivers that want to provide Sideband path for USB Audio 1.0 devices should wait for Pnp notification for the Sideband interface to be published by the USB Audio 1.0 class driver - GUID_DEVINTERFACE_USB_SIDEBAND_AUDIO_HS_HCIBYPASS.
 When Audio driver recieves Pnp notification, it can use the symbolic link to send I/O and interact with the USB Audio 1.0 class device.
 
-The IOCTLs are specified in the [sidebandaudio.h](/windows-hardware/drivers/ddi/sidebandaudio/) header for all standard Sideband Audio operations.
+The IOCTLs are specified in the [sidebandaudio.h](../sidebandaudio/index.md) header for all standard Sideband Audio operations.
 USB Audio 1.0 specific structures and enums are defined in this header.
 
 For more information, see:
 
 [Audio](../_audio/index.md)
-

--- a/wdk-ddi-src/content/usbsidebandaudio/ne-usbsidebandaudio-_sidebandaudio_ep_usb_transport_resource_type.md
+++ b/wdk-ddi-src/content/usbsidebandaudio/ne-usbsidebandaudio-_sidebandaudio_ep_usb_transport_resource_type.md
@@ -45,19 +45,19 @@ Describes the type of transport resource. The resources will be returned in the 
 
 ### -field SIOP_TYPE_USBAUD_USBD_INTERFACE_DESCRIPTOR
 
-[USB Interface Descriptor](/windows-hardware/drivers/ddi/usbspec/ns-usbspec-_usb_interface_descriptor)
+[USB Interface Descriptor](../usbspec/ns-usbspec-_usb_interface_descriptor.md)
 
 ### -field SIOP_TYPE_USBAUD_EP_USBD_ENDPOINT_DESCRIPTOR 
 
-[USBD Endpoint Descriptor](/windows-hardware/drivers/ddi/usbspec/ns-usbspec-_usb_endpoint_descriptor)
+[USBD Endpoint Descriptor](../usbspec/ns-usbspec-_usb_endpoint_descriptor.md)
 
 ### -field SIOP_TYPE_USBAUD_EP_USBD_ENDPOINT_OFFLOAD_INFORMATION 
 
-[USBD Endpoint Offload Information](/windows-hardware/drivers/ddi/usb/ns-usb-_usbd_endpoint_offload_information)
+[USBD Endpoint Offload Information](../usb/ns-usb-_usbd_endpoint_offload_information.md)
 
 ### -field SIOP_TYPE_USBAUD_EP_USBAUDIO_TRANSPORT_RESOURCES
 
-[Sideband Audio EP transport resource](/windows-hardware/drivers/ddi/usbsidebandaudio/ns-usbsidebandaudio-_sidebandaudio_ep_usbaudio_transport_resources)
+[Sideband Audio EP transport resource](./ns-usbsidebandaudio-_sidebandaudio_ep_usbaudio_transport_resources.md)
 
 ### -field SIOP_TYPE_USBAUD_EP_OFFLOAD_RESOURCE_ID
 
@@ -65,15 +65,15 @@ ULONG resource ID specific to hardware platform.
 
 ### -field SIOP_TYPE_USBAUD_FB_EP_USBD_ENDPOINT_DESCRIPTOR
 
-Feedback Endpoint [USBD Endpoint Descriptor](/windows-hardware/drivers/ddi/usbspec/ns-usbspec-_usb_endpoint_descriptor)
+Feedback Endpoint [USBD Endpoint Descriptor](../usbspec/ns-usbspec-_usb_endpoint_descriptor.md)
 
 ### -field SIOP_TYPE_USBAUD_FB_EP_USBD_ENDPOINT_OFFLOAD_INFORMATION
 
-Feedback Endpoint [USBD Endpoint Offload Information](/windows-hardware/drivers/ddi/usb/ns-usb-_usbd_endpoint_offload_information)
+Feedback Endpoint [USBD Endpoint Offload Information](../usb/ns-usb-_usbd_endpoint_offload_information.md)
 
 ### -field SIOP_TYPE_USBAUD_FB_EP_USBAUDIO_TRANSPORT_RESOURCES
 
-Feedback Endpoint [Sideband Audio EP transport resource](/windows-hardware/drivers/ddi/usbsidebandaudio/ns-usbsidebandaudio-_sidebandaudio_ep_usbaudio_transport_resources)
+Feedback Endpoint [Sideband Audio EP transport resource](./ns-usbsidebandaudio-_sidebandaudio_ep_usbaudio_transport_resources.md)
 
 ### -field SIOP_TYPE_USBAUD_FB_EP_OFFLOAD_RESOURCE_ID,
 
@@ -88,10 +88,9 @@ USBD_ENDPOINT_DESCRIPTOR for specific format
 Unused
 
 ## -remarks
-[IOCTL_SBAUD_GET_SIOP](/windows-hardware/drivers/ddi/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_siop) is defined with [METHOD_NEITHER](/windows-hardware/drivers/kernel/using-neither-buffered-nor-direct-i-o) buffering model. The requested resource information will be copied to the [Irp->UserBuffer](/windows-hardware/drivers/ddi/wdm/ns-wdm-_irp).
+[IOCTL_SBAUD_GET_SIOP](../sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_siop.md) is defined with [METHOD_NEITHER](/windows-hardware/drivers/kernel/using-neither-buffered-nor-direct-i-o) buffering model. The requested resource information will be copied to the [Irp->UserBuffer](../wdm/ns-wdm-_irp.md).
 
 ## -see-also
-[IOCTL_SBAUD_GET_SIOP](/windows-hardware/drivers/ddi/sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_siop)
+[IOCTL_SBAUD_GET_SIOP](../sidebandaudio/ni-sidebandaudio-ioctl_sbaud_get_siop.md)
 
 [usbsidebandaudio.h](index.md)
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-keregisterbugcheckreasoncallback.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-keregisterbugcheckreasoncallback.md
@@ -77,9 +77,9 @@ A pointer to a null-terminated ANSI string that identifies the caller. For examp
 
 Drivers can use <b>KeRegisterBugCheckReasonCallback</b> to register routines that execute during a system bug check.
 
-For descriptions of each type of callback, see [**KBUGCHECK_CALLBACK_REASON**](/windows-hardware/drivers/ddi/wdm/ne-wdm-_kbugcheck_callback_reason).
+For descriptions of each type of callback, see [**KBUGCHECK_CALLBACK_REASON**](./ne-wdm-_kbugcheck_callback_reason.md).
 
-Drivers can use the [**KeDeregisterBugCheckReasonCallback**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kederegisterbugcheckreasoncallback) routine to remove the bug check callback registration. Any driver that can be unloaded must remove the registrations of all of its callbacks in its <a href="/windows-hardware/drivers/ddi/wdm/nc-wdm-driver_unload">Unload</a> routine.
+Drivers can use the [**KeDeregisterBugCheckReasonCallback**](./nf-wdm-kederegisterbugcheckreasoncallback.md) routine to remove the bug check callback registration. Any driver that can be unloaded must remove the registrations of all of its callbacks in its <a href="/windows-hardware/drivers/ddi/wdm/nc-wdm-driver_unload">Unload</a> routine.
 
 For information about how to implement these callback routines, see <a href="/windows-hardware/drivers/kernel/writing-a-bug-check-callback-routine">Writing a Bug Check Callback Routine</a>.
 

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlunicodestringtoutf8string.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlunicodestringtoutf8string.md
@@ -57,7 +57,7 @@ Pointer to the Unicode source string to be converted to UTF8.
 
 ### -param AllocateDestinationString
 
-**TRUE** if this routine is to allocate the buffer space for the *DestinationString*. If it does, the buffer must be deallocated by calling [RtlFreeUTF8String](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlfreeutf8string).
+**TRUE** if this routine is to allocate the buffer space for the *DestinationString*. If it does, the buffer must be deallocated by calling [RtlFreeUTF8String](./nf-wdm-rtlfreeutf8string.md).
 
 ## -returns
 
@@ -65,4 +65,4 @@ If the conversion succeeds, **RtlUnicodeStringToUTF8String** returns STATUS_SUCC
 
 ## -see-also
 
-[RtlFreeUTF8String](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlfreeutf8string)
+[RtlFreeUTF8String](./nf-wdm-rtlfreeutf8string.md)

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlutf8stringtounicodestring.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlutf8stringtounicodestring.md
@@ -59,7 +59,7 @@ Pointer to the UTF8 string to be converted to Unicode.
 
 ### -param AllocateDestinationString
 
-Specifies if this routine should allocate the buffer space for the destination string. If it does, the caller must deallocate the buffer by calling [**RtlFreeUnicodeString**](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlfreeunicodestring).
+Specifies if this routine should allocate the buffer space for the destination string. If it does, the caller must deallocate the buffer by calling [**RtlFreeUnicodeString**](./nf-wdm-rtlfreeunicodestring.md).
 
 ## -returns
 
@@ -67,4 +67,4 @@ If the conversion succeeds, **RtlUTF8StringToUnicodeString** returns STATUS_SUCC
 
 ## -see-also
 
-[**RtlFreeUnicodeString**](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlfreeunicodestring)
+[**RtlFreeUnicodeString**](./nf-wdm-rtlfreeunicodestring.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to cleanup links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```