### PR TITLE
LinkFix: windows-driver-docs-ddi (2022-01)

### DIFF
--- a/wdk-ddi-src/content/bthioctl/ns-bthioctl-_bth_sdp_connect.md
+++ b/wdk-ddi-src/content/bthioctl/ns-bthioctl-_bth_sdp_connect.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-The BTH_SDP_CONNECT structure contains input and output information about a connection between the local Bluetooth system and a remote SDP server. This structure is passed as the input buffer and output buffer of [IOCTL_BTH_SDP_CONNECT](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_connect).
+The BTH_SDP_CONNECT structure contains input and output information about a connection between the local Bluetooth system and a remote SDP server. This structure is passed as the input buffer and output buffer of [IOCTL_BTH_SDP_CONNECT](./ni-bthioctl-ioctl_bth_sdp_connect.md).
 
 ## -struct-fields
 
@@ -77,4 +77,4 @@ Timeout, in seconds, for the requests on this SDP channel. If the request times 
 
 ## -see-also
 
-- [IOCTL_BTH_SDP_CONNECT](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_connect)
+- [IOCTL_BTH_SDP_CONNECT](./ni-bthioctl-ioctl_bth_sdp_connect.md)

--- a/wdk-ddi-src/content/bthioctl/ns-bthioctl-_bth_sdp_disconnect.md
+++ b/wdk-ddi-src/content/bthioctl/ns-bthioctl-_bth_sdp_disconnect.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-The BTH_SDP_DISCONNECT structure contains input information about a connection handle to the remote SDP connection to terminate. This structure is passed as the input buffer of [IOCTL_BTH_SDP_DISCONNECT](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_disconnect).
+The BTH_SDP_DISCONNECT structure contains input information about a connection handle to the remote SDP connection to terminate. This structure is passed as the input buffer of [IOCTL_BTH_SDP_DISCONNECT](./ni-bthioctl-ioctl_bth_sdp_disconnect.md).
 
 ## -struct-fields
 
@@ -60,6 +60,6 @@ When the connect request returns, this specifies the handle to the SDP connectio
 
 ## -see-also
 
-- [BTH_SDP_CONNECT](/windows-hardware/drivers/ddi/bthioctl/ns-bthioctl-_bth_sdp_connect)
-- [IOCTL_BTH_SDP_CONNECT](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_connect)
-- [IOCTL_BTH_SDP_DISCONNECT](/windows-hardware/drivers/ddi/bthioctl/ni-bthioctl-ioctl_bth_sdp_disconnect)
+- [BTH_SDP_CONNECT](./ns-bthioctl-_bth_sdp_connect.md)
+- [IOCTL_BTH_SDP_CONNECT](./ni-bthioctl-ioctl_bth_sdp_connect.md)
+- [IOCTL_BTH_SDP_DISCONNECT](./ni-bthioctl-ioctl_bth_sdp_disconnect.md)

--- a/wdk-ddi-src/content/bthsdpddi/nc-bthsdpddi-pbyteswapuuid128.md
+++ b/wdk-ddi-src/content/bthsdpddi/nc-bthsdpddi-pbyteswapuuid128.md
@@ -62,8 +62,8 @@ A pointer to the converted 128-bit GUID.
 
 The **SdpByteSwapUuid128** function always reverses the byte order of the value pointed to by the *pUuidFrom* parameter. Use this function to convert 128-bit GUID values from the byte order on the local computer to the byte order of the network to which the computer is connected.
 
-Bluetooth profile drivers can obtain a pointer to this function through the [BTHDDI_SDP_PARSE_INTERFACE](/windows-hardware/drivers/ddi/bthsdpddi/ns-bthsdpddi-_bthddi_sdp_parse_interface).
+Bluetooth profile drivers can obtain a pointer to this function through the [BTHDDI_SDP_PARSE_INTERFACE](./ns-bthsdpddi-_bthddi_sdp_parse_interface.md).
 
 ## -see-also
 
-- [BTHDDI_SDP_PARSE_INTERFACE](/windows-hardware/drivers/ddi/bthsdpddi/ns-bthsdpddi-_bthddi_sdp_parse_interface)
+- [BTHDDI_SDP_PARSE_INTERFACE](./ns-bthsdpddi-_bthddi_sdp_parse_interface.md)

--- a/wdk-ddi-src/content/bthxddi/ns-bthxddi-_bthx_hci_read_write_context.md
+++ b/wdk-ddi-src/content/bthxddi/ns-bthxddi-_bthx_hci_read_write_context.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-The **BTHX_HCI_READ_WRITE_CONTEXT** structure is used by [IOCTL_BTHX_HCI_READ](/windows-hardware/drivers/ddi/bthxddi/ni-bthxddi-ioctl_bthx_read_hci) and [IOCTL_BTHX_HCI_WRITE](/windows-hardware/drivers/ddi/bthxddi/ni-bthxddi-ioctl_bthx_write_hci) for input and output.
+The **BTHX_HCI_READ_WRITE_CONTEXT** structure is used by [IOCTL_BTHX_HCI_READ](./ni-bthxddi-ioctl_bthx_read_hci.md) and [IOCTL_BTHX_HCI_WRITE](./ni-bthxddi-ioctl_bthx_write_hci.md) for input and output.
 
 ## -struct-fields
 
@@ -68,13 +68,13 @@ Actual data to be read/written.
 
 ## -remarks
 
-The **BTHX_HCI_READ_WRITE_CONTEXT** structure is an input parameter to [IOCTL_BTHX_HCI_WRITE](/windows-hardware/drivers/ddi/bthxddi/ni-bthxddi-ioctl_bthx_write_hci) and specifies the type of packet associated with the write. It also specifies the data to be written in the **Data** member.
+The **BTHX_HCI_READ_WRITE_CONTEXT** structure is an input parameter to [IOCTL_BTHX_HCI_WRITE](./ni-bthxddi-ioctl_bthx_write_hci.md) and specifies the type of packet associated with the write. It also specifies the data to be written in the **Data** member.
 
-This structure is also used as an output parameter for [IOCTL_BTHX_HCI_READ](/windows-hardware/drivers/ddi/bthxddi/ni-bthxddi-ioctl_bthx_read_hci) and specifies the type of packet and the data associated with the read.
+This structure is also used as an output parameter for [IOCTL_BTHX_HCI_READ](./ni-bthxddi-ioctl_bthx_read_hci.md) and specifies the type of packet and the data associated with the read.
 
 This structure is packed to 1-byte boundary.
 
 ## -see-also
 
-- [IOCTL_BTHX_HCI_WRITE](/windows-hardware/drivers/ddi/bthxddi/ni-bthxddi-ioctl_bthx_write_hci)
-- [IOCTL_BTHX_HCI_READ](/windows-hardware/drivers/ddi/bthxddi/ni-bthxddi-ioctl_bthx_read_hci)
+- [IOCTL_BTHX_HCI_WRITE](./ni-bthxddi-ioctl_bthx_write_hci.md)
+- [IOCTL_BTHX_HCI_READ](./ni-bthxddi-ioctl_bthx_read_hci.md)

