### PR TITLE
LinkFix: windows-driver-docs-ddi (2021-11)

### DIFF
--- a/wdk-ddi-src/content/dispmprt/nc-dispmprt-dxgkcb_query_services.md
+++ b/wdk-ddi-src/content/dispmprt/nc-dispmprt-dxgkcb_query_services.md
@@ -58,7 +58,7 @@ A constant from the [**DXGK_SERVICES**](ne-dispmprt-dxgk_services.md) enumeratio
 
 ### -param Interface [in, out]
 
-A pointer to an [**INTERFACE**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface) structure that receives the requested interface.
+A pointer to an [**INTERFACE**](../wdm/ns-wdm-_interface.md) structure that receives the requested interface.
 
 ## -returns
 
@@ -78,7 +78,7 @@ To obtain an Accelerated Graphics Port (AGP) interface, do the following:
 
 3. Set the **Version** member. Version constants are defined in *Dispmprt.h* (for example, DXGK_AGP_INTERFACE_VERSION_1).
 
-4. Call **DxgkCbQueryServices**; set **ServicesType** to **DxgkServicesAgp**, and set **Interface** to the address (cast as [PINTERFACE](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface)) of your **DXGK_AGP_INTERFACE** structure.
+4. Call **DxgkCbQueryServices**; set **ServicesType** to **DxgkServicesAgp**, and set **Interface** to the address (cast as [PINTERFACE](../wdm/ns-wdm-_interface.md)) of your **DXGK_AGP_INTERFACE** structure.
 
 5. On return from **DxgkCbQueryServices**, your **DXGK_AGP_INTERFACE** structure will contain pointers to the AGP interface functions; for example, [**AgpAllocatePool**](nc-dispmprt-dxgkcb_agp_allocate_pool.md).
 
