### PR TITLE
Update nf-wdm-kequerynodeactiveaffinity2.md

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-kequerynodeactiveaffinity2.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-kequerynodeactiveaffinity2.md
@@ -83,7 +83,7 @@ Starting in Windows Server 2022, the operating system no longer splits large NUM
 
 > [!NOTE]
 > To re-enable the legacy node splitting behavior, make the following change to the registry and reboot the system:
-> `reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\NUMA" /v SplitLargeNumaNodes /t REG_DWORD /v 1`
+> `reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\NUMA" /v SplitLargeNodes /t REG_DWORD /d 1`
 
 
 If your driver maps processors to NUMA nodes by calling [**KeQueryNodeActiveAffinity**](./nf-wdm-kequerynodeactiveaffinity.md), and your code runs on systems with more than 64 processors per NUMA node, use one of the following workarounds:


### PR DESCRIPTION
Updating  `reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\NUMA" /v SplitLargeNumaNodes /t REG_DWORD /v 1 ` to `reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\NUMA" /v SplitLargeNodes /t REG_DWORD /d 1`

Our partner reported this issue:

- `reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\NUMA" /v SplitLargeNumaNodes /t REG_DWORD /v 1` will tell us the **error** with reg add command. It should be “/d 1” to set the value of newly added registry key to 1.
- `reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\NUMA" /v SplitLargeNumaNodes /t REG_DWORD /d 1` **will not work** with node splitting. 

The correct command should be `reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\NUMA" /v SplitLargeNodes /t REG_DWORD /d 1`