--- a/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_getbuttons.md
+++ b/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_getbuttons.md
@@ -56,7 +56,7 @@ The **HidP_GetButtons** macro is a mnemonic alias for the [**HidP_GetUsages**](.
 
 ### -param Rty [in]
 
-Specifies a [**HIDP_REPORT_TYPE**](/windows-hardware/drivers/ddi/hidpi/ne-hidpi-_hidp_report_type) enumerator value that identifies the report type.
+Specifies a [**HIDP_REPORT_TYPE**](./ne-hidpi-_hidp_report_type.md) enumerator value that identifies the report type.
 
 ### -param UPa [in]
 

--- a/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_getbuttonsex.md
+++ b/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_getbuttonsex.md
@@ -56,7 +56,7 @@ The **HidP_GetButtonsEx** macro is a mnemonic alias for the [**HidP_GetUsagesEx*
 
 ### -param Rty [in]
 
-Specifies a [**HIDP_REPORT_TYPE**](/windows-hardware/drivers/ddi/hidpi/ne-hidpi-_hidp_report_type) enumerator value that identifies the report type.
+Specifies a [**HIDP_REPORT_TYPE**](./ne-hidpi-_hidp_report_type.md) enumerator value that identifies the report type.
 
 ### -param LCo [in]
 

--- a/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_setbuttons.md
+++ b/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_setbuttons.md
@@ -56,7 +56,7 @@ The **HidP_SetButtons** macro is a mnemonic alias for the [**HidP_SetUsages**](.
 
 ### -param Rty [in]
 
-Specifies a [**HIDP_REPORT_TYPE**](/windows-hardware/drivers/ddi/hidpi/ne-hidpi-_hidp_report_type) enumerator value that indicates the type of report located at *Rep*.
+Specifies a [**HIDP_REPORT_TYPE**](./ne-hidpi-_hidp_report_type.md) enumerator value that indicates the type of report located at *Rep*.
 
 ### -param Up [in]
 
@@ -84,7 +84,7 @@ Pointer to a report.
 
 ### -param Rle [in]
 
-Specifies the size, in bytes, of the report located at *Rep*, which must be equal to the report length for the specified report type that [**HidP_GetCaps**](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getcaps) returns in a collection's [**HIDP_CAPS**](/windows-hardware/drivers/ddi/hidpi/ns-hidpi-_hidp_caps) structure.
+Specifies the size, in bytes, of the report located at *Rep*, which must be equal to the report length for the specified report type that [**HidP_GetCaps**](./nf-hidpi-hidp_getcaps.md) returns in a collection's [**HIDP_CAPS**](./ns-hidpi-_hidp_caps.md) structure.
 
 ## -remarks
 

--- a/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_unsetbuttons.md
+++ b/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_unsetbuttons.md
@@ -56,7 +56,7 @@ The **HidP_UnsetButtons** macro is a mnemonic alias for the [**HidP_UnsetUsages*
 
 ### -param Rty [in]
 
-Specifies a [**HIDP_REPORT_TYPE**](/windows-hardware/drivers/ddi/hidpi/ne-hidpi-_hidp_report_type) enumerator value that indicates the type of report located at *Rep*.
+Specifies a [**HIDP_REPORT_TYPE**](./ne-hidpi-_hidp_report_type.md) enumerator value that indicates the type of report located at *Rep*.
 
 ### -param Up [in]
 
@@ -84,7 +84,7 @@ Pointer to a report.
 
 ### -param Rle [in]
 
-Specifies the size, in bytes, of the report located at *Rep*, which must be equal to the report length for the specified report type that [**HidP_GetCaps**](/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getcaps) returns in a collection's [**HIDP_CAPS**](/windows-hardware/drivers/ddi/hidpi/ns-hidpi-_hidp_caps) structure.
+Specifies the size, in bytes, of the report located at *Rep*, which must be equal to the report length for the specified report type that [**HidP_GetCaps**](./nf-hidpi-hidp_getcaps.md) returns in a collection's [**HIDP_CAPS**](./ns-hidpi-_hidp_caps.md) structure.
 
 ## -remarks
 

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_file_disposition_information_ex.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_file_disposition_information_ex.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-The **FILE_DISPOSITION_INFORMATION_EX** structure is used as an argument to the [ZwSetInformationFile](/windows-hardware/drivers/ddi/wdm/nf-wdm-zwsetinformationfile) routine and indicates how the operating system should delete a file.
+The **FILE_DISPOSITION_INFORMATION_EX** structure is used as an argument to the [ZwSetInformationFile](../wdm/nf-wdm-zwsetinformationfile.md) routine and indicates how the operating system should delete a file.
 
 ## -struct-fields
 
@@ -79,6 +79,6 @@ A return value of STATUS_CANNOT_DELETE indicates that either the file is read-on
 
 ## -see-also
 
-[ZwClose](/windows-hardware/drivers/ddi/wdm/nf-wdm-zwclose)
+[ZwClose](../wdm/nf-wdm-zwclose.md)
 
-[ZwSetInformationFile](/windows-hardware/drivers/ddi/wdm/nf-wdm-zwsetinformationfile)
+[ZwSetInformationFile](../wdm/nf-wdm-zwsetinformationfile.md)

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_capability.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_capability.md
@@ -56,59 +56,59 @@ The PCI_EXPRESS_CAPABILITY structure describes a PCI Express (PCIe) capability s
 
 ### -field Header
 
-A [PCI_CAPABILITIES_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_capabilities_header) structure that describes the PCI capabilities header of the PCIe capability structure.
+A [PCI_CAPABILITIES_HEADER](../wdm/ns-wdm-_pci_capabilities_header.md) structure that describes the PCI capabilities header of the PCIe capability structure.
 
 ### -field ExpressCapabilities
 
-A [PCI_EXPRESS_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capabilities_register) structure that describes the PCIe capabilities register of the PCIe capability structure.
+A [PCI_EXPRESS_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_capabilities_register.md) structure that describes the PCIe capabilities register of the PCIe capability structure.
 
 ### -field DeviceCapabilities
 
-A [PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_device_capabilities_register) structure that describes the PCIe device capabilities register of the PCIe capability structure.
+A [PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_device_capabilities_register.md) structure that describes the PCIe device capabilities register of the PCIe capability structure.
 
 ### -field DeviceControl
 
-A [PCI_EXPRESS_DEVICE_CONTROL_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_device_control_register) structure that describes the PCIe device control register of the PCIe capability structure.
+A [PCI_EXPRESS_DEVICE_CONTROL_REGISTER](./ns-ntddk-_pci_express_device_control_register.md) structure that describes the PCIe device control register of the PCIe capability structure.
 
 ### -field DeviceStatus
 
-A [PCI_EXPRESS_DEVICE_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_device_status_register) structure that describes the PCIe device status register of the PCIe capability structure.
+A [PCI_EXPRESS_DEVICE_STATUS_REGISTER](./ns-ntddk-_pci_express_device_status_register.md) structure that describes the PCIe device status register of the PCIe capability structure.
 
 ### -field LinkCapabilities
 
-A [PCI_EXPRESS_LINK_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_link_capabilities_register) structure that describes the PCIe link capabilities register of the PCIe capability structure.
+A [PCI_EXPRESS_LINK_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_link_capabilities_register.md) structure that describes the PCIe link capabilities register of the PCIe capability structure.
 
 ### -field LinkControl
 
-A [PCI_EXPRESS_LINK_CONTROL_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_link_control_register) structure that describes the PCIe link control register of the PCIe capability structure.
+A [PCI_EXPRESS_LINK_CONTROL_REGISTER](./ns-ntddk-_pci_express_link_control_register.md) structure that describes the PCIe link control register of the PCIe capability structure.
 
 ### -field LinkStatus
 
-A [PCI_EXPRESS_LINK_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_link_status_register) structure that describes the PCIe link status register of the PCIe capability structure.
+A [PCI_EXPRESS_LINK_STATUS_REGISTER](./ns-ntddk-_pci_express_link_status_register.md) structure that describes the PCIe link status register of the PCIe capability structure.
 
 ### -field SlotCapabilities
 
-A [PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_slot_capabilities_register) structure that describes the PCIe slot capabilities register of the PCIe capability structure.
+A [PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_slot_capabilities_register.md) structure that describes the PCIe slot capabilities register of the PCIe capability structure.
 
 ### -field SlotControl
 
-A [PCI_EXPRESS_SLOT_CONTROL_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_slot_control_register) structure that describes the PCIe slot control register of the PCIe capability structure.
+A [PCI_EXPRESS_SLOT_CONTROL_REGISTER](./ns-ntddk-_pci_express_slot_control_register.md) structure that describes the PCIe slot control register of the PCIe capability structure.
 
 ### -field SlotStatus
 
-A [PCI_EXPRESS_SLOT_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_slot_status_register) structure that describes the PCIe slot status register of the PCIe capability structure.
+A [PCI_EXPRESS_SLOT_STATUS_REGISTER](./ns-ntddk-_pci_express_slot_status_register.md) structure that describes the PCIe slot status register of the PCIe capability structure.
 
 ### -field RootControl
 
-A [PCI_EXPRESS_ROOT_CONTROL_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_root_control_register) structure that describes the PCIe root control register of the PCIe capability structure.
+A [PCI_EXPRESS_ROOT_CONTROL_REGISTER](./ns-ntddk-_pci_express_root_control_register.md) structure that describes the PCIe root control register of the PCIe capability structure.
 
 ### -field RootCapabilities
 
-A [PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_root_capabilities_register) structure that describes the PCIe root capabilities register of the PCIe capability structure.
+A [PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_root_capabilities_register.md) structure that describes the PCIe root capabilities register of the PCIe capability structure.
 
 ### -field RootStatus
 
-A [PCI_EXPRESS_ROOT_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_root_status_register) structure that describes the PCIe root status register of the PCIe capability structure.
+A [PCI_EXPRESS_ROOT_STATUS_REGISTER](./ns-ntddk-_pci_express_root_status_register.md) structure that describes the PCIe root status register of the PCIe capability structure.
 
 ### -field DeviceCapabilities2
 
@@ -143,30 +143,30 @@ For additional information about the PCIe capability structure, see the [PCI Exp
 
 ## -see-also
 
-[PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_device_capabilities_register)
+[PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_device_capabilities_register.md)
 
-[PCI_EXPRESS_LINK_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_link_capabilities_register)
+[PCI_EXPRESS_LINK_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_link_capabilities_register.md)
 
-[PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_root_capabilities_register)
+[PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_root_capabilities_register.md)
 
-[PCI_EXPRESS_ROOT_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_root_status_register)
+[PCI_EXPRESS_ROOT_STATUS_REGISTER](./ns-ntddk-_pci_express_root_status_register.md)
 
-[PCI_EXPRESS_ROOT_CONTROL_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_root_control_register)
+[PCI_EXPRESS_ROOT_CONTROL_REGISTER](./ns-ntddk-_pci_express_root_control_register.md)
 
-[PCI_EXPRESS_DEVICE_CONTROL_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_device_control_register)
+[PCI_EXPRESS_DEVICE_CONTROL_REGISTER](./ns-ntddk-_pci_express_device_control_register.md)
 
-[PCI_EXPRESS_DEVICE_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_device_status_register)
+[PCI_EXPRESS_DEVICE_STATUS_REGISTER](./ns-ntddk-_pci_express_device_status_register.md)
 
-[PCI_EXPRESS_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capabilities_register)
+[PCI_EXPRESS_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_capabilities_register.md)
 
-[PCI_CAPABILITIES_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_capabilities_header)
+[PCI_CAPABILITIES_HEADER](../wdm/ns-wdm-_pci_capabilities_header.md)
 
-[PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_slot_capabilities_register)
+[PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER](./ns-ntddk-_pci_express_slot_capabilities_register.md)
 
-[PCI_EXPRESS_LINK_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_link_status_register)
+[PCI_EXPRESS_LINK_STATUS_REGISTER](./ns-ntddk-_pci_express_link_status_register.md)
 
-[PCI_EXPRESS_SLOT_CONTROL_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_slot_control_register)
+[PCI_EXPRESS_SLOT_CONTROL_REGISTER](./ns-ntddk-_pci_express_slot_control_register.md)
 
-[PCI_EXPRESS_LINK_CONTROL_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_link_control_register)
+[PCI_EXPRESS_LINK_CONTROL_REGISTER](./ns-ntddk-_pci_express_link_control_register.md)
 
-[PCI_EXPRESS_SLOT_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_slot_status_register)
+[PCI_EXPRESS_SLOT_STATUS_REGISTER](./ns-ntddk-_pci_express_slot_status_register.md)

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntquerydirectoryfile.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntquerydirectoryfile.md
@@ -133,7 +133,7 @@ If **NtQueryDirectoryFile** is called multiple times on the same directory and s
 
 Callers of **NtQueryDirectoryFile** must be running at IRQL = PASSIVE_LEVEL and [with special kernel APCs enabled](/windows-hardware/drivers/kernel/disabling-apcs).
 
-For information about other file information query routines, see [File Objects](/windows-hardware/drivers/ddi/_kernel/#file-objects).
+For information about other file information query routines, see [File Objects](../_kernel/index.md#file-objects).
 
 > [!NOTE]
 > If the call to the **NtQueryDirectoryFile** function occurs in user mode, you should use the name "**NtQueryDirectoryFile**" instead of "**ZwQueryDirectoryFile**".

--- a/wdk-ddi-src/content/sensorsclassextension/nf-sensorsclassextension-isensorclassextension-poststatechange.md
+++ b/wdk-ddi-src/content/sensorsclassextension/nf-sensorsclassextension-isensorclassextension-poststatechange.md
@@ -55,7 +55,7 @@ The **ISensorClassExtension::PostStateChange** method notifies the sensor class 
 
 ### -param state [in]
 
-[SensorState](/windows-hardware/drivers/ddi/sensorsclassextension/ne-sensorsclassextension-__midl___midl_itf_windowssensorclassextension_0000_0000_0001) value that indicates the new state.
+[SensorState](./ne-sensorsclassextension-__midl___midl_itf_windowssensorclassextension_0000_0000_0001.md) value that indicates the new state.
 
 ## -returns
 
@@ -101,6 +101,6 @@ HRESULT PostStateEvent()
 
 ## -see-also
 
-- [ISensorClassExtension](/windows-hardware/drivers/ddi/sensorsclassextension/nn-sensorsclassextension-isensorclassextension)
-- [ISensorDriver::OnClientSubscribeToEvents](/windows-hardware/drivers/ddi/sensorsclassextension/nf-sensorsclassextension-isensordriver-onclientsubscribetoevents)
-- [ISensorDriver::OnClientUnsubscribeFromEvents](/windows-hardware/drivers/ddi/sensorsclassextension/nf-sensorsclassextension-isensordriver-onclientunsubscribefromevents)
+- [ISensorClassExtension](./nn-sensorsclassextension-isensorclassextension.md)
+- [ISensorDriver::OnClientSubscribeToEvents](./nf-sensorsclassextension-isensordriver-onclientsubscribetoevents.md)
+- [ISensorDriver::OnClientUnsubscribeFromEvents](./nf-sensorsclassextension-isensordriver-onclientunsubscribefromevents.md)

--- a/wdk-ddi-src/content/sensorscx/nf-sensorscx-sensorscxsensordataready.md
+++ b/wdk-ddi-src/content/sensorscx/nf-sensorscx-sensorscxsensordataready.md
@@ -54,14 +54,14 @@ A reference to a sensor object.
 
 ### -param pSensorData [in]
 
-A list of [sensor properties](/windows-hardware/drivers/sensors/sensor-properties2). For more information, see [SENSOR_COLLECTION_LIST](/windows-hardware/drivers/ddi/sensorsdef/ns-sensorsdef-sensor_collection_list).
+A list of [sensor properties](/windows-hardware/drivers/sensors/sensor-properties2). For more information, see [SENSOR_COLLECTION_LIST](../sensorsdef/ns-sensorsdef-sensor_collection_list.md).
 
 ## -remarks
 
-This function is implemented by the class extension and the driver must call it. When batch latency expires for sensor drivers that support data batching, **SensorsCxSensorDataReady** is called repeatedly until all the batched data samples are delivered to the client. For more information about the callback function related to batch latency, see [EvtSensorSetBatchLatency](/windows-hardware/drivers/ddi/sensorscx/ns-sensorscx-_sensor_controller_config).
+This function is implemented by the class extension and the driver must call it. When batch latency expires for sensor drivers that support data batching, **SensorsCxSensorDataReady** is called repeatedly until all the batched data samples are delivered to the client. For more information about the callback function related to batch latency, see [EvtSensorSetBatchLatency](./ns-sensorscx-_sensor_controller_config.md).
 
 ## -see-also
 
-- [EvtSensorSetBatchLatency](/windows-hardware/drivers/ddi/sensorscx/ns-sensorscx-_sensor_controller_config)
-- [SENSOR_COLLECTION_LIST](/windows-hardware/drivers/ddi/sensorsdef/ns-sensorsdef-sensor_collection_list)
+- [EvtSensorSetBatchLatency](./ns-sensorscx-_sensor_controller_config.md)
+- [SENSOR_COLLECTION_LIST](../sensorsdef/ns-sensorsdef-sensor_collection_list.md)
 - [Sensor properties](/windows-hardware/drivers/sensors/sensor-properties2)

--- a/wdk-ddi-src/content/ucmmanager/nf-ucmmanager-ucmconnectordatadirectionchanged.md
+++ b/wdk-ddi-src/content/ucmmanager/nf-ucmmanager-ucmconnectordatadirectionchanged.md
@@ -51,17 +51,17 @@ Notifies the USB connector manager framework extension (UcmCx) with the new data
 
 ### -param Connector [in]
 
-Handle to the connector object that the client driver received in the previous call to [UcmConnectorCreate](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucmconnectorcreate).
+Handle to the connector object that the client driver received in the previous call to [UcmConnectorCreate](./nf-ucmmanager-ucmconnectorcreate.md).
 
 ### -param Success [in]
 
-Used to indicate failure of a data-role swap that was initiated by UcmCx using [EVT_UCM_CONNECTOR_SET_DATA_ROLE](/windows-hardware/drivers/ddi/ucmmanager/nc-ucmmanager-evt_ucm_connector_set_data_role).
+Used to indicate failure of a data-role swap that was initiated by UcmCx using [EVT_UCM_CONNECTOR_SET_DATA_ROLE](./nc-ucmmanager-evt_ucm_connector_set_data_role.md).
 
 If TRUE, the operation was successful. FALSE, otherwise.
 
 ### -param CurrentDataRole [in]
 
-A [UCM_TYPEC_PARTNER](/windows-hardware/drivers/ddi/ucmtypes/ne-ucmtypes-_ucm_typec_partner) value that indicates the new data role.
+A [UCM_TYPEC_PARTNER](../ucmtypes/ne-ucmtypes-_ucm_typec_partner.md) value that indicates the new data role.
 
 ## -remarks
 
@@ -69,10 +69,10 @@ A [UCM_TYPEC_PARTNER](/windows-hardware/drivers/ddi/ucmtypes/ne-ucmtypes-_ucm_ty
 
 If the connector partner is attached, UcmCx updates the data role of the partner depending on the *CurrentDataRole* value. For example, if the client driver changes the data role to **UcmTypeCPortStateUfp**, UcmCx updates the role of the connector partner to **UcmTypeCPortStateDfp**.
 
-UcmCx can change the data role of a connector, and invokes [EVT_UCM_CONNECTOR_SET_DATA_ROLE](/windows-hardware/drivers/ddi/ucmmanager/nc-ucmmanager-evt_ucm_connector_set_data_role). In response to that call, the client should perform the DR_Swap operation, and indicate success/failure of the operation by calling  **UcmConnectorDataDirectionChanged**.
+UcmCx can change the data role of a connector, and invokes [EVT_UCM_CONNECTOR_SET_DATA_ROLE](./nc-ucmmanager-evt_ucm_connector_set_data_role.md). In response to that call, the client should perform the DR_Swap operation, and indicate success/failure of the operation by calling  **UcmConnectorDataDirectionChanged**.
 
 Alternatively, the client driver might choose to perform a role-swap autonomously, or the partner might perform a role-swap. In either case, when the role-swap has completed, the driver must report the new role to UcmCx using **UcmConnectorDataDirectionChanged**.
 
 ## -see-also
 
-- [UcmConnectorCreate](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucmconnectorcreate)
+- [UcmConnectorCreate](./nf-ucmmanager-ucmconnectorcreate.md)

--- a/wdk-ddi-src/content/ucmmanager/nf-ucmmanager-ucmconnectorpowerdirectionchanged.md
+++ b/wdk-ddi-src/content/ucmmanager/nf-ucmmanager-ucmconnectorpowerdirectionchanged.md
@@ -51,17 +51,17 @@ Notifies the USB connector manager framework extension (UcmCx) with the new powe
 
 ### -param Connector [in]
 
-Handle to the connector object that the client driver received in the previous call to [UcmConnectorCreate](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucmconnectorcreate).
+Handle to the connector object that the client driver received in the previous call to [UcmConnectorCreate](./nf-ucmmanager-ucmconnectorcreate.md).
 
 ### -param Success [in]
 
-Used to indicate failure of a power-role swap that was initiated by UcmCx using [EVT_UCM_CONNECTOR_SET_POWER_ROLE](/windows-hardware/drivers/ddi/ucmmanager/nc-ucmmanager-evt_ucm_connector_set_power_role).
+Used to indicate failure of a power-role swap that was initiated by UcmCx using [EVT_UCM_CONNECTOR_SET_POWER_ROLE](./nc-ucmmanager-evt_ucm_connector_set_power_role.md).
 
 If TRUE, the operation was successful. FALSE, otherwise.
 
 ### -param CurrentPowerRole [in]
 
-One of the [UCM_POWER_ROLE](/windows-hardware/drivers/ddi/ucmtypes/ne-ucmtypes-_ucm_power_role)-typed flags that indicates the new data role.
+One of the [UCM_POWER_ROLE](../ucmtypes/ne-ucmtypes-_ucm_power_role.md)-typed flags that indicates the new data role.
 
 ## -remarks
 
@@ -69,10 +69,10 @@ One of the [UCM_POWER_ROLE](/windows-hardware/drivers/ddi/ucmtypes/ne-ucmtypes-_
 
 If the connector partner is attached, UcmCx updates the power role of the partner depending on the *CurrentPowerRole* value.
 
-UcmCx can change the power role of a connector, and invokes [EVT_UCM_CONNECTOR_SET_POWER_ROLE](/windows-hardware/drivers/ddi/ucmmanager/nc-ucmmanager-evt_ucm_connector_set_power_role). In response to that call, the client should perform the PR_Swap operation, and indicate success/failure of the operation by calling  **UcmConnectorPowerDirectionChanged**.
+UcmCx can change the power role of a connector, and invokes [EVT_UCM_CONNECTOR_SET_POWER_ROLE](./nc-ucmmanager-evt_ucm_connector_set_power_role.md). In response to that call, the client should perform the PR_Swap operation, and indicate success/failure of the operation by calling  **UcmConnectorPowerDirectionChanged**.
 
 Alternatively, the client driver might choose to perform a role-swap autonomously, or the partner might perform a role-swap. In either case, when the role-swap has completed, the driver must report the new role to UcmCx using **UcmConnectorPowerDirectionChanged**.
 
 ## -see-also
 
-- [UcmConnectorCreate](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucmconnectorcreate)
+- [UcmConnectorCreate](./nf-ucmmanager-ucmconnectorcreate.md)

--- a/wdk-ddi-src/content/ucmmanager/ns-ucmmanager-_ucm_connector_config.md
+++ b/wdk-ddi-src/content/ucmmanager/ns-ucmmanager-_ucm_connector_config.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Describes the configuration options for a Type-C connector object. An initialized [UCM_MANAGER_CONFIG](/windows-hardware/drivers/ddi/ucmmanager/ns-ucmmanager-_ucm_manager_config) structure is an input parameter value to [UcmInitializeDevice](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucminitializedevice).
+Describes the configuration options for a Type-C connector object. An initialized [UCM_MANAGER_CONFIG](./ns-ucmmanager-_ucm_manager_config.md) structure is an input parameter value to [UcmInitializeDevice](./nf-ucmmanager-ucminitializedevice.md).
 
 ## -struct-fields
 
@@ -64,16 +64,16 @@ Connector identifier.
 
 ### -field TypeCConfig
 
-A pointer to an initialized [UCM_CONNECTOR_TYPEC_CONFIG](/windows-hardware/drivers/ddi/ucmmanager/ns-ucmmanager-_ucm_connector_typec_config) structure that contains the configuration options for the connector.
+A pointer to an initialized [UCM_CONNECTOR_TYPEC_CONFIG](./ns-ucmmanager-_ucm_connector_typec_config.md) structure that contains the configuration options for the connector.
 
 ### -field PdConfig
 
-A pointer to an initialized [UCM_CONNECTOR_PD_CONFIG](/windows-hardware/drivers/ddi/ucmmanager/ns-ucmmanager-_ucm_connector_pd_config) structure that contains the power roles supported by the connector.
+A pointer to an initialized [UCM_CONNECTOR_PD_CONFIG](./ns-ucmmanager-_ucm_connector_pd_config.md) structure that contains the power roles supported by the connector.
 
 ## -remarks
 
-Initialize this structure by calling [UCM_CONNECTOR_CONFIG_INIT](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucm_connector_config_init). An initialized **UCM_CONNECTOR_CONFIG** structure is an input parameter value to [UcmConnectorCreate](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucmconnectorcreate) that is used by the client driver to create a connector object.
+Initialize this structure by calling [UCM_CONNECTOR_CONFIG_INIT](./nf-ucmmanager-ucm_connector_config_init.md). An initialized **UCM_CONNECTOR_CONFIG** structure is an input parameter value to [UcmConnectorCreate](./nf-ucmmanager-ucmconnectorcreate.md) that is used by the client driver to create a connector object.
 
 ## -see-also
 
-- [UcmConnectorCreate](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucmconnectorcreate)
+- [UcmConnectorCreate](./nf-ucmmanager-ucmconnectorcreate.md)

--- a/wdk-ddi-src/content/ucmmanager/ns-ucmmanager-_ucm_connector_typec_attach_params.md
+++ b/wdk-ddi-src/content/ucmmanager/ns-ucmmanager-_ucm_connector_typec_attach_params.md
@@ -60,7 +60,7 @@ Size of the **UCM_CONNECTOR_TYPEC_ATTACH_PARAMS** structure.
 
 ### -field Partner
 
-The type of partner attached to the connector, indicated by a [UCM_TYPEC_PARTNER](/windows-hardware/drivers/ddi/ucmtypes/ne-ucmtypes-_ucm_typec_partner) value.
+The type of partner attached to the connector, indicated by a [UCM_TYPEC_PARTNER](../ucmtypes/ne-ucmtypes-_ucm_typec_partner.md) value.
 
 ### -field CurrentAdvertisement
 
@@ -68,12 +68,12 @@ Power sourcing capabilities of: the partner port when **PortPartnerType** is **U
 
 ### -field ChargingState
 
-Optional. Charging state of the port indicated by one of the [UCM_CHARGING_STATE](/windows-hardware/drivers/ddi/ucmtypes/ne-ucmtypes-_ucm_charging_state)-typed flags.
+Optional. Charging state of the port indicated by one of the [UCM_CHARGING_STATE](../ucmtypes/ne-ucmtypes-_ucm_charging_state.md)-typed flags.
 
 ## -remarks
 
-Initialize this structure by calling [UCM_CONNECTOR_TYPEC_ATTACH_PARAMS_INIT](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucm_connector_typec_attach_params_init). An initialized **UCM_CONNECTOR_TYPEC_ATTACH_PARAMS** structure is an input parameter value to [UcmConnectorTypeCAttach](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucmconnectortypecattach) that is used by the client driver to notify UcmCx about the Attached state of the port.
+Initialize this structure by calling [UCM_CONNECTOR_TYPEC_ATTACH_PARAMS_INIT](./nf-ucmmanager-ucm_connector_typec_attach_params_init.md). An initialized **UCM_CONNECTOR_TYPEC_ATTACH_PARAMS** structure is an input parameter value to [UcmConnectorTypeCAttach](./nf-ucmmanager-ucmconnectortypecattach.md) that is used by the client driver to notify UcmCx about the Attached state of the port.
 
 ## -see-also
 
-- [UcmConnectorTypeCAttach](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucmconnectortypecattach)
+- [UcmConnectorTypeCAttach](./nf-ucmmanager-ucmconnectortypecattach.md)

--- a/wdk-ddi-src/content/ucmtcpciportcontroller/nf-ucmtcpciportcontroller-ucmtcpciportcontrolleralert.md
+++ b/wdk-ddi-src/content/ucmtcpciportcontroller/nf-ucmtcpciportcontroller-ucmtcpciportcontrolleralert.md
@@ -50,11 +50,11 @@ Sends information about the hardware alerts that are received on the port contro
 
 ### -param PortControllerObject [in]
 
-Handle to the port controller object that the client driver received in the previous call to [UcmTcpciPortControllerCreate](/windows-hardware/drivers/ddi/ucmtcpciportcontroller/nf-ucmtcpciportcontroller-ucmtcpciportcontrollercreate).
+Handle to the port controller object that the client driver received in the previous call to [UcmTcpciPortControllerCreate](./nf-ucmtcpciportcontroller-ucmtcpciportcontrollercreate.md).
 
 ### -param AlertData
 
-A pointer to an array of [UCMTCPCI_PORT_CONTROLLER_ALERT_DATA](/windows-hardware/drivers/ddi/ucmtcpciportcontroller/ns-ucmtcpciportcontroller-_ucmtcpci_port_controller_alert_data) that contains all current alerts that have not been sent to UcmTcpciCx. This value cannot be NULL.
+A pointer to an array of [UCMTCPCI_PORT_CONTROLLER_ALERT_DATA](./ns-ucmtcpciportcontroller-_ucmtcpci_port_controller_alert_data.md) that contains all current alerts that have not been sent to UcmTcpciCx. This value cannot be NULL.
 
 ### -param NumberOfAlerts
 
@@ -64,7 +64,7 @@ The number of items in the array pointed to by *AlertData*. This value cannot be
 
 **UcmTcpciPortControllerAlert** returns STATUS_SUCCESS if the operation succeeds. Otherwise, this inline function may return an appropriate [NTSTATUS](/windows-hardware/drivers/kernel/ntstatus-values) error code.
 
-The client driver must call **UcmTcpciPortControllerAlert** that has been previously started by calling [UcmTcpciPortControllerStart](/windows-hardware/drivers/ddi/ucmtcpciportcontroller/nf-ucmtcpciportcontroller-ucmtcpciportcontrollerstart).
+The client driver must call **UcmTcpciPortControllerAlert** that has been previously started by calling [UcmTcpciPortControllerStart](./nf-ucmtcpciportcontroller-ucmtcpciportcontrollerstart.md).
 
 When a hardware alert occurs, the client driver must determine the type of alerts, fetch any auxiliary information associated with that alert, such as a PD message, populate the array, and then call **UcmTcpciPortControllerAlert**.
 

--- a/wdk-ddi-src/content/ucmtypes/ne-ucmtypes-_ucm_typec_partner.md
+++ b/wdk-ddi-src/content/ucmtypes/ne-ucmtypes-_ucm_typec_partner.md
@@ -81,5 +81,5 @@ The partner is a debug accessory.
 
 ## -see-also
 
-- [UCM_CONNECTOR_TYPEC_ATTACH_PARAMS](/windows-hardware/drivers/ddi/ucmmanager/ns-ucmmanager-_ucm_connector_typec_attach_params)
-- [UcmConnectorTypeCAttach](/windows-hardware/drivers/ddi/ucmmanager/nf-ucmmanager-ucmconnectortypecattach)
+- [UCM_CONNECTOR_TYPEC_ATTACH_PARAMS](../ucmmanager/ns-ucmmanager-_ucm_connector_typec_attach_params.md)
+- [UcmConnectorTypeCAttach](../ucmmanager/nf-ucmmanager-ucmconnectortypecattach.md)

--- a/wdk-ddi-src/content/wdfworkitem/nf-wdfworkitem-wdfworkitemflush.md
+++ b/wdk-ddi-src/content/wdfworkitem/nf-wdfworkitem-wdfworkitemflush.md
@@ -63,14 +63,14 @@ A handle to a framework work-item object that is obtained from a previous call t
 
 A bug check occurs if the driver supplies an invalid object handle.
 
-If [**WdfWorkItemEnqueue**](/windows-hardware/drivers/ddi/wdfworkitem/nf-wdfworkitem-wdfworkitemenqueue) has been called and your driver calls the <b>WdfWorkItemFlush</b> method, the method does not return until a system worker thread has removed the specified work item from the work-item queue and called the driver's <a href="/windows-hardware/drivers/ddi/wdfworkitem/nc-wdfworkitem-evt_wdf_workitem">EvtWorkItem</a> callback function, and the <i>EvtWorkItem</i> callback function has subsequently returned after processing the work item.
+If [**WdfWorkItemEnqueue**](./nf-wdfworkitem-wdfworkitemenqueue.md) has been called and your driver calls the <b>WdfWorkItemFlush</b> method, the method does not return until a system worker thread has removed the specified work item from the work-item queue and called the driver's <a href="/windows-hardware/drivers/ddi/wdfworkitem/nc-wdfworkitem-evt_wdf_workitem">EvtWorkItem</a> callback function, and the <i>EvtWorkItem</i> callback function has subsequently returned after processing the work item.
 Note that **WdfWorkItemFlush** does wait for an already running *EvtWorkItem* callback function to complete.
 
 If **WdfWorkItemEnqueue** has not been called, calling **WdfWorkItemFlush** completes immediately.
 
 It is illegal to call **WdfWorkItemFlush** from within the work item callback or from code it calls that runs on the same system worker thread.
 Indeed, if driver verifier is enabled, WDF breaks into the debugger to warn that doing so will lead to deadlock.
-On the other hand, calling [**WdfObjectDelete**](/windows-hardware/drivers/ddi/wdfobject/nf-wdfobject-wdfobjectdelete) on the work item object from within the callback is perfectly fine.
+On the other hand, calling [**WdfObjectDelete**](../wdfobject/nf-wdfobject-wdfobjectdelete.md) on the work item object from within the callback is perfectly fine.
 
 Most drivers that use work items do not need to call <b>WdfWorkItemFlush</b>. A driver might call <b>WdfWorkItemFlush</b> if it must synchronize completion of work items with the removal of a remote I/O target. In this case, the driver can call <b>WdfWorkItemFlush</b> from within its <a href="/windows-hardware/drivers/ddi/wdfiotarget/nc-wdfiotarget-evt_wdf_io_target_query_remove">EvtIoTargetQueryRemove</a> callback function. 
 

--- a/wdk-ddi-src/content/wdm/ns-wdm-_ob_pre_duplicate_handle_information.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-_ob_pre_duplicate_handle_information.md
@@ -51,13 +51,13 @@ api_name:
 
 ## -description
 
-The <b>OB_PRE_DUPLICATE_HANDLE_INFORMATION</b> structure provides information to an [*ObjectPreCallback*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pob_pre_operation_callback) routine about a thread or process handle that is being duplicated.
+The <b>OB_PRE_DUPLICATE_HANDLE_INFORMATION</b> structure provides information to an [*ObjectPreCallback*](./nc-wdm-pob_pre_operation_callback.md) routine about a thread or process handle that is being duplicated.
 
 ## -struct-fields
 
 ### -field DesiredAccess
 
-An <a href="/windows-hardware/drivers/kernel/access-mask">ACCESS_MASK</a> value that specifies the access rights to grant for the handle. By default, this member equals <i>OriginalDesiredAccess</i>, but the [*ObjectPreCallback*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pob_pre_operation_callback) routine can modify this value to restrict the access that is granted. For a description of the access rights that drivers can use, see <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-_ob_pre_create_handle_information">OB_PRE_CREATE_HANDLE_INFORMATION</a>.
+An <a href="/windows-hardware/drivers/kernel/access-mask">ACCESS_MASK</a> value that specifies the access rights to grant for the handle. By default, this member equals <i>OriginalDesiredAccess</i>, but the [*ObjectPreCallback*](./nc-wdm-pob_pre_operation_callback.md) routine can modify this value to restrict the access that is granted. For a description of the access rights that drivers can use, see <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-_ob_pre_create_handle_information">OB_PRE_CREATE_HANDLE_INFORMATION</a>.
 
 ### -field OriginalDesiredAccess
 
@@ -80,5 +80,4 @@ You can never add access rights beyond what is specified in the <b>DesiredAccess
 <a href="/windows-hardware/drivers/kernel/access-mask">ACCESS_MASK</a>
 
 
-[*ObjectPreCallback*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pob_pre_operation_callback)
-
+[*ObjectPreCallback*](./nc-wdm-pob_pre_operation_callback.md)

--- a/wdk-ddi-src/content/wdm/ns-wdm-_pci_express_bridge_aer_capability.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-_pci_express_bridge_aer_capability.md
@@ -57,31 +57,31 @@ The PCI_EXPRESS_BRIDGE_AER_CAPABILITY structure describes a PCI Express (PCIe) a
 
 ### -field Header
 
-A [PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_enhanced_capability_header) structure that describes the header for this structure.
+A [PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](./ns-wdm-_pci_express_enhanced_capability_header.md) structure that describes the header for this structure.
 
 ### -field UncorrectableErrorStatus
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_status) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_uncorrectable_error_status.md) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
 
 ### -field UncorrectableErrorMask
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_mask) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_uncorrectable_error_mask.md) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
 
 ### -field UncorrectableErrorSeverity
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_severity) structure that describes the PCIe uncorrectable error severity register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](./ns-wdm-_pci_express_uncorrectable_error_severity.md) structure that describes the PCIe uncorrectable error severity register of the PCIe AER capability structure.
 
 ### -field CorrectableErrorStatus
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_status) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_uncorrectable_error_status.md) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
 
 ### -field CorrectableErrorMask
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_mask) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_uncorrectable_error_mask.md) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
 
 ### -field CapabilitiesAndControl
 
