### PR TITLE
Updating warning to use warning syntax

### DIFF
--- a/wdk-ddi-src/content/ntddk/nc-ntddk-pcreate_process_notify_routine_ex.md
+++ b/wdk-ddi-src/content/ntddk/nc-ntddk-pcreate_process_notify_routine_ex.md
@@ -46,7 +46,9 @@ api_name:
 ## -description
 
 A callback routine implemented by a driver to notify the caller when a process is created or exits.
-<div class="alert"><b>Warning</b>  The actions that  you can perform in this routine are restricted for safe calls. See <a href="/windows-hardware/drivers/kernel/windows-kernel-mode-process-and-thread-manager#best">Best Practices</a>. </div><div> </div>
+
+> [!WARNING]
+> The actions that  you can perform in this routine are restricted for safe calls. See <a href="/windows-hardware/drivers/kernel/windows-kernel-mode-process-and-thread-manager#best">Best Practices
 
 ## -parameters
 


### PR DESCRIPTION
Warning was wrapped in "alert" instead of using the actual WARNING wrapper