### PR TITLE
Linkfix: MmGetSystemAddressForMdlSafe

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-mmgetsystemaddressformdl.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmgetsystemaddressformdl.md
@@ -45,7 +45,7 @@ api_name:
 
 ## -description
 
-The <b>MmGetSystemAddressForMdl</b> routine is <u>obsolete</u> for Windows 2000 and later versions of Windows, and for Windows Me. It is supported only for WDM drivers that must run on Windows 98. Otherwise, use <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-mmgetsystemaddressformdlsafe.md">MmGetSystemAddressForMdlSafe</a>.
+The <b>MmGetSystemAddressForMdl</b> routine is <u>obsolete</u> for Windows 2000 and later versions of Windows, and for Windows Me. It is supported only for WDM drivers that must run on Windows 98. Otherwise, use <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-mmgetsystemaddressformdlsafe">MmGetSystemAddressForMdlSafe</a>.
 
 <b>MmGetSystemAddressForMdl</b> is a macro that returns a nonpaged system-space virtual address for the buffer described by the MDL. It maps the physical pages described by a given MDL into system space, if they are not already mapped to system space.
 
@@ -75,7 +75,7 @@ The MDL must describe nonpageable memory. In other words, the input MDL must des
 
 The returned base address has the same offset as the virtual address in the MDL.
 
-Windows 2000 issues a bug check if the attempt to map to system space fails. (Therefore, you should use <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-mmgetsystemaddressformdlsafe.md">MmGetSystemAddressForMdlSafe</a> instead). In Windows 98, this routine returns <b>NULL</b> in case of failure.
+Windows 2000 issues a bug check if the attempt to map to system space fails. (Therefore, you should use <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-mmgetsystemaddressformdlsafe">MmGetSystemAddressForMdlSafe</a> instead). In Windows 98, this routine returns <b>NULL</b> in case of failure.
 
 ## -see-also
 
@@ -83,7 +83,7 @@ Windows 2000 issues a bug check if the attempt to map to system space fails. (Th
 
 
 
-<a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-mmgetsystemaddressformdlsafe.md">MmGetSystemAddressForMdlSafe</a>
+<a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-mmgetsystemaddressformdlsafe">MmGetSystemAddressForMdlSafe</a>
 
 
 


### PR DESCRIPTION
My previous PR #1172 some links were with the `.md` extension so I fixed it again.