### PR TITLE
Linkfix: Windows Driver DDI - 1

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntopenprocesstoken.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntopenprocesstoken.md
@@ -52,7 +52,7 @@ The **NtOpenProcessToken** routine opens the access token associated with a proc
 
 ### -param DesiredAccess
 
-[in] [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask) structure specifying the requested types of access to the access token. These requested access types are compared with the token's discretionary access-control list ([**DACL**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_acl)) to determine which accesses are granted or denied.
+[in] [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask) structure specifying the requested types of access to the access token. These requested access types are compared with the token's discretionary access-control list ([**DACL**](../wdm/ns-wdm-_acl.md)) to determine which accesses are granted or denied.
 
 ### -param TokenHandle
 
@@ -88,9 +88,9 @@ For calls from kernel-mode drivers, the **Nt*Xxx*** and **Zw*Xxx*** versions of 
 
 [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask)
 
-[**ACL**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_acl)
+[**ACL**](../wdm/ns-wdm-_acl.md)
 
-[**PsDereferencePrimaryToken**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-psdereferenceprimarytoken)
+[**PsDereferencePrimaryToken**](./nf-ntifs-psdereferenceprimarytoken.md)
 
 [**NtClose**](nf-ntifs-ntclose.md)
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntopenprocesstokenex.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntopenprocesstokenex.md
@@ -54,7 +54,7 @@ The **NtOpenProcessTokenEx** routine opens the access token associated with a pr
 
 ### -param DesiredAccess
 
-[in] [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask) structure specifying the requested types of access to the access token. These requested access types are compared with the token's discretionary access-control list ([**DACL**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_acl)) to determine which accesses are granted or denied.
+[in] [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask) structure specifying the requested types of access to the access token. These requested access types are compared with the token's discretionary access-control list ([**DACL**](../wdm/ns-wdm-_acl.md)) to determine which accesses are granted or denied.
 
 ### -param HandleAttributes
 
@@ -93,9 +93,9 @@ For calls from kernel-mode drivers, the **Nt*Xxx*** and **Zw*Xxx*** versions of 
 
 [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask)
 
-[**ACL**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_acl)
+[**ACL**](../wdm/ns-wdm-_acl.md)
 
-[**PsDereferencePrimaryToken**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-psdereferenceprimarytoken)
+[**PsDereferencePrimaryToken**](./nf-ntifs-psdereferenceprimarytoken.md)
 
 [**NtClose**](nf-ntifs-ntclose.md)
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntopenthreadtoken.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntopenthreadtoken.md
@@ -52,7 +52,7 @@ The **NtOpenThreadToken** routine opens the access token associated with a threa
 
 ### -param DesiredAccess
 
-[in] [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask) structure specifying the requested types of access to the access token. These requested access types are compared with the token's discretionary access-control list ([**DACL**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_acl)) to determine which access rights are granted or denied.
+[in] [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask) structure specifying the requested types of access to the access token. These requested access types are compared with the token's discretionary access-control list ([**DACL**](../wdm/ns-wdm-_acl.md)) to determine which access rights are granted or denied.
 
 ### -param OpenAsSelf
 
@@ -72,7 +72,7 @@ If this parameter is **FALSE**, the access check is performed using the security
 | ----------- | ----------- |
 | STATUS_ACCESS_DENIED |
 **ThreadHandle** did not have THREAD_QUERY_INFORMATION access. |
-| STATUS_CANT_OPEN_ANONYMOUS | The client requested the SecurityAnonymous impersonation level. However, an anonymous token cannot be opened. For more information, see [**SECURITY_IMPERSONATION_LEVEL**](/windows-hardware/drivers/ddi/wdm/ne-wdm-_security_impersonation_level). |
+| STATUS_CANT_OPEN_ANONYMOUS | The client requested the SecurityAnonymous impersonation level. However, an anonymous token cannot be opened. For more information, see [**SECURITY_IMPERSONATION_LEVEL**](../wdm/ne-wdm-_security_impersonation_level.md). |
 | STATUS_INVALID_HANDLE | **ThreadHandle** was not a valid handle. |
 | STATUS_NO_TOKEN | An attempt has been made to open a token associated with a thread that is not currently impersonating a client. |
 | STATUS_OBJECT_TYPE_MISMATCH | **ThreadHandle** was not a thread handle. |
@@ -93,14 +93,14 @@ For calls from kernel-mode drivers, the **Nt*Xxx*** and **Zw*Xxx*** versions of 
 
 [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask)
 
-[**ACL**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_acl)
+[**ACL**](../wdm/ns-wdm-_acl.md)
 
 [**NtOpenThreadTokenEx**](nf-ntifs-ntopenthreadtokenex.md)
 
-[**PsDereferencePrimaryToken**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-psdereferenceprimarytoken)
+[**PsDereferencePrimaryToken**](./nf-ntifs-psdereferenceprimarytoken.md)
 
-[**SECURITY_IMPERSONATION_LEVEL**](/windows-hardware/drivers/ddi/wdm/ne-wdm-_security_impersonation_level)
+[**SECURITY_IMPERSONATION_LEVEL**](../wdm/ne-wdm-_security_impersonation_level.md)
 