-A [PCI_EXPRESS_AER_CAPABILITIES](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capabilities) structure that describes the PCIe advanced error capabilities and control register of the PCIe AER capability structure.
+A [PCI_EXPRESS_AER_CAPABILITIES](./ns-wdm-_pci_express_aer_capabilities.md) structure that describes the PCIe advanced error capabilities and control register of the PCIe AER capability structure.
 
 ### -field HeaderLog
 
@@ -92,19 +92,19 @@ An array of four 32-bit values that together contain the header for the transact
 
 ### -field SecUncorrectableErrorStatus
 
-A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_uncorrectable_error_status) structure that describes the PCIe secondary uncorrectable error status register of the PCIe AER capability structure.
+A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_sec_uncorrectable_error_status.md) structure that describes the PCIe secondary uncorrectable error status register of the PCIe AER capability structure.
 
 ### -field SecUncorrectableErrorMask
 
-A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_uncorrectable_error_mask) structure that describes the PCIe secondary uncorrectable error mask register of the PCIe AER capability structure.
+A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_sec_uncorrectable_error_mask.md) structure that describes the PCIe secondary uncorrectable error mask register of the PCIe AER capability structure.
 
 ### -field SecUncorrectableErrorSeverity
 
-A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_uncorrectable_error_severity) structure that describes the PCIe secondary uncorrectable error severity register of the PCIe AER capability structure.
+A [PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY](./ns-wdm-_pci_express_sec_uncorrectable_error_severity.md) structure that describes the PCIe secondary uncorrectable error severity register of the PCIe AER capability structure.
 
 ### -field SecCapabilitiesAndControl
 
