### PR TITLE
LinkFix: windows-driver-docs-ddi (2022-03)

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltqueuedeferredioworkitem.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltqueuedeferredioworkitem.md
@@ -109,7 +109,7 @@ The operation must be an IRP-based I/O operation. To determine whether a given c
 
 * **FltQueueDeferredIoWorkItem** cannot post a paging I/O operation to a worker thread.
 
-* **FltQueueDeferredIoWorkItem** cannot post an I/O operation to a worker thread if the **TopLevelIrp** field of the current thread is not **NULL**, because the resulting file system recursion could cause deadlocks or stack overflows. For more information, see [**IoGetTopLevelIrp**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-iogettoplevelirp).
+* **FltQueueDeferredIoWorkItem** cannot post an I/O operation to a worker thread if the **TopLevelIrp** field of the current thread is not **NULL**, because the resulting file system recursion could cause deadlocks or stack overflows. For more information, see [**IoGetTopLevelIrp**](../ntifs/nf-ntifs-iogettoplevelirp.md).
 
 A minifilter driver can use **FltQueueDeferredIoWorkItem** in a preoperation callback ([**PFLT_PRE_OPERATION_CALLBACK**](nc-fltkernel-pflt_pre_operation_callback.md)) routine as follows:
 
@@ -149,7 +149,7 @@ The work routine calls [**FltFreeDeferredIoWorkItem**](nf-fltkernel-fltfreedefer
 
 [**FltFreeDeferredIoWorkItem**](nf-fltkernel-fltfreedeferredioworkitem.md)
 
-[**IoGetTopLevelIrp**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-iogettoplevelirp)
+[**IoGetTopLevelIrp**](../ntifs/nf-ntifs-iogettoplevelirp.md)
 
 [**PFLT_POST_OPERATION_CALLBACK**](nc-fltkernel-pflt_post_operation_callback.md)
 

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-pssetcreatethreadnotifyroutineex.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-pssetcreatethreadnotifyroutineex.md
@@ -57,7 +57,7 @@ A <a href="/windows-hardware/drivers/ddi/ntddk/ne-ntddk-_pscreatethreadnotifytyp
 ### -param NotifyInformation [in]
 
 Provides the address of the notification information for the specified type of thread notification.
-If **NotifyType** is **PsCreateThreadNotifyNonSystem** or **PsCreateThreadNotifySubsystems** then **NotifyInformation** should be a pointer to the driver's implementation of [PCREATE_THREAD_NOTIFY_ROUTINE](/windows-hardware/drivers/ddi/ntddk/nc-ntddk-pcreate_thread_notify_routine).
+If **NotifyType** is **PsCreateThreadNotifyNonSystem** or **PsCreateThreadNotifySubsystems** then **NotifyInformation** should be a pointer to the driver's implementation of [PCREATE_THREAD_NOTIFY_ROUTINE](./nc-ntddk-pcreate_thread_notify_routine.md).
 
 ## -returns
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-obopenobjectbypointer.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-obopenobjectbypointer.md
@@ -65,7 +65,7 @@ Bitmask of flags specifying the desired attributes for the object handle. If the
 
 ### -param PassedAccessState [in, optional]
 
-Pointer to an [**ACCESS_STATE**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_access_state) structure containing the object's subject context, granted access types, and remaining desired access types. This parameter is optional and can be NULL. In a create dispatch routine, this pointer can be found in **IrpSp->Parameters.Create.SecurityContext->AccessState**, where **IrpSp** is a pointer to the caller's own stack location in the IRP. (For more information, see [**IRP_MJ_CREATE**](/windows-hardware/drivers/ifs/irp-mj-create).)
+Pointer to an [**ACCESS_STATE**](../wdm/ns-wdm-_access_state.md) structure containing the object's subject context, granted access types, and remaining desired access types. This parameter is optional and can be NULL. In a create dispatch routine, this pointer can be found in **IrpSp->Parameters.Create.SecurityContext->AccessState**, where **IrpSp** is a pointer to the caller's own stack location in the IRP. (For more information, see [**IRP_MJ_CREATE**](/windows-hardware/drivers/ifs/irp-mj-create).)
 
 ### -param DesiredAccess [in]
 
@@ -109,7 +109,7 @@ Pointer to a caller-allocated variable that receives a handle to the object.
 
 If the **Object** parameter points to a file object (that is, a FILE_OBJECT structure), **ObOpenObjectByPointer** can only be called after at least one handle has been created for the file object. Callers can check the **Flags** member of the FILE_OBJECT structure that the **Object** parameter points to. If the FO_HANDLE_CREATED flag is set, this means that one or more handles have been created for the file object, so it is safe to call **ObOpenObjectByPointer**.
 
-Any handle obtained by calling **ObOpenObjectByPointer** must eventually be released by calling [**ZwClose**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntclose).
+Any handle obtained by calling **ObOpenObjectByPointer** must eventually be released by calling [**ZwClose**](./nf-ntifs-ntclose.md).
 
 Driver routines that run in a process context other than that of the system process must set the OBJ_KERNEL_HANDLE flag in the **HandleAttributes** parameter. This restricts the use of the handle returned by **ObOpenObjectByPointer** to processes running in kernel mode. Otherwise, the handle can be accessed by the process in whose context the driver is running.
 
@@ -117,14 +117,14 @@ Driver routines that run in a process context other than that of the system proc
 
 [**ACCESS_MASK**](/windows-hardware/drivers/kernel/access-mask)
 
-[**ACCESS_STATE**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_access_state)
+[**ACCESS_STATE**](../wdm/ns-wdm-_access_state.md)
 
 [**IRP_MJ_CREATE**](/windows-hardware/drivers/ifs/irp-mj-create)
 
-[**ObReferenceObject**](/windows-hardware/drivers/ddi/wdm/nf-wdm-obfreferenceobject)
+[**ObReferenceObject**](../wdm/nf-wdm-obfreferenceobject.md)
 
-[**ObReferenceObjectByHandle**](/windows-hardware/drivers/ddi/wdm/nf-wdm-obreferenceobjectbyhandle)
+[**ObReferenceObjectByHandle**](../wdm/nf-wdm-obreferenceobjectbyhandle.md)
 
-[**ObReferenceObjectByPointer**](/windows-hardware/drivers/ddi/wdm/nf-wdm-obreferenceobjectbypointer)
+[**ObReferenceObjectByPointer**](../wdm/nf-wdm-obreferenceobjectbypointer.md)
 
-[**ZwClose**](/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ntclose)
+[**ZwClose**](./nf-ntifs-ntclose.md)

--- a/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_isochurballocate.md
+++ b/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_isochurballocate.md
@@ -75,6 +75,6 @@ Possible values include, but are not limited to, STATUS_INVALID_PARAMETER, which
 ## -see-also
 
 - [Allocating and Building URBs](/windows-hardware/drivers/usbcon/how-to-add-xrb-support-for-client-drivers)
-- [How to Transfer Data to USB Isochronous Endpoints](/windows-hardware/drivers/ddi/index)
+- [How to Transfer Data to USB Isochronous Endpoints](../index.yml)
 - [USBD_ISO_PACKET_DESCRIPTOR](../usb/ns-usb-_usbd_iso_packet_descriptor.md)
 - [_URB_ISOCH_TRANSFER](../usb/ns-usb-_urb_isoch_transfer.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 