-[**ZwClose**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntclose)
+[**ZwClose**](./nf-ntifs-ntclose.md)
 
 [**ZwOpenProcessTokenEx**](/previous-versions/ff567024(v=vs.85))

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntopenthreadtokenex.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntopenthreadtokenex.md
@@ -54,7 +54,7 @@ The **NtOpenThreadTokenEx** routine opens the access token associated with a thr
 
 ### -param DesiredAccess
 
-[in] [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask) structure specifying the requested types of access to the access token. These requested access types are compared with the token's discretionary access-control list ([**DACL**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_acl)) to determine which access rights are granted or denied.
+[in] [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask) structure specifying the requested types of access to the access token. These requested access types are compared with the token's discretionary access-control list ([**DACL**](../wdm/ns-wdm-_acl.md)) to determine which access rights are granted or denied.
 
 ### -param OpenAsSelf
 
@@ -78,7 +78,7 @@ If this parameter is **FALSE**, the access check is performed using the security
 | ----------- | ----------- |
 | STATUS_ACCESS_DENIED |
 **ThreadHandle** did not have THREAD_QUERY_INFORMATION access. |
-| STATUS_CANT_OPEN_ANONYMOUS | The client requested the SecurityAnonymous impersonation level. However, an anonymous token cannot be opened. For more information, see [**SECURITY_IMPERSONATION_LEVEL**](/windows-hardware/drivers/ddi/wdm/ne-wdm-_security_impersonation_level). |
+| STATUS_CANT_OPEN_ANONYMOUS | The client requested the SecurityAnonymous impersonation level. However, an anonymous token cannot be opened. For more information, see [**SECURITY_IMPERSONATION_LEVEL**](../wdm/ne-wdm-_security_impersonation_level.md). |
 | STATUS_INVALID_HANDLE | **ThreadHandle** was not a valid handle. |
 | STATUS_INVALID_PARAMETER | The specified **HandleAttributes** did not include OBJ_KERNEL_HANDLE. |
 | STATUS_NO_TOKEN | An attempt has been made to open a token associated with a thread that is not currently impersonating a client. |
@@ -102,12 +102,12 @@ For calls from kernel-mode drivers, the **Nt*Xxx*** and **Zw*Xxx*** versions of 
 
 [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask)
 
-[**ACL**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_acl)
+[**ACL**](../wdm/ns-wdm-_acl.md)
 
-[**PsDereferencePrimaryToken**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-psdereferenceprimarytoken)
+[**PsDereferencePrimaryToken**](./nf-ntifs-psdereferenceprimarytoken.md)
 
-[**SECURITY_IMPERSONATION_LEVEL**](/windows-hardware/drivers/ddi/wdm/ne-wdm-_security_impersonation_level)
+[**SECURITY_IMPERSONATION_LEVEL**](../wdm/ne-wdm-_security_impersonation_level.md)
 
-[**ZwClose**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntclose)
+[**ZwClose**](./nf-ntifs-ntclose.md)
 
 [**ZwOpenProcessTokenEx**](/previous-versions/ff567024(v=vs.85))

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntprivilegecheck.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntprivilegecheck.md
@@ -68,24 +68,24 @@ dev_langs:
 
 ## -remarks
 
-An access token contains a list of the privileges held by the account associated with the token. These privileges can be enabled or disabled; most are disabled by default. **NtPrivilegeCheck** checks only for enabled privileges. To get a list of all the enabled and disabled privileges held by an access token, call [**SeQueryInformationToken**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-sequeryinformationtoken).
+An access token contains a list of the privileges held by the account associated with the token. These privileges can be enabled or disabled; most are disabled by default. **NtPrivilegeCheck** checks only for enabled privileges. To get a list of all the enabled and disabled privileges held by an access token, call [**SeQueryInformationToken**](./nf-ntifs-sequeryinformationtoken.md).
 
 For more information about security and access control, see the documentation on these topics in the Microsoft Windows SDK.
 
 ## -see-also
 
-[**LUID_AND_ATTRIBUTES**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_luid_and_attributes)
+[**LUID_AND_ATTRIBUTES**](../wdm/ns-wdm-_luid_and_attributes.md)
 
 [**PRIVILEGE_SET**](/previous-versions/windows/hardware/drivers/ff551860(v=vs.85))
 
 [**SECURITY_SUBJECT_CONTEXT**](/windows-hardware/drivers/kernel/eprocess)
 
-[**SeAccessCheck**](/windows-hardware/drivers/ddi/wdm/nf-wdm-seaccesscheck)
+[**SeAccessCheck**](../wdm/nf-wdm-seaccesscheck.md)
 
-[**SeAppendPrivileges**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-seappendprivileges)
+[**SeAppendPrivileges**](./nf-ntifs-seappendprivileges.md)
 
-[**SeFreePrivileges**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-sefreeprivileges)
+[**SeFreePrivileges**](./nf-ntifs-sefreeprivileges.md)
 
-[**SeQueryInformationToken**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-sequeryinformationtoken)
+[**SeQueryInformationToken**](./nf-ntifs-sequeryinformationtoken.md)
 
