### PR TITLE
Links: windows-driver-docs-ddi (2021-10) - 1

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-read_register_buffer_uchar.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-read_register_buffer_uchar.md
@@ -68,9 +68,8 @@ Specifies the number of bytes to be read into the buffer.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 The size of the buffer must be large enough to contain at least the specified number of bytes.
 
 Callers of <b>READ_REGISTER_BUFFER_UCHAR</b> can be running at any IRQL, assuming the <i>Buffer</i> is resident and the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-read_register_buffer_ulong.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-read_register_buffer_ulong.md
@@ -68,9 +68,8 @@ Specifies the number of ULONG values to be read into the buffer.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 The size of the buffer must be large enough to contain at least the specified number of ULONG values.
 
 Callers of <b>READ_REGISTER_BUFFER_ULONG</b> can be running at any IRQL, assuming the <i>Buffer</i> is resident and the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-read_register_buffer_ulong64.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-read_register_buffer_ulong64.md
@@ -67,7 +67,7 @@ Specifies the number of ULONG64 values to be read into the buffer.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 The size of the *Buffer* buffer must be large enough to contain at least the specified number of ULONG64 values.
 

--- a/wdk-ddi-src/content/wdm/nf-wdm-read_register_buffer_ushort.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-read_register_buffer_ushort.md
@@ -68,9 +68,8 @@ Specifies the number of USHORT values to be read into the buffer.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 The size of the buffer must be large enough to contain at least the specified number of USHORT values.
 
 Callers of <b>READ_REGISTER_BUFFER_USHORT</b> can be running at any IRQL, assuming the <i>Buffer</i> is resident and the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-read_register_uchar.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-read_register_uchar.md
@@ -61,7 +61,6 @@ Pointer to the register address, which must be a mapped range in memory space.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 Callers of <b>READ_REGISTER_UCHAR</b> can be running at any IRQL, assuming the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-read_register_ulong.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-read_register_ulong.md
@@ -61,7 +61,6 @@ Pointer to the register address, which must be a mapped range in memory space.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 Callers of <b>READ_REGISTER_ULONG</b> can be running at any IRQL, assuming the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-read_register_ulong64.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-read_register_ulong64.md
@@ -61,6 +61,6 @@ Pointer to the register address, which must be a mapped range in memory space.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
-Callers of the **READ_REGISTER_ULONG64** macro can be running at any IRQL, assuming the *Register* address is resident, mapped device memory. 
+Callers of the **READ_REGISTER_ULONG64** macro can be running at any IRQL, assuming the *Register* address is resident, mapped device memory.

--- a/wdk-ddi-src/content/wdm/nf-wdm-read_register_ushort.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-read_register_ushort.md
@@ -61,7 +61,6 @@ Pointer to the register address, which must be a mapped range in memory space.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 Callers of <b>READ_REGISTER_USHORT</b> can be running at any IRQL, assuming the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-write_register_buffer_uchar.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-write_register_buffer_uchar.md
@@ -68,9 +68,8 @@ Specifies the number of bytes to be written to the register.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 The size of the buffer must be large enough to contain at least the specified number of bytes.
 
 Callers of <b>WRITE_REGISTER_BUFFER_UCHAR</b> can be running at any IRQL, assuming the <i>Buffer</i> is resident and the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-write_register_buffer_ulong.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-write_register_buffer_ulong.md
@@ -68,9 +68,8 @@ Specifies the number of ULONG values to be written to the register.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 The size of the buffer must be large enough to contain at least the specified number of ULONG values.
 
 Callers of <b>WRITE_REGISTER_BUFFER_ULONG</b> can be running at any IRQL, assuming the <i>Buffer</i> is resident and the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-write_register_buffer_ulong64.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-write_register_buffer_ulong64.md
@@ -69,7 +69,7 @@ Specifies the number of ULONG64 values to write to the register.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 The size of the buffer must be large enough to contain at least the specified number of bytes.
 

--- a/wdk-ddi-src/content/wdm/nf-wdm-write_register_buffer_ushort.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-write_register_buffer_ushort.md
@@ -68,9 +68,8 @@ Specifies the number of USHORT values to be written to the register.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 The size of the buffer must be large enough to contain at least the specified number of USHORT values.
 
 Callers of <b>WRITE_REGISTER_BUFFER_USHORT</b> can be running at any IRQL, assuming the <i>Buffer</i> is resident and the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-write_register_uchar.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-write_register_uchar.md
