### PR TITLE
Update nc-ntddk-pshed_pi_read_error_record.md

### DIFF
--- a/wdk-ddi-src/content/ntddk/nc-ntddk-pshed_pi_read_error_record.md
+++ b/wdk-ddi-src/content/ntddk/nc-ntddk-pshed_pi_read_error_record.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <=DISPATCH_LEVEL (For V2 Plugins, IRQL = DISPATCH_LEVEL)
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
Customer asked we update this documentation to specify that V2 plugins are always called at DISPATCH_LEVEL