@@ -132,4 +132,4 @@ The [Simple Peripheral Bus (SPB)](ns-dispmprt-_dxgk_spb_interface.md) and [Syste
 
 [**DXGKRNL_INTERFACE**](ns-dispmprt-_dxgkrnl_interface.md)
 
-[**INTERFACE**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface)
+[**INTERFACE**](../wdm/ns-wdm-_interface.md)

--- a/wdk-ddi-src/content/hidpi/ne-hidpi-_hidp_report_type.md
+++ b/wdk-ddi-src/content/hidpi/ne-hidpi-_hidp_report_type.md
@@ -65,7 +65,7 @@ Indicates a feature report.
 
 ## -see-also
 
-- [HIDP_BUTTON_CAPS](/windows-hardware/drivers/ddi/hidpi/ns-hidpi-_hidp_button_caps)
-- [HIDP_VALUE_CAPS](/windows-hardware/drivers/ddi/hidpi/ns-hidpi-_hidp_value_caps)
-- [HidP_GetData](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getdata)
-- [HidP_SetData](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_setdata)
+- [HIDP_BUTTON_CAPS](./ns-hidpi-_hidp_button_caps.md)
+- [HIDP_VALUE_CAPS](./ns-hidpi-_hidp_value_caps.md)
+- [HidP_GetData](./nf-hidpi-hidp_getdata.md)
+- [HidP_SetData](./nf-hidpi-hidp_setdata.md)

--- a/wdk-ddi-src/content/hidpi/ns-hidpi-_hidp_button_caps.md
+++ b/wdk-ddi-src/content/hidpi/ns-hidpi-_hidp_button_caps.md
@@ -184,7 +184,7 @@ Reserved for internal system use.
 
 ## -remarks
 
-Clients obtain a [button capability array](/windows-hardware/drivers/hid/button-capability-arrays) by calling [HidP_GetButtonCaps](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getbuttoncaps) or [HidP_GetSpecificButtonCaps](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getspecificbuttoncaps). These routines return an array of HIDP_BUTTON_CAPS structures in a caller-allocated buffer. The required buffer length is specified in the [HIDP_CAPS](/windows-hardware/drivers/ddi/hidpi/ns-hidpi-_hidp_caps) structure returned by [HidP_GetCaps](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getcaps).
+Clients obtain a [button capability array](/windows-hardware/drivers/hid/button-capability-arrays) by calling [HidP_GetButtonCaps](./nf-hidpi-hidp_getbuttoncaps.md) or [HidP_GetSpecificButtonCaps](./nf-hidpi-hidp_getspecificbuttoncaps.md). These routines return an array of HIDP_BUTTON_CAPS structures in a caller-allocated buffer. The required buffer length is specified in the [HIDP_CAPS](./ns-hidpi-_hidp_caps.md) structure returned by [HidP_GetCaps](./nf-hidpi-hidp_getcaps.md).
 
 For information about the capabilities of HID control values, see [Collection Capability](/windows-hardware/drivers/hid/collection-capability) and [Value Capability Arrays](/windows-hardware/drivers/hid/value-capability-arrays).
 
@@ -192,10 +192,10 @@ When a report descriptor declares an input, output, or feature main item with fe
 
 ## -see-also
 
-- [HIDP_CAPS](/windows-hardware/drivers/ddi/hidpi/ns-hidpi-_hidp_caps)
-- [HIDP_VALUE_CAPS](/windows-hardware/drivers/ddi/hidpi/ns-hidpi-_hidp_value_caps)
-- [HidP_GetButtonCaps](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getbuttoncaps)
-- [HidP_GetCaps](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getcaps)
-- [HidP_GetSpecificButtonCaps](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getspecificbuttoncaps)
-- [HidP_GetSpecificValueCaps](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getspecificvaluecaps)
-- [HidP_GetValueCaps](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getvaluecaps)
+- [HIDP_CAPS](./ns-hidpi-_hidp_caps.md)
+- [HIDP_VALUE_CAPS](./ns-hidpi-_hidp_value_caps.md)
+- [HidP_GetButtonCaps](./nf-hidpi-hidp_getbuttoncaps.md)
+- [HidP_GetCaps](./nf-hidpi-hidp_getcaps.md)
+- [HidP_GetSpecificButtonCaps](./nf-hidpi-hidp_getspecificbuttoncaps.md)
+- [HidP_GetSpecificValueCaps](./nf-hidpi-hidp_getspecificvaluecaps.md)
+- [HidP_GetValueCaps](./nf-hidpi-hidp_getvaluecaps.md)

--- a/wdk-ddi-src/content/vhf/nf-vhf-vhf_config_init.md
+++ b/wdk-ddi-src/content/vhf/nf-vhf-vhf_config_init.md
@@ -82,7 +82,7 @@ A pointer to the <a href="/windows-hardware/drivers/ddi/vhf/ns-vhf-_vhf_config">
 
 A pointer to the <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-_device_object">DEVICE_OBJECT</a> structure for the HID source driver. Get that pointer by calling  <a href="/windows-hardware/drivers/ddi/wdfdevice/nf-wdfdevice-wdfdevicewdmgetdeviceobject">WdfDeviceWdmGetDeviceObject</a> and passing the WDFDEVICE handle that the driver received in the <a href="/windows-hardware/drivers/ddi/wdfdevice/nf-wdfdevice-wdfdevicecreate">WdfDeviceCreate</a> call.
 
-A user-mode driver would instead provide a *FileHandle*. For more info, see [**VHF_CONFIG**](/windows-hardware/drivers/ddi/vhf/ns-vhf-_vhf_config).
+A user-mode driver would instead provide a *FileHandle*. For more info, see [**VHF_CONFIG**](./ns-vhf-_vhf_config.md).
 
 ### -param ReportDescriptorLength [in]
 

--- a/wdk-ddi-src/content/vhf/ns-vhf-_vhf_config.md
+++ b/wdk-ddi-src/content/vhf/ns-vhf-_vhf_config.md
@@ -118,8 +118,8 @@ Required for kernel-mode drivers. A pointer to the <a href="/windows-hardware/dr
 
 ### -field FileHandle
 
-Required for user-mode drivers. A file handle obtained by calling [**WdfIoTargetWdmGetTargetFileHandle**](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetfilehandle).
-To open a WDFIOTARGET, a user-mode (UMDF) VHF source driver should call [**WdfIoTargetOpen**](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetopen) with **OpenParams.Type** set
+Required for user-mode drivers. A file handle obtained by calling [**WdfIoTargetWdmGetTargetFileHandle**](../wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetfilehandle.md).
+To open a WDFIOTARGET, a user-mode (UMDF) VHF source driver should call [**WdfIoTargetOpen**](../wdfiotarget/nf-wdfiotarget-wdfiotargetopen.md) with **OpenParams.Type** set
  to **WdfIoTargetOpenLocalTargetByFile**.
 
 ### -field VendorID
@@ -182,4 +182,3 @@ Optional. A pointer to a <a href="/windows-hardware/drivers/ddi/vhf/nc-vhf-evt_v
 ## -see-also
 
 <a href="/windows-hardware/drivers/hid/virtual-hid-framework--vhf-">Write a HID source driver by using Virtual HID Framework (VHF)</a>
-

--- a/wdk-ddi-src/content/wdfdevice/ne-wdfdevice-_wdf_special_file_type.md
+++ b/wdk-ddi-src/content/wdfdevice/ne-wdfdevice-_wdf_special_file_type.md
@@ -97,6 +97,6 @@ For more information, see <a href="/windows-hardware/drivers/wdf/supporting-spec
 
 <a href="/windows-hardware/drivers/ddi/wdfdevice/nf-wdfdevice-wdfdevicesetspecialfilesupport">WdfDeviceSetSpecialFileSupport</a>
 
-[EVT_WDF_DEVICE_USAGE_NOTIFICATION callback function](/windows-hardware/drivers/ddi/wdfdevice/nc-wdfdevice-evt_wdf_device_usage_notification)
+[EVT_WDF_DEVICE_USAGE_NOTIFICATION callback function](./nc-wdfdevice-evt_wdf_device_usage_notification.md)
 
-[DEVICE_USAGE_NOTIFICATION_TYPE enumeration](/windows-hardware/drivers/ddi/wdm/ne-wdm-device_usage_notification_type)
+[DEVICE_USAGE_NOTIFICATION_TYPE enumeration](../wdm/ne-wdm-device_usage_notification_type.md)

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestprobeandlockuserbufferforread.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestprobeandlockuserbufferforread.md
@@ -158,7 +158,7 @@ The buffer length that the <i>Length</i> parameter specifies must not be larger 
 
 If <b>WdfRequestProbeAndLockUserBufferForRead</b> returns STATUS_SUCCESS, the driver receives a handle to a framework memory object that represents the user-mode buffer. To access the buffer, the driver must call <a href="/windows-hardware/drivers/ddi/wdfmemory/nf-wdfmemory-wdfmemorygetbuffer">WdfMemoryGetBuffer</a>.
 
-The framework memory object is automatically released when the driver calls [**WdfRequestComplete**](/windows-hardware/drivers/ddi/wdfrequest/nf-wdfrequest-wdfrequestcomplete).
+The framework memory object is automatically released when the driver calls [**WdfRequestComplete**](./nf-wdfrequest-wdfrequestcomplete.md).
 
 For more information about <b>WdfRequestProbeAndLockUserBufferForRead</b>, see <a href="/windows-hardware/drivers/wdf/accessing-data-buffers-in-wdf-drivers">Accessing Data Buffers in Framework-Based Drivers</a>.
 

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestprobeandlockuserbufferforwrite.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestprobeandlockuserbufferforwrite.md
@@ -158,7 +158,7 @@ The buffer length that the <i>Length</i> parameter specifies must not be larger 
 
 If <b>WdfRequestProbeAndLockUserBufferForWrite</b> returns STATUS_SUCCESS, the driver receives a handle to a framework memory object that represents the user-mode buffer. To access the buffer, the driver must call <a href="/windows-hardware/drivers/ddi/wdfmemory/nf-wdfmemory-wdfmemorygetbuffer">WdfMemoryGetBuffer</a>.
 
-The framework memory object is automatically released when the driver calls [**WdfRequestComplete**](/windows-hardware/drivers/ddi/wdfrequest/nf-wdfrequest-wdfrequestcomplete).
+The framework memory object is automatically released when the driver calls [**WdfRequestComplete**](./nf-wdfrequest-wdfrequestcomplete.md).
 
 For more information about <b>WdfRequestProbeAndLockUserBufferForWrite</b>, see <a href="/windows-hardware/drivers/wdf/accessing-data-buffers-in-wdf-drivers">Accessing Data Buffers in Framework-Based Drivers</a>.
 

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlunicodestringtointeger.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlunicodestringtointeger.md
@@ -99,10 +99,10 @@ The following table contains examples of output values that result from various 
 | "FGH" | 16 | 15 |
 | " " | 10 | 0 |
 
-A related routine, [RtlIntegerToUnicodeString](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlintegertounicodestring), converts an integer value to the equivalent Unicode string representation.
+A related routine, [RtlIntegerToUnicodeString](./nf-wdm-rtlintegertounicodestring.md), converts an integer value to the equivalent Unicode string representation.
 
 ## -see-also
 
-[RtlIntegerToUnicodeString](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlintegertounicodestring)
+[RtlIntegerToUnicodeString](./nf-wdm-rtlintegertounicodestring.md)
 
 [UNICODE_STRING](/windows/win32/api/ntdef/ns-ntdef-_unicode_string)

--- a/wdk-ddi-src/content/wificx/nc-wificx-evt_wifi_device_send_command.md
+++ b/wdk-ddi-src/content/wificx/nc-wificx-evt_wifi_device_send_command.md
@@ -64,7 +64,7 @@ The WiFiCx framework invokes *EvtWifiDeviceSendCommand* to issue a command messa
 
 - To complete the request, the driver sends the M3 for the command asynchronously by calling [**WifiRequestComplete**](nf-wificx-wifirequestcomplete.md). 
 
-- If this command is a set command and the original request did not contain a large enough buffer, the client should call [**WifiRequestSetBytesNeeded**](/windows-hardware/drivers/ddi/wificx/nf-wificx-wifirequestsetbytesneeded) to set the required buffer size and then fail the request with status BUFFER\_OVERFLOW.
+- If this command is a set command and the original request did not contain a large enough buffer, the client should call [**WifiRequestSetBytesNeeded**](./nf-wificx-wifirequestsetbytesneeded.md) to set the required buffer size and then fail the request with status BUFFER\_OVERFLOW.
 
 - If this command is a task command, the client driver needs to later send the associated M4 indication by calling [**WifiDeviceReceiveIndication**](nf-wificx-wifidevicereceiveindication.md) and pass the indication buffer with a WDI header that contains the same message ID as contained in the M1.
 
@@ -80,4 +80,4 @@ For more information, see [Handling WiFiCx command messages](/windows-hardware/d
 
 [**WifiRequestGetMessageId**](nf-wificx-wifirequestgetmessageid.md)
 
-[**WifiRequestComplete**](nf-wificx-wifirequestcomplete.md) 
+[**WifiRequestComplete**](nf-wificx-wifirequestcomplete.md)

--- a/wdk-ddi-src/content/wificx/nf-wificx-wifideviceinitconfig.md
+++ b/wdk-ddi-src/content/wificx/nf-wificx-wifideviceinitconfig.md
@@ -56,7 +56,7 @@ Returns STATUS_SUCCESS if the operation succeeds. Otherwise, this function may r
 
 ## -remarks
 
-In its [*EVT_WDF_DRIVER_DEVICE_ADD*](/windows-hardware/drivers/ddi/wdfdriver/nc-wdfdriver-evt_wdf_driver_device_add) callback function, a WifiCx client driver calls **WifiDeviceInitConfig** after calling [**NetDeviceInitConfig**](../netdevice/nf-netdevice-netdeviceinitconfig.md) but before calling [**WdfDeviceCreate**](/windows-hardware/drivers/ddi/wdfdevice/nf-wdfdevice-wdfdevicecreate).
+In its [*EVT_WDF_DRIVER_DEVICE_ADD*](../wdfdriver/nc-wdfdriver-evt_wdf_driver_device_add.md) callback function, a WifiCx client driver calls **WifiDeviceInitConfig** after calling [**NetDeviceInitConfig**](../netdevice/nf-netdevice-netdeviceinitconfig.md) but before calling [**WdfDeviceCreate**](../wdfdevice/nf-wdfdevice-wdfdevicecreate.md).
 
 The driver must reference the same [**WDFDEVICE_INIT**](/windows-hardware/drivers/wdf/wdfdevice_init) object passed in by the framework.
 
@@ -64,8 +64,8 @@ The driver must reference the same [**WDFDEVICE_INIT**](/windows-hardware/driver
 
 [**WDFDEVICE_INIT**](/windows-hardware/drivers/wdf/wdfdevice_init)
 
-[*EVT_WDF_DRIVER_DEVICE_ADD*](/windows-hardware/drivers/ddi/wdfdriver/nc-wdfdriver-evt_wdf_driver_device_add) 
+[*EVT_WDF_DRIVER_DEVICE_ADD*](../wdfdriver/nc-wdfdriver-evt_wdf_driver_device_add.md) 
 
 [**NetDeviceInitConfig**](../netdevice/nf-netdevice-netdeviceinitconfig.md)
 
-[**WdfDeviceCreate**](/windows-hardware/drivers/ddi/wdfdevice/nf-wdfdevice-wdfdevicecreate)
+[**WdfDeviceCreate**](../wdfdevice/nf-wdfdevice-wdfdevicecreate.md)

--- a/wdk-ddi-src/content/wificx/nf-wificx-wifitxqueuegetdemuxpeeraddress.md
+++ b/wdk-ddi-src/content/wificx/nf-wificx-wifitxqueuegetdemuxpeeraddress.md
@@ -56,11 +56,10 @@ Returns the peer address.
 
 ## -remarks
 
-The client driver should query the peer address from [*EvtPacketQueueStart*](/windows-hardware/drivers/ddi/netpacketqueue/nc-netpacketqueue-evt_packet_queue_start).
+The client driver should query the peer address from [*EvtPacketQueueStart*](../netpacketqueue/nc-netpacketqueue-evt_packet_queue_start.md).
 
 For more information, see [Setting up multiple Tx queues](/windows-hardware/drivers/netcx/writing-a-wificx-client-driver#setting-up-multiple-tx-queues).
 
 ## -see-also
 
 [Setting up multiple Tx queues](/windows-hardware/drivers/netcx/writing-a-wificx-client-driver#setting-up-multiple-tx-queues)
-

--- a/wdk-ddi-src/content/wificx/nf-wificx-wifitxqueuegetdemuxwmminfo.md
+++ b/wdk-ddi-src/content/wificx/nf-wificx-wifitxqueuegetdemuxwmminfo.md
@@ -56,7 +56,7 @@ Returns the queue priority.
 
 ## -remarks
 
-The client driver should query the queue priority from [*EvtPacketQueueStart*](/windows-hardware/drivers/ddi/netpacketqueue/nc-netpacketqueue-evt_packet_queue_start).
+The client driver should query the queue priority from [*EvtPacketQueueStart*](../netpacketqueue/nc-netpacketqueue-evt_packet_queue_start.md).
 
 For more information, see [Setting up multiple Tx queues](/windows-hardware/drivers/netcx/writing-a-wificx-client-driver#setting-up-multiple-tx-queues).
 


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

```