@@ -62,7 +62,6 @@ Specifies a byte to be written to the register.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 Callers of <b>WRITE_REGISTER_UCHAR</b> can be running at any IRQL, assuming the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-write_register_ulong.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-write_register_ulong.md
@@ -62,7 +62,6 @@ Specifies a ULONG value to be written to the register.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 Callers of <b>WRITE_REGISTER_ULONG</b> can be running at any IRQL, assuming the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/nf-wdm-write_register_ulong64.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-write_register_ulong64.md
@@ -62,7 +62,6 @@ Specifies a ULONG64 value to write to the register.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
-Callers of the **WRITE_REGISTER_ULONG64** macro can be running at any IRQL, assuming the *Register* register is resident, mapped device memory. 
-
+Callers of the **WRITE_REGISTER_ULONG64** macro can be running at any IRQL, assuming the *Register* register is resident, mapped device memory.

--- a/wdk-ddi-src/content/wdm/nf-wdm-write_register_ushort.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-write_register_ushort.md
@@ -62,7 +62,6 @@ Specifies a USHORT value to be written to the register.
 
 This routine inserts a memory barrier into your code. This barrier guarantees that every operation that appears in the source code before the call to this routine will complete before any operation that appears after the call.
 
-For more info about memory barriers, see [**KeMemoryBarrier**](/windows-hardware/drivers/ddi/wdm/nf-wdm-kememorybarrier).
+For more info about memory barriers, see [**KeMemoryBarrier**](./nf-wdm-kememorybarrier.md).
 
 Callers of <b>WRITE_REGISTER_USHORT</b> can be running at any IRQL, assuming the <i>Register</i> is resident, mapped device memory.
-

--- a/wdk-ddi-src/content/wdm/ns-wdm-_io_stack_location.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-_io_stack_location.md
@@ -700,7 +700,7 @@ For each IRP, there is one <b>IO_STACK_LOCATION</b> structure for each driver in
 
 Every higher-level driver is responsible for setting up the I/O stack location for the next-lower driver in each IRP. A driver must call <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetcurrentirpstacklocation">IoGetCurrentIrpStackLocation</a> to get a pointer to its own stack location for each IRP. Higher-level drivers can call <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetnextirpstacklocation">IoGetNextIrpStackLocation</a> to get a pointer to the next-lower driver's stack location.
 
-The higher-level driver must set up the stack location contents before calling <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-iocalldriver">IoCallDriver</a> to pass an IRP to the lower-level driver. If the driver will pass the input IRP on to the next lower-level driver, the dispatch routine should call [IoSkipCurrentIrpStackLocation](/windows-hardware/drivers/ddi/wdm/nf-wdm-ioskipcurrentirpstacklocation) or <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-iocopycurrentirpstacklocationtonext">IoCopyCurrentIrpStackLocationToNext</a> to set up the I/O stack location of the next-lower driver.
+The higher-level driver must set up the stack location contents before calling <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-iocalldriver">IoCallDriver</a> to pass an IRP to the lower-level driver. If the driver will pass the input IRP on to the next lower-level driver, the dispatch routine should call [IoSkipCurrentIrpStackLocation](./nf-wdm-ioskipcurrentirpstacklocation.md) or <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-iocopycurrentirpstacklocationtonext">IoCopyCurrentIrpStackLocationToNext</a> to set up the I/O stack location of the next-lower driver.
 
 A higher-level driver's call to <b>IoCallDriver</b> sets the <b>DeviceObject</b> member to the next-lower-level driver's target device object, in the I/O stack location of the lower driver. The I/O manager passes each higher-level driver's <a href="/windows-hardware/drivers/ddi/wdm/nc-wdm-io_completion_routine">IoCompletion</a> routine a pointer to its own device object when the <i>IoCompletion</i> routine is called on completion of the IRP.
 
@@ -742,4 +742,4 @@ In some cases, a higher-level driver layered over a mass-storage device driver i
 
 
 
-[IoSkipCurrentIrpStackLocation](/windows-hardware/drivers/ddi/wdm/nf-wdm-ioskipcurrentirpstacklocation)
+[IoSkipCurrentIrpStackLocation](./nf-wdm-ioskipcurrentirpstacklocation.md)

--- a/wdk-ddi-src/content/wdm/ns-wdm-_pci_express_aer_capability.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-_pci_express_aer_capability.md
@@ -57,31 +57,31 @@ The PCI_EXPRESS_AER_CAPABILITY structure describes a PCI Express (PCIe) advanced
 
 ### -field Header
 
-A [PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_enhanced_capability_header) structure that describes the header for this structure.
+A [PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](./ns-wdm-_pci_express_enhanced_capability_header.md) structure that describes the header for this structure.
 
 ### -field UncorrectableErrorStatus
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_status) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_uncorrectable_error_status.md) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
 
 ### -field UncorrectableErrorMask
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_mask) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_uncorrectable_error_mask.md) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
 
 ### -field UncorrectableErrorSeverity
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_severity) structure that describes the PCIe uncorrectable error severity register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](./ns-wdm-_pci_express_uncorrectable_error_severity.md) structure that describes the PCIe uncorrectable error severity register of the PCIe AER capability structure.
 
 ### -field CorrectableErrorStatus
 