-[**SeSinglePrivilegeCheck**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-sesingleprivilegecheck)
+[**SeSinglePrivilegeCheck**](../ntddk/nf-ntddk-sesingleprivilegecheck.md)

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-seprivilegecheck.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-seprivilegecheck.md
@@ -68,24 +68,24 @@ When **SePrivilegeCheck** returns, the **Attributes** member of each LUID_AND_AT
 
 ## -remarks
 
-An access token contains a list of the privileges held by the account associated with the token. These privileges can be enabled or disabled; most are disabled by default. **SePrivilegeCheck** checks only for enabled privileges. To get a list of all the enabled and disabled privileges held by an access token, call [**SeQueryInformationToken**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-sequeryinformationtoken).
+An access token contains a list of the privileges held by the account associated with the token. These privileges can be enabled or disabled; most are disabled by default. **SePrivilegeCheck** checks only for enabled privileges. To get a list of all the enabled and disabled privileges held by an access token, call [**SeQueryInformationToken**](./nf-ntifs-sequeryinformationtoken.md).
 
 For more information about security and access control, see the documentation on these topics in the Microsoft Windows SDK.
 
 ## -see-also
 
-[**LUID_AND_ATTRIBUTES**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_luid_and_attributes)
+[**LUID_AND_ATTRIBUTES**](../wdm/ns-wdm-_luid_and_attributes.md)
 
 [**PRIVILEGE_SET**](/previous-versions/windows/hardware/drivers/ff551860(v=vs.85))
 
 [**SECURITY_SUBJECT_CONTEXT**](/windows-hardware/drivers/kernel/eprocess)
 
-[**SeAccessCheck**](/windows-hardware/drivers/ddi/wdm/nf-wdm-seaccesscheck)
+[**SeAccessCheck**](../wdm/nf-wdm-seaccesscheck.md)
 
-[**SeAppendPrivileges**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-seappendprivileges)
+[**SeAppendPrivileges**](./nf-ntifs-seappendprivileges.md)
 
-[**SeFreePrivileges**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-sefreeprivileges)
+[**SeFreePrivileges**](./nf-ntifs-sefreeprivileges.md)
 
-[**SeQueryInformationToken**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-sequeryinformationtoken)
+[**SeQueryInformationToken**](./nf-ntifs-sequeryinformationtoken.md)
 
-[**SeSinglePrivilegeCheck**](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-sesingleprivilegecheck)
+[**SeSinglePrivilegeCheck**](../ntddk/nf-ntddk-sesingleprivilegecheck.md)

--- a/wdk-ddi-src/content/ntifs/ni-ntifs-fsctl_mark_handle.md
+++ b/wdk-ddi-src/content/ntifs/ni-ntifs-fsctl_mark_handle.md
@@ -42,7 +42,7 @@ The **FSCTL_MARK_HANDLE** control code marks a specified file or directory and i
 
 ## -remarks
 
-To perform this operation, call [**FltFsControlFile**](/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltfscontrolfile) or [**ZwFsControlFile**](/previous-versions/ff566462(v=vs.85)) with the following parameters.
+To perform this operation, call [**FltFsControlFile**](../fltkernel/nf-fltkernel-fltfscontrolfile.md) or [**ZwFsControlFile**](/previous-versions/ff566462(v=vs.85)) with the following parameters.
 
 | Parameter | Description |
 | --------- | ----------- |
@@ -57,6 +57,6 @@ To perform this operation, call [**FltFsControlFile**](/windows-hardware/drivers
 
 ## -see-also
 
-[**FltFsControlFile**](/windows-hardware/drivers/ddi/fltkernel/nf-fltkernel-fltfscontrolfile)
+[**FltFsControlFile**](../fltkernel/nf-fltkernel-fltfscontrolfile.md)
 
 [**ZwFsControlFile**](/previous-versions/ff566462(v=vs.85))

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-disabledriver.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-disabledriver.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintOemEngine](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemengine)
+[IPrintOemEngine](./nn-prcomoem-iprintoemengine.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-disablepdev.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-disablepdev.md
@@ -55,4 +55,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintOemEngine](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemengine)
+[IPrintOemEngine](./nn-prcomoem-iprintoemengine.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-enabledriver.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-enabledriver.md
@@ -59,4 +59,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintOemEngine](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemengine)
+[IPrintOemEngine](./nn-prcomoem-iprintoemengine.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-enablepdev.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-enablepdev.md
@@ -73,4 +73,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintOemEngine](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemengine)
+[IPrintOemEngine](./nn-prcomoem-iprintoemengine.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-resetpdev.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemengine-resetpdev.md
@@ -57,4 +57,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintOemEngine](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemengine)
+[IPrintOemEngine](./nn-prcomoem-iprintoemengine.md)

--- a/wdk-ddi-src/content/prcomoem/nn-prcomoem-iprintcorehelperuni2.md
+++ b/wdk-ddi-src/content/prcomoem/nn-prcomoem-iprintcorehelperuni2.md
@@ -43,7 +43,7 @@ api_name:
 
 ## -description
 
-The IPrintCoreHelperUni2 interface derives from the [IPrintCoreHelperUni](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperuni) interface and adds a method.
+The IPrintCoreHelperUni2 interface derives from the [IPrintCoreHelperUni](./nn-prcomoem-iprintcorehelperuni.md) interface and adds a method.
 
 ## -inheritance
 