-A [PCI_EXPRESS_SEC_AER_CAPABILITIES](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_aer_capabilities) structure that describes the PCIe secondary error capabilities and control register of the PCIe AER capability structure.
+A [PCI_EXPRESS_SEC_AER_CAPABILITIES](./ns-wdm-_pci_express_sec_aer_capabilities.md) structure that describes the PCIe secondary error capabilities and control register of the PCIe AER capability structure.
 
 ### -field SecHeaderLog
 
@@ -134,36 +134,36 @@ typedef struct _PCI_EXPRESS_BRIDGE_AER_CAPABILITY {
 
 The PCI_EXPRESS_BRIDGE_AER_CAPABILITY structure is available in Windows Server 2008 and later versions of Windows.
 
-Root ports and root complex event collectors use the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structure instead of the PCI_EXPRESS_BRIDGE_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
+Root ports and root complex event collectors use the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](./ns-wdm-_pci_express_rootport_aer_capability.md) structure instead of the PCI_EXPRESS_BRIDGE_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
 
-All other PCIe devices and ports that are not bridge devices use the [PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability) structure instead of the PCI_EXPRESS_BRIDGE_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
+All other PCIe devices and ports that are not bridge devices use the [PCI_EXPRESS_AER_CAPABILITY](./ns-wdm-_pci_express_aer_capability.md) structure instead of the PCI_EXPRESS_BRIDGE_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
 
 For additional information about the PCIe advanced error reporting capability structure for PCIe bridge devices, see the [PCI Express Specification](https://pcisig.com/specifications/pciexpress/).
 
 ## -see-also
 
-[PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_uncorrectable_error_status)
+[PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_sec_uncorrectable_error_status.md)
 
-[PCI_EXPRESS_CORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_correctable_error_status)
+[PCI_EXPRESS_CORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_correctable_error_status.md)
 
-[PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_severity)
+[PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](./ns-wdm-_pci_express_uncorrectable_error_severity.md)
 
-[PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_uncorrectable_error_severity)
+[PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY](./ns-wdm-_pci_express_sec_uncorrectable_error_severity.md)
 
-[PCI_EXPRESS_SEC_AER_CAPABILITIES](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_aer_capabilities)
+[PCI_EXPRESS_SEC_AER_CAPABILITIES](./ns-wdm-_pci_express_sec_aer_capabilities.md)
 
-[PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_mask)
+[PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_uncorrectable_error_mask.md)
 
-[PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability)
+[PCI_EXPRESS_AER_CAPABILITY](./ns-wdm-_pci_express_aer_capability.md)
 
-[PCI_EXPRESS_AER_CAPABILITIES](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capabilities)
+[PCI_EXPRESS_AER_CAPABILITIES](./ns-wdm-_pci_express_aer_capabilities.md)
 
-[PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_enhanced_capability_header)
+[PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](./ns-wdm-_pci_express_enhanced_capability_header.md)
 
-[PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_status)
+[PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_uncorrectable_error_status.md)
 
-[PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_sec_uncorrectable_error_mask)
+[PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_sec_uncorrectable_error_mask.md)
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](./ns-wdm-_pci_express_rootport_aer_capability.md)
 
