### PR TITLE
Fixed a small Typo on NtCreateSectionEx document

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatesectionex.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatesectionex.md
@@ -103,7 +103,7 @@ The size of the _ExtendedParameters_ array.
 
 ## -returns
 
-eturns STATUS_SUCCESS on success, or the appropriate NTSTATUS error code on failure. Possible error status codes include the following:
+Returns STATUS_SUCCESS on success, or the appropriate NTSTATUS error code on failure. Possible error status codes include the following:
 
 <table>
 <tr>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/9837449/152714903-99384810-1611-49c5-a81e-cc1569fdec41.png)
**Before**

![image](https://user-images.githubusercontent.com/9837449/152714962-c56c3fbc-a02f-4ad6-b65d-e6e83c3520c5.png)
**After**

Replaced "eturns" in to "Returns" on NtCreateSectionEx document.

This is the fix that I have mentioned at #1257.