--- a/wdk-ddi-src/content/prcomoem/nn-prcomoem-iprintoemps2.md
+++ b/wdk-ddi-src/content/prcomoem/nn-prcomoem-iprintoemps2.md
@@ -43,7 +43,7 @@ api_name:
 
 ## -description
 
-This section describes the methods defined for the **IPrintOemPS2** COM interface. In addition to these methods, this interface includes all of the methods defined in the [IPrintOemPS](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemps) COM interface.
+This section describes the methods defined for the **IPrintOemPS2** COM interface. In addition to these methods, this interface includes all of the methods defined in the [IPrintOemPS](./nn-prcomoem-iprintoemps.md) COM interface.
 
 ## -inheritance
 

--- a/wdk-ddi-src/content/prcomoem/nn-prcomoem-iprintoemuni2.md
+++ b/wdk-ddi-src/content/prcomoem/nn-prcomoem-iprintoemuni2.md
@@ -45,7 +45,7 @@ api_name:
 
 This section describes the methods defined for the **IPrintOemUni2** COM interface.
 
-In addition to the methods that belong to the IPrintOemUni2 COM interface, this interface includes all of the methods that belong to the [IPrintOemUni](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemuni) COM interface.
+In addition to the methods that belong to the IPrintOemUni2 COM interface, this interface includes all of the methods that belong to the [IPrintOemUni](./nn-prcomoem-iprintoemuni.md) COM interface.
 
 ## -inheritance
 

--- a/wdk-ddi-src/content/prcomoem/nn-prcomoem-iprintoemuni3.md
+++ b/wdk-ddi-src/content/prcomoem/nn-prcomoem-iprintoemuni3.md
@@ -45,11 +45,10 @@ api_name:
 
 This section describes the methods defined for the **IPrintOemUni3** COM interface.
 
-The **IPrintOemUni3** COM interface includes its own methods as well as those that belong to [IPrintOemUni](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemuni) COM interface and the [IPrintOemUni2](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemuni2) COM interface.
+The **IPrintOemUni3** COM interface includes its own methods as well as those that belong to [IPrintOemUni](./nn-prcomoem-iprintoemuni.md) COM interface and the [IPrintOemUni2](./nn-prcomoem-iprintoemuni2.md) COM interface.
 
 The **IPrintOemUni3** COM interface is available in Windows Vista and later.
 
 ## -inheritance
 
 The **IPrintOemUni3** interface inherits from the [IUnknown](/windows/win32/api/unknwn/nn-unknwn-iunknown) interface.