-[PCI_EXPRESS_CORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_correctable_error_mask)
+[PCI_EXPRESS_CORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_correctable_error_mask.md)

--- a/wdk-ddi-src/content/wdm/ns-wdm-_pci_express_rootport_aer_capability.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-_pci_express_rootport_aer_capability.md
@@ -57,31 +57,31 @@ The PCI_EXPRESS_ROOTPORT_AER_CAPABILITY structure describes a PCI Express (PCIe)
 
 ### -field Header
 
-A [PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_enhanced_capability_header) structure that describes the header for this structure.
+A [PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](./ns-wdm-_pci_express_enhanced_capability_header.md) structure that describes the header for this structure.
 
 ### -field UncorrectableErrorStatus
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_status) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_uncorrectable_error_status.md) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
 
 ### -field UncorrectableErrorMask
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_mask) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_uncorrectable_error_mask.md) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
 
 ### -field UncorrectableErrorSeverity
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_severity) structure that describes the PCIe uncorrectable error severity register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](./ns-wdm-_pci_express_uncorrectable_error_severity.md) structure that describes the PCIe uncorrectable error severity register of the PCIe AER capability structure.
 
 ### -field CorrectableErrorStatus
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_status) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_uncorrectable_error_status.md) structure that describes the PCIe uncorrectable error status register of the PCIe AER capability structure.
 
 ### -field CorrectableErrorMask
 
