### PR TITLE
"In bytes" phrase should emphasized.

### DIFF
--- a/wdk-ddi-src/content/ntifs/ns-ntifs-_file_id_both_dir_information.md
+++ b/wdk-ddi-src/content/ntifs/ns-ntifs-_file_id_both_dir_information.md
@@ -105,7 +105,7 @@ File attributes, which can be any valid combination of the following:
 
 ### -field FileNameLength
 
-Specifies the length of the file name string.
+Specifies the length, in bytes, of the file name string.
 
 ### -field EaSize
 


### PR DESCRIPTION
FileNameLength parameter could be confused with "length in character count". In bytes phrase should be added to avoid the misunderstanding