-

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag2-getreadstreamasxml.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag2-getreadstreamasxml.md
@@ -61,4 +61,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag2](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag2)
+[IPrinterScriptablePropertyBag2](./nn-printerextension-iprinterscriptablepropertybag2.md)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterbidisetrequestcallback.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterbidisetrequestcallback.md
@@ -51,7 +51,7 @@ The **IPrinterBidiSetRequestCallback** interface inherits from the [IUnknown](/w
 
 ## -remarks
 
-**IPrinterBidiSetRequestCallback** provides the Bidi response string, and **HRESULT** value returned from the [IBidiSpl2::SendRecvXmlString](/windows-hardware/drivers/ddi/bidispl/nf-bidispl-ibidispl2-sendrecvxmlstring) method. In other words,  this interface provides the results of the attempt to send data to the device. 
+**IPrinterBidiSetRequestCallback** provides the Bidi response string, and **HRESULT** value returned from the [IBidiSpl2::SendRecvXmlString](../bidispl/nf-bidispl-ibidispl2-sendrecvxmlstring.md) method. In other words,  this interface provides the results of the attempt to send data to the device. 
 
 **IPrinterBidiSetRequestCallback**  helps to make it possible to perform device maintenance from a UWP  device app or from a printer extension. For more information, see [Device Maintenance](/windows-hardware/drivers/print/device-maintenance).
 
@@ -59,6 +59,6 @@ The **IPrinterBidiSetRequestCallback** interface inherits from the [IUnknown](/w
 
 [Device Maintenance](/windows-hardware/drivers/print/device-maintenance)
 
-[IBidiSpl2::SendRecvXmlString](/windows-hardware/drivers/ddi/bidispl/nf-bidispl-ibidispl2-sendrecvxmlstring)
+[IBidiSpl2::SendRecvXmlString](../bidispl/nf-bidispl-ibidispl2-sendrecvxmlstring.md)
 
-[SendBidiSetRequestAsync](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueue2-sendbidisetrequestasync)
+[SendBidiSetRequestAsync](./nf-printerextension-iprinterqueue2-sendbidisetrequestasync.md)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterextensioncontext.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterextensioncontext.md
@@ -47,12 +47,12 @@ Represents the context for the activation of a UWP device app for printers.
 
 ## -see-also
 
-[IPrinterExtensionContextCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontextcollection)
+[IPrinterExtensionContextCollection](./nn-printerextension-iprinterextensioncontextcollection.md)
 
-[IPrinterExtensionContextCollection::Count](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensioncontextcollection-get_count)
+[IPrinterExtensionContextCollection::Count](./nf-printerextension-iprinterextensioncontextcollection-get_count.md)
 
-[IPrinterExtensionContextCollection::GetAt](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensioncontextcollection-getat)
+[IPrinterExtensionContextCollection::GetAt](./nf-printerextension-iprinterextensioncontextcollection-getat.md)
 
-[IPrinterExtensionEvent::OnPrinterQueuesEnumerated](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensionevent-onprinterqueuesenumerated)
+[IPrinterExtensionEvent::OnPrinterQueuesEnumerated](./nf-printerextension-iprinterextensionevent-onprinterqueuesenumerated.md)
 
 [V4 Printer Driver Property Bags](/windows-hardware/drivers/print/v4-driver-property-bags)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterextensioneventargs.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterextensioneventargs.md
@@ -47,6 +47,6 @@ Represents the context for the desktop printer extension activation.
 
 ## -see-also
 
-[IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext)
+[IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md)
 
 [V4 Printer Driver Property Bags](/windows-hardware/drivers/print/v4-driver-property-bags)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterextensionmanager.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterextensionmanager.md
@@ -51,7 +51,7 @@ The **IPrinterExtensionManager** interface inherits from the [IUnknown](/windows
 
 ## -remarks
 
-Any event sink that implements [IPrinterExtensionEvent](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionevent) is connected to the associated event source, **IPrinterExtensionManager**, via the **IConnectionPoint** mechanism. You must retrieve a pointer to the **IConnectionPoint** interface by invoking **QueryInterface** on the **IPrinterExtensionManager** object.
+Any event sink that implements [IPrinterExtensionEvent](./nn-printerextension-iprinterextensionevent.md) is connected to the associated event source, **IPrinterExtensionManager**, via the **IConnectionPoint** mechanism. You must retrieve a pointer to the **IConnectionPoint** interface by invoking **QueryInterface** on the **IPrinterExtensionManager** object.
 
 It is mandatory to implement **IDispatch::Invoke** on the event sink that implements **IPrinterExtensionEvent**, since that is the mechanism via which events are raised.
 

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterqueue2.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterqueue2.md
@@ -45,11 +45,11 @@ api_name:
 
 Represents a single printer queue.
 
-This interface extends [IPrinterQueue](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue) and allows a user to manage print jobs and device maintenance from within a UWP  device app for printers, or from a printer extension.
+This interface extends [IPrinterQueue](./nn-printerextension-iprinterqueue.md) and allows a user to manage print jobs and device maintenance from within a UWP  device app for printers, or from a printer extension.
 
 ## -inheritance
 
-The **IPrinterQueue2** interface inherits from [IPrinterQueue](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue).
+The **IPrinterQueue2** interface inherits from [IPrinterQueue](./nn-printerextension-iprinterqueue.md).
 
 ## -remarks
 
@@ -59,6 +59,6 @@ The **IPrinterQueue2** interface inherits from [IPrinterQueue](/windows-hardware
 
 [Device Maintenance](/windows-hardware/drivers/print/device-maintenance)
 
-[IPrinterQueue](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue)
+[IPrinterQueue](./nn-printerextension-iprinterqueue.md)
 
 [Job Management](/windows-hardware/drivers/print/job-management)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterscriptablepropertybag.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterscriptablepropertybag.md
@@ -45,7 +45,7 @@ api_name:
 
 The IPrinterScriptablePropertyBag interface is the property bag interface passed to script clients.
 
-This interface is the same as [IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag), except that the GetBytes and SetBytes methods operate on JavaScript arrays and the GetReadStream and GetWriteStream methods operate on [IPrinterScriptableStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablestream) objects.
+This interface is the same as [IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md), except that the GetBytes and SetBytes methods operate on JavaScript arrays and the GetReadStream and GetWriteStream methods operate on [IPrinterScriptableStream](./nn-printerextension-iprinterscriptablestream.md) objects.
 
 ## -inheritance
 
@@ -53,14 +53,14 @@ The **IPrinterScriptablePropertyBag** interface inherits from the [IUnknown](/wi
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)
 
-[IPrinterScriptContext::DriverProperties](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterscriptcontext-get_driverproperties)
+[IPrinterScriptContext::DriverProperties](./nf-printerextension-iprinterscriptcontext-get_driverproperties.md)
 
-[IPrinterScriptContext::QueueProperties](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterscriptcontext-get_queueproperties)
+[IPrinterScriptContext::QueueProperties](./nf-printerextension-iprinterscriptcontext-get_queueproperties.md)
 
-[IPrinterScriptContext::UserProperties](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterscriptcontext-get_userproperties)
+[IPrinterScriptContext::UserProperties](./nf-printerextension-iprinterscriptcontext-get_userproperties.md)
 
-[IPrinterScriptableStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablestream)
+[IPrinterScriptableStream](./nn-printerextension-iprinterscriptablestream.md)
 
 [V4 Printer Driver Property Bags](/windows-hardware/drivers/print/v4-driver-property-bags)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterscriptablestream.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprinterscriptablestream.md
@@ -43,18 +43,18 @@ api_name:
 
 ## -description
 
-The **IPrinterScriptableStream** interface builds on [IPrinterScriptableSequentialStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablesequentialstream) and adds IStream-like semantics.
+The **IPrinterScriptableStream** interface builds on [IPrinterScriptableSequentialStream](./nn-printerextension-iprinterscriptablesequentialstream.md) and adds IStream-like semantics.
 
 ## -inheritance
 
-The **IPrinterScriptableStream** interface inherits from [IPrinterScriptableSequentialStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablesequentialstream).
+The **IPrinterScriptableStream** interface inherits from [IPrinterScriptableSequentialStream](./nn-printerextension-iprinterscriptablesequentialstream.md).
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)
 
-[IPrinterScriptablePropertyBag::GetReadStream](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterscriptablepropertybag-getreadstream)
+[IPrinterScriptablePropertyBag::GetReadStream](./nf-printerextension-iprinterscriptablepropertybag-getreadstream.md)
 
-[IPrinterScriptablePropertyBag::GetWriteStream](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterscriptablepropertybag-getwritestream)
+[IPrinterScriptablePropertyBag::GetWriteStream](./nf-printerextension-iprinterscriptablepropertybag-getwritestream.md)
 
-[IPrinterScriptableSequentialStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablesequentialstream)
+[IPrinterScriptableSequentialStream](./nn-printerextension-iprinterscriptablesequentialstream.md)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemacapabilities.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemacapabilities.md
@@ -47,11 +47,11 @@ Provides the primary method to access PrintCapabilities.
 
 ## -inheritance
 
-The **IPrintSchemaCapabilities** interface inherits from [IPrintSchemaElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaelement).
+The **IPrintSchemaCapabilities** interface inherits from [IPrintSchemaElement](./nn-printerextension-iprintschemaelement.md).
 
 ## -remarks
 
-To obtain an **IXMLDOMDocument2** object for the PrintCapabilities object, you must first dereference the *ppXmlNode* parameter of the [XmlNode](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaelement-get_xmlnode) property (using *ppXmlNode ). This retrieves a pointer to an interface of type **IUnknown**. 
+To obtain an **IXMLDOMDocument2** object for the PrintCapabilities object, you must first dereference the *ppXmlNode* parameter of the [XmlNode](./nf-printerextension-iprintschemaelement-get_xmlnode.md) property (using *ppXmlNode ). This retrieves a pointer to an interface of type **IUnknown**. 
 
 Use this pointer to  call the **QueryInterface** method of the PrintCapabilities object to access the underlying **IXMLDOMDocument2** object.
 
@@ -59,12 +59,12 @@ Use this pointer to  call the **QueryInterface** method of the PrintCapabilities
 
 [Developing v4 print drivers](/windows-hardware/drivers/print/v4-printer-driver)
 
-[IPrintSchemaElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaelement)
+[IPrintSchemaElement](./nn-printerextension-iprintschemaelement.md)
 
-[IPrintSchemaElement::XmlNode](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaelement-get_xmlnode)
+[IPrintSchemaElement::XmlNode](./nf-printerextension-iprintschemaelement-get_xmlnode.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)
 
-[IPrintSchemaTicket_GetCapabilities](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschematicket-getcapabilities)
+[IPrintSchemaTicket_GetCapabilities](./nf-printerextension-iprintschematicket-getcapabilities.md)
 
 [V4 Printer Driver Localization](/windows-hardware/drivers/print/v4-driver-localization)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemacapabilities2.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemacapabilities2.md
@@ -43,12 +43,12 @@ api_name:
 
 ## -description
 
-The **IPrintSchemaCapabilities2** interface represents an extension to the [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities) object, which provides wrapper methods over a print capabilities document.
+The **IPrintSchemaCapabilities2** interface represents an extension to the [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md) object, which provides wrapper methods over a print capabilities document.
 
 ## -inheritance
 
-The **IPrintSchemaCapabilities2** interface inherits from [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities).
+The **IPrintSchemaCapabilities2** interface inherits from [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md).
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemadisplayableelement.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemadisplayableelement.md
@@ -47,6 +47,6 @@ Provides the displayable string for a PrintCapabilites PrintSchema element.
 
 ## -see-also
 
-[IPrintSchemaElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaelement)
+[IPrintSchemaElement](./nn-printerextension-iprintschemaelement.md)
 
-[IPrintSchemaParameterDefinition](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaparameterdefinition)
+[IPrintSchemaParameterDefinition](./nn-printerextension-iprintschemaparameterdefinition.md)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemafeature.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemafeature.md
@@ -47,18 +47,18 @@ Exposes a Print Schema Feature element.
 
 ## -inheritance
 
-The **IPrintSchemaFeature** interface inherits from [IPrintSchemaDisplayableElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemadisplayableelement).
+The **IPrintSchemaFeature** interface inherits from [IPrintSchemaDisplayableElement](./nn-printerextension-iprintschemadisplayableelement.md).
 
 ## -remarks
 
-You must ensure that each Feature or Option in a PrintTicket or PrintCapabilities XML document has a *name* attribute specified. This attribute is used to build the [IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption) and **IPrintSchemaFeature** objects. If the *name* attribute is omitted, the feature or option will not be displayed in the object model, or the Microsoft-provided print preferences experience.
+You must ensure that each Feature or Option in a PrintTicket or PrintCapabilities XML document has a *name* attribute specified. This attribute is used to build the [IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md) and **IPrintSchemaFeature** objects. If the *name* attribute is omitted, the feature or option will not be displayed in the object model, or the Microsoft-provided print preferences experience.
 
 ## -see-also
 
-[IPrintSchemaCapabilities::GetFeature](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeature)
+[IPrintSchemaCapabilities::GetFeature](./nf-printerextension-iprintschemacapabilities-getfeature.md)
 
-[IPrintSchemaDisplayableElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemadisplayableelement)
+[IPrintSchemaDisplayableElement](./nn-printerextension-iprintschemadisplayableelement.md)
 
-[IPrintSchemaTicket::GetFeature](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschematicket-getfeature)
+[IPrintSchemaTicket::GetFeature](./nf-printerextension-iprintschematicket-getfeature.md)
 
-[IPrintSchemaTicket::GetFeatureByKeyName](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschematicket-getfeaturebykeyname)
+[IPrintSchemaTicket::GetFeatureByKeyName](./nf-printerextension-iprintschematicket-getfeaturebykeyname.md)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemaoption.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemaoption.md
@@ -47,20 +47,20 @@ Exposes a Print Schema Option object.
 
 ## -inheritance
 
-The **IPrintSchemaOption** interface inherits from [IPrintSchemaDisplayableElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemadisplayableelement).
+The **IPrintSchemaOption** interface inherits from [IPrintSchemaDisplayableElement](./nn-printerextension-iprintschemadisplayableelement.md).
 
 ## -remarks
 
-You must ensure that each Feature or Option in a PrintTicket or PrintCapabilities XML document has a *name* attribute specified. This attribute is used to build the **IPrintSchemaOption** and [IPrintSchemaFeature](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemafeature) objects. If the *name* attribute is omitted, the feature or option will not be displayed in the object model, or the Microsoft-provided print preferences experience.
+You must ensure that each Feature or Option in a PrintTicket or PrintCapabilities XML document has a *name* attribute specified. This attribute is used to build the **IPrintSchemaOption** and [IPrintSchemaFeature](./nn-printerextension-iprintschemafeature.md) objects. If the *name* attribute is omitted, the feature or option will not be displayed in the object model, or the Microsoft-provided print preferences experience.
 
 ## -see-also
 
-[IPrintSchemaDisplayableElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemadisplayableelement)
+[IPrintSchemaDisplayableElement](./nn-printerextension-iprintschemadisplayableelement.md)
 
-[IPrintSchemaFeature::GetOption](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemafeature-getoption)
+[IPrintSchemaFeature::GetOption](./nf-printerextension-iprintschemafeature-getoption.md)
 
-[IPrintSchemaFeature::SelectedOption](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemafeature-get_selectedoption)
+[IPrintSchemaFeature::SelectedOption](./nf-printerextension-iprintschemafeature-get_selectedoption.md)
 
-[IPrintSchemaOptionCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoptioncollection)
+[IPrintSchemaOptionCollection](./nn-printerextension-iprintschemaoptioncollection.md)
 
-[IPrintSchemaPageMediaSizeOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapagemediasizeoption)
+[IPrintSchemaPageMediaSizeOption](./nn-printerextension-iprintschemapagemediasizeoption.md)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemapagemediasizeoption.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschemapagemediasizeoption.md
@@ -47,4 +47,4 @@ Exposes a Print Schema PageMediaSize Option element.
 
 ## -see-also
 
-[IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)
+[IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)

--- a/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschematicket.md
+++ b/wdk-ddi-src/content/printerextension/nn-printerextension-iprintschematicket.md
@@ -48,11 +48,11 @@ Provides the primary method to access and validate a PrintTicket.
 
 ## -inheritance
 
-The **IPrintSchemaTicket** interface inherits from [IPrintSchemaElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaelement).
+The **IPrintSchemaTicket** interface inherits from [IPrintSchemaElement](./nn-printerextension-iprintschemaelement.md).
 
 ## -remarks
 
-For C++ clients, to obtain an **IXMLDOMDocument2** object for the PrintTicket object, you must first dereference the *ppXmlNode* parameter of the [XmlNode](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaelement-get_xmlnode) property (using *ppXmlNode ). This retrieves a pointer to an interface of type **IUnknown**. Use this pointer to  call the **QueryInterface** method of the PrintTicket object to access the underlying IXMLDOMDocument2 object.
+For C++ clients, to obtain an **IXMLDOMDocument2** object for the PrintTicket object, you must first dereference the *ppXmlNode* parameter of the [XmlNode](./nf-printerextension-iprintschemaelement-get_xmlnode.md) property (using *ppXmlNode ). This retrieves a pointer to an interface of type **IUnknown**. Use this pointer to  call the **QueryInterface** method of the PrintTicket object to access the underlying IXMLDOMDocument2 object.
 
 For C# and JavaScript clients, use printerextension.h GetReadStream or GetWriteStream methods to access a IPrintSchemaElement XmlNode.
 

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-asyncclosechannel.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-asyncclosechannel.md
@@ -65,4 +65,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IBidiAsyncNotifyChannel](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-ibidiasyncnotifychannel)
+[IBidiAsyncNotifyChannel](./nn-prnasntp-ibidiasyncnotifychannel.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-asyncgetnotificationsendresponse.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-asyncgetnotificationsendresponse.md
@@ -65,4 +65,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IBidiAsyncNotifyChannel](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-ibidiasyncnotifychannel)
+[IBidiAsyncNotifyChannel](./nn-prnasntp-ibidiasyncnotifychannel.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-closechannel.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-closechannel.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IBidiAsyncNotifyChannel](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-ibidiasyncnotifychannel)
+[IBidiAsyncNotifyChannel](./nn-prnasntp-ibidiasyncnotifychannel.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-createnotificationchannel.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-createnotificationchannel.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IBidiAsyncNotifyChannel](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-ibidiasyncnotifychannel)
+[IBidiAsyncNotifyChannel](./nn-prnasntp-ibidiasyncnotifychannel.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-getchannelnotificationtype.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-getchannelnotificationtype.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IBidiAsyncNotifyChannel](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-ibidiasyncnotifychannel)
+[IBidiAsyncNotifyChannel](./nn-prnasntp-ibidiasyncnotifychannel.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-getprintname.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-getprintname.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IBidiAsyncNotifyChannel](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-ibidiasyncnotifychannel)
+[IBidiAsyncNotifyChannel](./nn-prnasntp-ibidiasyncnotifychannel.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-sendnotification.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-ibidiasyncnotifychannel-sendnotification.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IBidiAsyncNotifyChannel](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-ibidiasyncnotifychannel)
+[IBidiAsyncNotifyChannel](./nn-prnasntp-ibidiasyncnotifychannel.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasynccookie-cancelasynccall.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasynccookie-cancelasynccall.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncCookie](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasynccookie)
+[IPrintAsyncCookie](./nn-prnasntp-iprintasynccookie.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasynccookie-finishasynccall.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasynccookie-finishasynccall.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncCookie](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasynccookie)
+[IPrintAsyncCookie](./nn-prnasntp-iprintasynccookie.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnewchannelcookie-finishasynccallwithdata.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnewchannelcookie-finishasynccallwithdata.md
@@ -63,4 +63,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncNewChannelCookie](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasyncnewchannelcookie)
+[IPrintAsyncNewChannelCookie](./nn-prnasntp-iprintasyncnewchannelcookie.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotify-createprintasyncnotifychannel.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotify-createprintasyncnotifychannel.md
@@ -79,4 +79,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncNotify](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasyncnotify)
+[IPrintAsyncNotify](./nn-prnasntp-iprintasyncnotify.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotify-createprintasyncnotifyregistration.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotify-createprintasyncnotifyregistration.md
@@ -65,4 +65,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncNotify](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasyncnotify)
+[IPrintAsyncNotify](./nn-prnasntp-iprintasyncnotify.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyregistration-registerfornotifications.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyregistration-registerfornotifications.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncNotifyRegistration](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasyncnotifyregistration)
+[IPrintAsyncNotifyRegistration](./nn-prnasntp-iprintasyncnotifyregistration.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyregistration-unregisterfornotifications.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyregistration-unregisterfornotifications.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncNotifyRegistration](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasyncnotifyregistration)
+[IPrintAsyncNotifyRegistration](./nn-prnasntp-iprintasyncnotifyregistration.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyserverreferral-asyncgetserverreferral.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyserverreferral-asyncgetserverreferral.md
@@ -57,4 +57,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncNotifyServerReferral](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasyncnotifyserverreferral)
+[IPrintAsyncNotifyServerReferral](./nn-prnasntp-iprintasyncnotifyserverreferral.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyserverreferral-getserverreferral.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyserverreferral-getserverreferral.md
@@ -53,4 +53,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncNotifyServerReferral](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasyncnotifyserverreferral)
+[IPrintAsyncNotifyServerReferral](./nn-prnasntp-iprintasyncnotifyserverreferral.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyserverreferral-setserverreferral.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintasyncnotifyserverreferral-setserverreferral.md
@@ -57,4 +57,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintAsyncNotifyServerReferral](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintasyncnotifyserverreferral)
+[IPrintAsyncNotifyServerReferral](./nn-prnasntp-iprintasyncnotifyserverreferral.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintbidiasyncnotifyregistration-asyncgetnewchannel.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintbidiasyncnotifyregistration-asyncgetnewchannel.md
@@ -57,4 +57,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintBidiAsyncNotifyRegistration](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintbidiasyncnotifyregistration)
+[IPrintBidiAsyncNotifyRegistration](./nn-prnasntp-iprintbidiasyncnotifyregistration.md)

--- a/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintunidiasyncnotifyregistration-asyncgetnotification.md
+++ b/wdk-ddi-src/content/prnasntp/nf-prnasntp-iprintunidiasyncnotifyregistration-asyncgetnotification.md
@@ -57,4 +57,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IPrintUnidiAsyncNotifyRegistration](/windows-hardware/drivers/ddi/prnasntp/nn-prnasntp-iprintunidiasyncnotifyregistration)
+[IPrintUnidiAsyncNotifyRegistration](./nn-prnasntp-iprintunidiasyncnotifyregistration.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to cleanup links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```