-A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_mask) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
+A [PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_uncorrectable_error_mask.md) structure that describes the PCIe uncorrectable error mask register of the PCIe AER capability structure.
 
 ### -field CapabilitiesAndControl
 
-A [PCI_EXPRESS_AER_CAPABILITIES](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capabilities) structure that describes the PCIe advanced error capabilities and control register of the PCIe AER capability structure.
+A [PCI_EXPRESS_AER_CAPABILITIES](./ns-wdm-_pci_express_aer_capabilities.md) structure that describes the PCIe advanced error capabilities and control register of the PCIe AER capability structure.
 
 ### -field HeaderLog
 
@@ -92,15 +92,15 @@ An array of four 32-bit values that together contain the header for the transact
 
 ### -field RootErrorCommand
 
-A [PCI_EXPRESS_ROOT_ERROR_COMMAND](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_root_error_command) structure that describes the PCIe root error command register of the PCIe AER capability structure.
+A [PCI_EXPRESS_ROOT_ERROR_COMMAND](./ns-wdm-_pci_express_root_error_command.md) structure that describes the PCIe root error command register of the PCIe AER capability structure.
 
 ### -field RootErrorStatus
 
-A [PCI_EXPRESS_ROOT_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_root_error_status) structure that describes the PCIe root error status register of the PCIe AER capability structure.
+A [PCI_EXPRESS_ROOT_ERROR_STATUS](./ns-wdm-_pci_express_root_error_status.md) structure that describes the PCIe root error status register of the PCIe AER capability structure.
 
 ### -field ErrorSourceId
 
