### PR TITLE
Add hyperlink in markdown

### DIFF
--- a/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_d3dkmdt_gamma_ramp.md
+++ b/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_d3dkmdt_gamma_ramp.md
@@ -74,7 +74,7 @@ If <b>Type</b> is equal to D3DDDI_GAMMARAMP_DXGI_1, this member is a pointer to 
 
 ### -field Data.p3x4
 
-Pointer to a D3DDDI_3x4_COLORSPACE_TRANSFORM which describes the 3 by 4 matrix color space transform to be applied.
+Pointer to a <a href="/windows-hardware/drivers/ddi/d3dukmdt/ns-d3dukmdt-_d3dkmdt_3x4_colorspace_transform">D3DDDI_3x4_COLORSPACE_TRANSFORM structure which describes the 3 by 4 matrix color space transform to be applied, a scalar multiplier, and a lookup table.
 
 ### -field Data.pRaw
 

--- a/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_d3dkmdt_gamma_ramp.md
+++ b/wdk-ddi-src/content/d3dkmdt/ns-d3dkmdt-_d3dkmdt_gamma_ramp.md
@@ -74,7 +74,7 @@ If <b>Type</b> is equal to D3DDDI_GAMMARAMP_DXGI_1, this member is a pointer to 
 
 ### -field Data.p3x4
 
-Pointer to a <a href="/windows-hardware/drivers/ddi/d3dukmdt/ns-d3dukmdt-_d3dkmdt_3x4_colorspace_transform">D3DDDI_3x4_COLORSPACE_TRANSFORM structure which describes the 3 by 4 matrix color space transform to be applied, a scalar multiplier, and a lookup table.
+Pointer to a <a href="/windows-hardware/drivers/ddi/d3dukmdt/ns-d3dukmdt-_d3dkmdt_3x4_colorspace_transform">D3DDDI_3x4_COLORSPACE_TRANSFORM</a> structure which describes the 3 by 4 matrix color space transform to be applied, a scalar multiplier, and the lookup table.
 
 ### -field Data.pRaw
 


### PR DESCRIPTION
Hyperlink to the D3DKMDT_3x4_COLORSPACE_TRANSFORM structure page. This is consistent with the descriptions of the other structures.