### PR TITLE
Add Win11 PoFx Enable/Disable fast resume flags

### DIFF
--- a/wdk-ddi-src/content/wdm/ns-wdm-po_fx_device_v3.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-po_fx_device_v3.md
@@ -66,6 +66,8 @@ Possible flag values include:
 |**PO_FX_DEVICE_FLAG_DIRECT_CHILDREN_OPTIONAL**|Allows direct child devices of this device to optionally support Directed PoFx. If not set, all direct children must support Directed PoFx for this device to fully support Directed PoFx.|
 |**PO_FX_DEVICE_FLAG_POWER_CHILDREN_OPTIONAL**|Allows power child devices of this device to optionally support Directed PoFx. If not provided, all power children must support Directed PoFx for this device to fully support Directed PoFx.|
 |**PO_FX_DEVICE_FLAG_DFX_CHILDREN_OPTIONAL**|Sets both **PO_FX_DEVICE_FLAG_DIRECT_CHILDREN_OPTIONAL** and **PO_FX_DEVICE_FLAG_POWER_CHILDREN_OPTIONAL**|
+|**PO_FX_DEVICE_FLAG_DISABLE_FAST_RESUME**|Forces PoFx to prevent the S0-IRP from being completed before the D0-IRP on resume from a system state such as Hibernate or Sleep. Mutually exclusive with **PO_FX_DEVICE_FLAG_ENABLE_FAST_RESUME**.|
+|**PO_FX_DEVICE_FLAG_ENABLE_FAST_RESUME**|Forces PoFx to allow the S0-IRP to be completed before the D0-IRP on resume from a system state such as Hibernate or Sleep. Mutually exclusive with **PO_FX_DEVICE_FLAG_ENABLE_FAST_RESUME**.|
 
 ### -field ComponentActiveConditionCallback
 
@@ -122,6 +124,8 @@ To register a device with PoFx, a driver calls the [**PoFxRegisterDevice**](./nf
 Each element in the <b>Components</b> array describes the power state attributes of one component in the device. Each component in the device is identified by its <b>Components</b> array index. Routines such as  <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-pofxactivatecomponent">PoFxActivateComponent</a> and <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-pofxcompleteidlecondition">PoFxCompleteIdleCondition</a> use the array index of a component to identify the component.
 
 A device driver is not required to implement all eight callback routines. The driver can set a function pointer in the <b>PO_FX_DEVICE</b> structure to NULL if the driver does not implement the corresponding callback routine. However, certain callback routines must be implemented. Specifically, if one or more components in a device has more than one Fx state, the driver must implement <a href="/windows-hardware/drivers/ddi/wdm/nc-wdm-po_fx_component_idle_state_callback">ComponentIdleStateCallback</a>, <a href="/windows-hardware/drivers/ddi/wdm/nc-wdm-po_fx_component_active_condition_callback">ComponentActiveConditionCallback</a>, and <a href="/windows-hardware/drivers/ddi/wdm/nc-wdm-po_fx_component_idle_condition_callback">ComponentIdleConditionCallback</a> routines. Otherwise, device registration fails and <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-pofxregisterdevice">PoFxRegisterDevice</a> returns <b>STATUS_INVALID_PARAMETER</b>.
+
+If a driver does not provide one of **PO_FX_DEVICE_FLAG_DISABLE_FAST_RESUME** or **PO_FX_DEVICE_FLAG_ENABLE_FAST_RESUME** the system will fallback to the platform's default configuration. The default configuration is **PO_FX_DEVICE_FLAG_ENABLE_FAST_RESUME** for x86/x64 platforms, and **PO_FX_DEVICE_FLAG_DISABLE_FAST_RESUME** for ARM32/ARM64 platforms. These flags are only honored for Win11 22000+ and are silently ignored for prior releases. For WDF drivers these flags can be provided using the **PoFxDeviceFlags** field of [WDF_POWER_FRAMEWORK_SETTINGS](../wdfdevice/ns-wdfdevice-_wdf_power_framework_settings.md).
 
 ## -see-also
 


### PR DESCRIPTION
This PR adds the PO_FX_DEVICE_FLAG_DISABLE_FAST_RESUME and PO_FX_DEVICE_FLAG_ENABLE_FAST_RESUME flags that were introduced with Win11 22000.