### PR TITLE
Add some more discouragement to the use of pushlocks.

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltinitializepushlock.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltinitializepushlock.md
@@ -4,7 +4,7 @@ title: FltInitializePushLock function (fltkernel.h)
 description: The FltInitializePushLock routine initializes a push lock variable.
 old-location: ifsk\fltinitializepushlock.htm
 tech.root: ifsk
-ms.date: 04/16/2018
+ms.date: 11/29/2021
 keywords: ["FltInitializePushLock function"]
 ms.keywords: FltApiRef_e_to_o_348be4fc-280f-4dc3-b5fb-ada1aa037d09.xml, FltInitializePushLock, FltInitializePushLock routine [Installable File System Drivers], fltkernel/FltInitializePushLock, ifsk.fltinitializepushlock
 req.header: fltkernel.h
@@ -60,7 +60,7 @@ None
 
 ## -remarks
 
-Push locks are rarely a good choice for file system minifilters.  As described below some of their characteristics are deeply incompatible with the inherently re-entrant nature of file systems.  
+Push locks are rarely a good choice for file system minifilters.  As described below, some of their characteristics can be incompatible with the inherently re-entrant nature of file systems.  
 
 Push locks are similar to <a href="/windows-hardware/drivers/kernel/eresource-structures">ERESOURCE structures</a> (also called "resources") in the following ways: 
 


### PR DESCRIPTION
Lori & co.
I rather suspect that much of this needs recast.  It was written (in frustration) after fighting my way through two different deadlocks caused by abuse of push-locks in two weeks so I'm not feeling very "push-lock friendly".

I hope you will be able to incorporate some of the words

---

Pushlocks are effectively undebuggable and hence represent a significant extra maintenance cost.

Pushlocks are however re-entrant when taken shared.

* Add some deprecation words at the top of remarks
* Recast the words to put the reasons not to use them before the reasons to use them. 
* Then at the end add some words about "Only use them if you need to"
* (attempt to) Clear up the issue about re-entrancy (they are non re-entrant,  except when they are)