-A [PCI_EXPRESS_CORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_correctable_error_status) structure that describes the PCIe correctable error status register of the PCIe AER capability structure.
+A [PCI_EXPRESS_CORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_correctable_error_status.md) structure that describes the PCIe correctable error status register of the PCIe AER capability structure.
 
 ### -field CorrectableErrorMask
 
-A [PCI_EXPRESS_CORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_correctable_error_mask) structure that describes the PCIe correctable error mask register of the PCIe AER capability structure.
+A [PCI_EXPRESS_CORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_correctable_error_mask.md) structure that describes the PCIe correctable error mask register of the PCIe AER capability structure.
 
 ### -field CapabilitiesAndControl
 
-A [PCI_EXPRESS_AER_CAPABILITIES](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capabilities) structure that describes the PCIe advanced error capabilities and control register of the PCIe AER capability structure.
+A [PCI_EXPRESS_AER_CAPABILITIES](./ns-wdm-_pci_express_aer_capabilities.md) structure that describes the PCIe advanced error capabilities and control register of the PCIe AER capability structure.
 
 ### -field HeaderLog
 
@@ -92,19 +92,19 @@ An array of four 32-bit values that together contain the header for the transact
 
 ### -field SecUncorrectableErrorStatus
 
-A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_uncorrectable_error_status) structure that describes the PCIe secondary uncorrectable error status register of the PCIe AER capability structure.
+A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_sec_uncorrectable_error_status.md) structure that describes the PCIe secondary uncorrectable error status register of the PCIe AER capability structure.
 
 ### -field SecUncorrectableErrorMask
 
-A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_uncorrectable_error_mask) structure that describes the PCIe secondary uncorrectable error mask register of the PCIe AER capability structure.
+A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_sec_uncorrectable_error_mask.md) structure that describes the PCIe secondary uncorrectable error mask register of the PCIe AER capability structure.
 
 ### -field SecUncorrectableErrorSeverity
 
-A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERIT](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_uncorrectable_error_severity)Y structure that describes the PCIe secondary uncorrectable error severity register of the PCIe AER capability structure.
+A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERIT](./ns-wdm-_pci_express_sec_uncorrectable_error_severity.md)Y structure that describes the PCIe secondary uncorrectable error severity register of the PCIe AER capability structure.
 
 ### -field SecCapabilitiesAndControl
 
-A [PCI_EXPRESS_SEC_AER_CAPABILITIES](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_aer_capabilities) structure that describes the PCIe secondary error capabilities and control register of the PCIe AER capability structure.
+A [PCI_EXPRESS_SEC_AER_CAPABILITIES](./ns-wdm-_pci_express_sec_aer_capabilities.md) structure that describes the PCIe secondary error capabilities and control register of the PCIe AER capability structure.
 
 ### -field SecHeaderLog
 
@@ -134,28 +134,28 @@ typedef struct _PCI_EXPRESS_AER_CAPABILITY {
 
 The PCI_EXPRESS_AER_CAPABILITY structure is available in Windows Server 2008 and later versions of Windows.
 
-PCIe bridge devices use the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability) structure instead of the PCI_EXPRESS_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
+PCIe bridge devices use the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](./ns-wdm-_pci_express_bridge_aer_capability.md) structure instead of the PCI_EXPRESS_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
 
-Root ports and root complex event collectors use the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structure instead of the PCI_EXPRESS_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
+Root ports and root complex event collectors use the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](./ns-wdm-_pci_express_rootport_aer_capability.md) structure instead of the PCI_EXPRESS_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
 
 For additional information about the PCIe advanced error reporting capability structure, see the [PCI Express Specification](https://go.microsoft.com/fwlink/p/?linkid=69486).
 
 ## -see-also
 
-[PCI_EXPRESS_CORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_correctable_error_status)
+[PCI_EXPRESS_CORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_correctable_error_status.md)
 
-[PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_severity)
+[PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](./ns-wdm-_pci_express_uncorrectable_error_severity.md)
 
-[PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_mask)
+[PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_uncorrectable_error_mask.md)
 
-[PCI_EXPRESS_AER_CAPABILITIES](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capabilities)
+[PCI_EXPRESS_AER_CAPABILITIES](./ns-wdm-_pci_express_aer_capabilities.md)
 
-[PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_enhanced_capability_header)
+[PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](./ns-wdm-_pci_express_enhanced_capability_header.md)
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](./ns-wdm-_pci_express_bridge_aer_capability.md)
 
-[PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_status)
+[PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_uncorrectable_error_status.md)
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](./ns-wdm-_pci_express_rootport_aer_capability.md)
 
-[PCI_EXPRESS_CORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_correctable_error_mask)
+[PCI_EXPRESS_CORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_correctable_error_mask.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 