-A [PCI_EXPRESS_ERROR_SOURCE_ID](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_error_source_id) structure that describes the PCIe error source identification register of the PCIe AER capability structure.
+A [PCI_EXPRESS_ERROR_SOURCE_ID](./ns-wdm-_pci_express_error_source_id.md) structure that describes the PCIe error source identification register of the PCIe AER capability structure.
 
 ## -syntax
 
@@ -124,34 +124,34 @@ typedef struct _PCI_EXPRESS_ROOTPORT_AER_CAPABILITY {
 
 The PCI_EXPRESS_ROOTPORT_AER_CAPABILITY structure is available in Windows Server 2008 and later versions of Windows.
 
-PCIe bridge devices use the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability) structure instead of the PCI_EXPRESS_ROOTPORT_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
+PCIe bridge devices use the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](./ns-wdm-_pci_express_bridge_aer_capability.md) structure instead of the PCI_EXPRESS_ROOTPORT_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
 
-All other PCIe devices and ports that are not root ports or root complex event collectors use the [PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability) structure instead of the PCI_EXPRESS_ROOTPORT_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
+All other PCIe devices and ports that are not root ports or root complex event collectors use the [PCI_EXPRESS_AER_CAPABILITY](./ns-wdm-_pci_express_aer_capability.md) structure instead of the PCI_EXPRESS_ROOTPORT_AER_CAPABILITY structure to describe the PCIe advanced error reporting capability structure.
 
 For additional information about the PCIe advanced error reporting capability structure, see the [PCI Express Specification](https://pcisig.com/specifications/pciexpress/).
 
 ## -see-also
 
-[PCI_EXPRESS_CORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_correctable_error_status)
+[PCI_EXPRESS_CORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_correctable_error_status.md)
 
-[PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_severity)
+[PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY](./ns-wdm-_pci_express_uncorrectable_error_severity.md)
 
-[PCI_EXPRESS_ROOT_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_root_error_status)
+[PCI_EXPRESS_ROOT_ERROR_STATUS](./ns-wdm-_pci_express_root_error_status.md)
 
-[PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_mask)
+[PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_uncorrectable_error_mask.md)
 
-[PCI_EXPRESS_ROOT_ERROR_COMMAND](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_root_error_command)
+[PCI_EXPRESS_ROOT_ERROR_COMMAND](./ns-wdm-_pci_express_root_error_command.md)
 
-[PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability)
+[PCI_EXPRESS_AER_CAPABILITY](./ns-wdm-_pci_express_aer_capability.md)
 
-[PCI_EXPRESS_AER_CAPABILITIES](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capabilities)
+[PCI_EXPRESS_AER_CAPABILITIES](./ns-wdm-_pci_express_aer_capabilities.md)
 
-[PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_enhanced_capability_header)
+[PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER](./ns-wdm-_pci_express_enhanced_capability_header.md)
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](./ns-wdm-_pci_express_bridge_aer_capability.md)
 
-[PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_uncorrectable_error_status)
+[PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS](./ns-wdm-_pci_express_uncorrectable_error_status.md)
 
-[PCI_EXPRESS_ERROR_SOURCE_ID](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_error_source_id)
+[PCI_EXPRESS_ERROR_SOURCE_ID](./ns-wdm-_pci_express_error_source_id.md)
 
-[PCI_EXPRESS_CORRECTABLE_ERROR_MASK](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_correctable_error_mask)
+[PCI_EXPRESS_CORRECTABLE_ERROR_MASK](./ns-wdm-_pci_express_correctable_error_mask.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 