### PR TITLE
LinkFix: windows-driver-docs-ddi (2022-04)

### DIFF
--- a/wdk-ddi-src/content/_netvista/index.md
+++ b/wdk-ddi-src/content/_netvista/index.md
@@ -132,7 +132,7 @@ Header files that support NetAdapterCx include the following:
 - [Netadapteroffload.h](../netadapteroffload/index.md)
 - [Netadapterpacket.h](../netadapterpacket/index.md)
 - [Netconfiguration.h](../netconfiguration/index.md)
-- [Netdatapathdescriptor.h](../netdatapathdescriptor/index.md)
+- [Netdatapathdescriptor.h](../ringcollection/index.md)
 - [Netdevice.h](../netdevice/index.md)
 - [Netpacketqueue.h](../netpacketqueue/index.md)
 - [Netpoweroffload.h](../netpoweroffload/index.md)

--- a/wdk-ddi-src/content/compstui/nc-compstui-_cpsuicallback.md
+++ b/wdk-ddi-src/content/compstui/nc-compstui-_cpsuicallback.md
@@ -47,7 +47,7 @@ The **_CPSUICALLBACK** function type is used by CPSUI applications (including pr
 
 ### -param pCPSUICBParam
 
-CPSUI-supplied pointer to a [CPSUICBPARAM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_cpsuicbparam) structure.
+CPSUI-supplied pointer to a [CPSUICBPARAM](./ns-compstui-_cpsuicbparam.md) structure.
 
 ## -returns
 
@@ -55,20 +55,20 @@ A _CPSUICALLBACK-typed callback function must return one of the values listed in
 
 | Return code | Description |
 |--|--|
-| **CPSUICB_ACTION_ITEMS_APPLIED** | The [CPSUICBPARAM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_cpsuicbparam) structure's **Reason** member was set to CPSUICB_REASON_APPLYNOW, and the callback function has successfully processed the current option values. |
-| **CPSUICB_ACTION_NO_APPLY_EXIT** | The [CPSUICBPARAM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_cpsuicbparam) structure's **Reason** member was set to CPSUICB_REASON_APPLYNOW, but the callback function has detected invalid or incompatible option values. The callback function must display a dialog box telling the user of the problem. |
+| **CPSUICB_ACTION_ITEMS_APPLIED** | The [CPSUICBPARAM](./ns-compstui-_cpsuicbparam.md) structure's **Reason** member was set to CPSUICB_REASON_APPLYNOW, and the callback function has successfully processed the current option values. |
+| **CPSUICB_ACTION_NO_APPLY_EXIT** | The [CPSUICBPARAM](./ns-compstui-_cpsuicbparam.md) structure's **Reason** member was set to CPSUICB_REASON_APPLYNOW, but the callback function has detected invalid or incompatible option values. The callback function must display a dialog box telling the user of the problem. |
 | **CPSUICB_ACTION_NONE** | No action by CPSUI is required. |
-| **CPSUICB_ACTION_OPTIF_CHANGED** | The callback function has set the OPTIF_CHANGED flag in an [OPTITEM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure to indicate that the selected option has changed, or that another OPTIF-prefixed flag has changed. |
-| **CPSUICB_ACTION_REINIT_ITEMS** | The callback function has set the OPTIF_CHANGED flag in an [OPTITEM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure to indicate that **Flags** or **pData** members of the associated [OPTTYPE](/windows-hardware/drivers/ddi/compstui/ns-compstui-_opttype) or [OPTPARAM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optparam) structure have changed. |
+| **CPSUICB_ACTION_OPTIF_CHANGED** | The callback function has set the OPTIF_CHANGED flag in an [OPTITEM](./ns-compstui-_optitem.md) structure to indicate that the selected option has changed, or that another OPTIF-prefixed flag has changed. |
+| **CPSUICB_ACTION_REINIT_ITEMS** | The callback function has set the OPTIF_CHANGED flag in an [OPTITEM](./ns-compstui-_optitem.md) structure to indicate that **Flags** or **pData** members of the associated [OPTTYPE](./ns-compstui-_opttype.md) or [OPTPARAM](./ns-compstui-_optparam.md) structure have changed. |
 
 ## -remarks
 
 Callback functions specified using the _CPSUICALLBACK function type are supplied by applications that use [CPSUI](/windows-hardware/drivers/print/common-property-sheet-user-interface) to manage property sheet pages. If one of these callback functions is associated with a property sheet page, CPSUI calls it when user activity (such as changing the page's control focus, modifying option values, or clicking **OK**) is detected.
 
-A _CPSUICALLBACK-typed callback function is assigned to a property sheet page by including its address in a [COMPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure, which is passed to CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function when the function code is [CPSFUNC_ADD_PCOMPROPSHEETUI](/previous-versions/ff546388(v=vs.85)).
+A _CPSUICALLBACK-typed callback function is assigned to a property sheet page by including its address in a [COMPROPSHEETUI](./ns-compstui-_compropsheetui.md) structure, which is passed to CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function when the function code is [CPSFUNC_ADD_PCOMPROPSHEETUI](/previous-versions/ff546388(v=vs.85)).
 
-Additionally, callback functions can be assigned to extended push buttons through the use of [EXTPUSH](/windows-hardware/drivers/ddi/compstui/ns-compstui-_extpush) structures.
+Additionally, callback functions can be assigned to extended push buttons through the use of [EXTPUSH](./ns-compstui-_extpush.md) structures.
 
-When one of these callback functions is called, it receives a pointer to a [CPSUICBPARAM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_cpsuicbparam) structure. This structure describes the current option settings for the page and indicates the user event that caused the function to be called. The callback function is responsible for validating and processing the settings. It should display a dialog box if a setting (or a combination of settings) is invalid. The function's return value indicates to CPSUI whether the page needs to be redisplayed or reinitialized.
+When one of these callback functions is called, it receives a pointer to a [CPSUICBPARAM](./ns-compstui-_cpsuicbparam.md) structure. This structure describes the current option settings for the page and indicates the user event that caused the function to be called. The callback function is responsible for validating and processing the settings. It should display a dialog box if a setting (or a combination of settings) is invalid. The function's return value indicates to CPSUI whether the page needs to be redisplayed or reinitialized.
 
-Callback functions specified with this function type cannot be used if the **DlgProc** member of the [DLGPAGE](/windows-hardware/drivers/ddi/compstui/ns-compstui-_dlgpage) structure specifies an application-supplied dialog box procedure. This is because _CPSUICALLBACK-typed callbacks are called from CPSUI's dialog box procedures, which are not used if the application supplies its own procedures.
+Callback functions specified with this function type cannot be used if the **DlgProc** member of the [DLGPAGE](./ns-compstui-_dlgpage.md) structure specifies an application-supplied dialog box procedure. This is because _CPSUICALLBACK-typed callbacks are called from CPSUI's dialog box procedures, which are not used if the application supplies its own procedures.

--- a/wdk-ddi-src/content/compstui/ns-compstui-_extpush.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_extpush.md
@@ -86,7 +86,7 @@ If this pointer is supplied, EPF_PUSH_TYPE_DLGPROC must be set in **Flags**.
 
 ### -field DUMMYUNIONNAME.pfnCallBack
 
-Pointer to a [_CPSUICALLBACK](/windows-hardware/drivers/ddi/compstui/nc-compstui-_cpsuicallback)-typed callback function to handle the CPSUICB_REASON_PUSHBUTTON reason. For more information, see the following Remarks section.
+Pointer to a [_CPSUICALLBACK](./nc-compstui-_cpsuicallback.md)-typed callback function to handle the CPSUICB_REASON_PUSHBUTTON reason. For more information, see the following Remarks section.
 
 If this pointer is supplied, EPF_PUSH_TYPE_DLGPROC must be cleared in **Flags**.
 
@@ -124,7 +124,7 @@ Reserved, must be initialized to zero.
 
 ## -remarks
 
-An extended push button is a CPSUI-defined type of push button that can be associated with an [OPTITEM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure. An OPTITEM structure can have one extended push button or one extended check box associated with it.
+An extended push button is a CPSUI-defined type of push button that can be associated with an [OPTITEM](./ns-compstui-_optitem.md) structure. An OPTITEM structure can have one extended push button or one extended check box associated with it.
 
 When you use the EXTPUSH structure to create a push button, you can optionally create an additional dialog box that opens when the user clicks on the button. To create this dialog box, you should specify a pointer to a dialog box procedure in the **DlgProc** member, and include a dialog template specification in either the **DlgTemplateID** or the **hDlgTemplate** member.
 
@@ -132,10 +132,10 @@ If EPF_USE_HDLGTEMPLATE is set in **Flags**, CPSUI creates the dialog box by cal
 
 If EPF_USE_HDLGTEMPLATE is not set in **Flags**, CPSUI creates the dialog box by calling [*DialogBoxParam*](/windows/win32/api/winuser/nf-winuser-dialogboxparama), passing the contents of the **DlgProc** and **DlgTemplateID** members.
 
-When the dialog box procedure is called with a *uMsg* value of WM_INITDIALOG, the *lParam* value is the address of a [CPSUICBPARAM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_cpsuicbparam) structure, with the **Reason** member set to CPSUICB_REASON_EXTPUSH. (For more information about the *uMsg* and *lParam* parameters, see *DialogProc* in the Windows SDK documentation.)
+When the dialog box procedure is called with a *uMsg* value of WM_INITDIALOG, the *lParam* value is the address of a [CPSUICBPARAM](./ns-compstui-_cpsuicbparam.md) structure, with the **Reason** member set to CPSUICB_REASON_EXTPUSH. (For more information about the *uMsg* and *lParam* parameters, see *DialogProc* in the Windows SDK documentation.)
 
-If you do not need CPSUI to display a dialog box when the user clicks on the button, you can specify the address of a [_CPSUICALLBACK](/windows-hardware/drivers/ddi/compstui/nc-compstui-_cpsuicallback)-typed callback function in the **pfnCallBack** member. When a user clicks on the button, CPSUI calls the callback function. The accompanying CPSUICBPARAM structure's **Reason** member will be set to CPSUICB_REASON_EXTPUSH.
+If you do not need CPSUI to display a dialog box when the user clicks on the button, you can specify the address of a [_CPSUICALLBACK](./nc-compstui-_cpsuicallback.md)-typed callback function in the **pfnCallBack** member. When a user clicks on the button, CPSUI calls the callback function. The accompanying CPSUICBPARAM structure's **Reason** member will be set to CPSUICB_REASON_EXTPUSH.
 
 ## -see-also
 
-[EXTCHKBOX](/windows-hardware/drivers/ddi/compstui/ns-compstui-_extchkbox)
+[EXTCHKBOX](./ns-compstui-_extchkbox.md)

--- a/wdk-ddi-src/content/filterpipeline/nf-filterpipeline-iprintpipelinefilter-initializefilter.md
+++ b/wdk-ddi-src/content/filterpipeline/nf-filterpipeline-iprintpipelinefilter-initializefilter.md
@@ -47,15 +47,15 @@ The **InitializeFilter** method initializes a filter.
 
 ### -param pINegotiation [in]
 
-A pointer to the [IInterFilterCommunicator](/windows-hardware/drivers/ddi/filterpipeline/nn-filterpipeline-iinterfiltercommunicator) interface.
+A pointer to the [IInterFilterCommunicator](./nn-filterpipeline-iinterfiltercommunicator.md) interface.
 
 ### -param pIPropertyBag [in]
 
-A pointer to the [IPrintPipelinePropertyBag](/windows-hardware/drivers/ddi/filterpipeline/nn-filterpipeline-iprintpipelinepropertybag) interface.
+A pointer to the [IPrintPipelinePropertyBag](./nn-filterpipeline-iprintpipelinepropertybag.md) interface.
 
 ### -param pIPipelineControl [in]
 
-A pointer to the [IPrintPipelineManagerControl](/windows-hardware/drivers/ddi/filterpipeline/nn-filterpipeline-iprintpipelinemanagercontrol) interface.
+A pointer to the [IPrintPipelineManagerControl](./nn-filterpipeline-iprintpipelinemanagercontrol.md) interface.
 
 ## -returns
 
@@ -71,10 +71,10 @@ When the **InitializeFilter** method is called, the filters should:
 
 ## -see-also
 
-[IInterFilterCommunicator](/windows-hardware/drivers/ddi/filterpipeline/nn-filterpipeline-iinterfiltercommunicator)
+[IInterFilterCommunicator](./nn-filterpipeline-iinterfiltercommunicator.md)
 
-[IPrintPipelineFilter](/windows-hardware/drivers/ddi/filterpipeline/nn-filterpipeline-iprintpipelinefilter)
+[IPrintPipelineFilter](./nn-filterpipeline-iprintpipelinefilter.md)
 
-[IPrintPipelineManagerControl](/windows-hardware/drivers/ddi/filterpipeline/nn-filterpipeline-iprintpipelinemanagercontrol)
+[IPrintPipelineManagerControl](./nn-filterpipeline-iprintpipelinemanagercontrol.md)
 
-[IPrintPipelinePropertyBag](/windows-hardware/drivers/ddi/filterpipeline/nn-filterpipeline-iprintpipelinepropertybag)
+[IPrintPipelinePropertyBag](./nn-filterpipeline-iprintpipelinepropertybag.md)

--- a/wdk-ddi-src/content/ksproxy/nf-ksproxy-iksdatatypehandler-kssetmediatype.md
+++ b/wdk-ddi-src/content/ksproxy/nf-ksproxy-iksdatatypehandler-kssetmediatype.md
@@ -59,4 +59,4 @@ Clients can call **KsSetMediaType** of a single data type handler to initialize 
 
 ## -see-also
 
-[IKsDataTypeHandler](/windows-hardware/drivers/ddi/ksproxy/nn-ksproxy-iksdatatypehandler)
+[IKsDataTypeHandler](./nn-ksproxy-iksdatatypehandler.md)

--- a/wdk-ddi-src/content/pointofservicecommontypes/ne-pointofservicecommontypes-_posdevicetype.md
+++ b/wdk-ddi-src/content/pointofservicecommontypes/ne-pointofservicecommontypes-_posdevicetype.md
@@ -44,7 +44,7 @@ api_name:
 
 ## -description
 
-This enumeration defines values used in the [PosDeviceBasicsType](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ns-pointofservicedriverinterface-_posdevicebasicstype) structure to indicate the type of device (for instance, barcode scanner or magnetic stripe reader).
+This enumeration defines values used in the [PosDeviceBasicsType](../pointofservicedriverinterface/ns-pointofservicedriverinterface-_posdevicebasicstype.md) structure to indicate the type of device (for instance, barcode scanner or magnetic stripe reader).
 
 ## -enum-fields
 

--- a/wdk-ddi-src/content/pointofservicedriverinterface/ne-pointofservicedriverinterface-_posdevicecontroltype.md
+++ b/wdk-ddi-src/content/pointofservicedriverinterface/ne-pointofservicedriverinterface-_posdevicecontroltype.md
@@ -58,43 +58,43 @@ The event code is not valid.
 
 ### -field GetProperty
 
-Represents [IOCTL_POINT_OF_SERVICE_GET_PROPERTY](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_get_property).
+Represents [IOCTL_POINT_OF_SERVICE_GET_PROPERTY](./ni-pointofservicedriverinterface-ioctl_point_of_service_get_property.md).
 
 ### -field SetProperty
 
-Represents [IOCTL_POINT_OF_SERVICE_SET_PROPERTY](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_set_property).
+Represents [IOCTL_POINT_OF_SERVICE_SET_PROPERTY](./ni-pointofservicedriverinterface-ioctl_point_of_service_set_property.md).
 
 ### -field ClaimDevice
 
-Represents [IOCTL_POINT_OF_SERVICE_CLAIM_DEVICE](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_claim_device).
+Represents [IOCTL_POINT_OF_SERVICE_CLAIM_DEVICE](./ni-pointofservicedriverinterface-ioctl_point_of_service_claim_device.md).
 
 ### -field ReleaseDevice
 
-Represents [IOCTL_POINT_OF_SERVICE_RELEASE_DEVICE](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_release_device).
+Represents [IOCTL_POINT_OF_SERVICE_RELEASE_DEVICE](./ni-pointofservicedriverinterface-ioctl_point_of_service_release_device.md).
 
 ### -field RetainDevice
 
-Represents [IOCTL_POINT_OF_SERVICE_RETAIN_DEVICE](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_retain_device).
+Represents [IOCTL_POINT_OF_SERVICE_RETAIN_DEVICE](./ni-pointofservicedriverinterface-ioctl_point_of_service_retain_device.md).
 
 ### -field RetrieveStatistics
 
-Represents [IOCTL_POINT_OF_SERVICE_RETRIEVE_STATISTICS](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_retrieve_statistics).
+Represents [IOCTL_POINT_OF_SERVICE_RETRIEVE_STATISTICS](./ni-pointofservicedriverinterface-ioctl_point_of_service_retrieve_statistics.md).
 
 ### -field ResetStatistics
 
-Represents [IOCTL_POINT_OF_SERVICE_RESET_STATISTICS](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_reset_statistics).
+Represents [IOCTL_POINT_OF_SERVICE_RESET_STATISTICS](./ni-pointofservicedriverinterface-ioctl_point_of_service_reset_statistics.md).
 
 ### -field UpdateStatistics
 
-Represents [IOCTL_POINT_OF_SERVICE_UPDATE_STATISTICS](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_update_statistics).
+Represents [IOCTL_POINT_OF_SERVICE_UPDATE_STATISTICS](./ni-pointofservicedriverinterface-ioctl_point_of_service_update_statistics.md).
 
 ### -field CheckHealth
 
-Represents [IOCTL_POINT_OF_SERVICE_CHECK_HEALTH](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_check_health).
+Represents [IOCTL_POINT_OF_SERVICE_CHECK_HEALTH](./ni-pointofservicedriverinterface-ioctl_point_of_service_check_health.md).
 
 ### -field GetDeviceBasics
 
-Represents [IOCTL_POINT_OF_SERVICE_GET_DEVICE_BASICS](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_get_device_basics).
+Represents [IOCTL_POINT_OF_SERVICE_GET_DEVICE_BASICS](./ni-pointofservicedriverinterface-ioctl_point_of_service_get_device_basics.md).
 
 ### -field BarcodeScannerInjectEvent
 
@@ -102,19 +102,19 @@ Defines the **BarcodeScannerInjectEvent** constant.
 
 ### -field MsrRetrieveDeviceAuthentication
 
-Represents [IOCTL_POINT_OF_SERVICE_MSR_RETRIEVE_DEVICE_AUTHENTICATION](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_msr_retrieve_device_authentication).
+Represents [IOCTL_POINT_OF_SERVICE_MSR_RETRIEVE_DEVICE_AUTHENTICATION](./ni-pointofservicedriverinterface-ioctl_point_of_service_msr_retrieve_device_authentication.md).
 
 ### -field MsrAuthenticateDevice
 
-Represents [IOCTL_POINT_OF_SERVICE_MSR_AUTHENTICATE_DEVICE](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_msr_authenticate_device).
+Represents [IOCTL_POINT_OF_SERVICE_MSR_AUTHENTICATE_DEVICE](./ni-pointofservicedriverinterface-ioctl_point_of_service_msr_authenticate_device.md).
 
 ### -field MsrDeAuthenticateDevice
 
-Represents [IOCTL_POINT_OF_SERVICE_MSR_DEAUTHENTICATE_DEVICE](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_msr_deauthenticate_device).
+Represents [IOCTL_POINT_OF_SERVICE_MSR_DEAUTHENTICATE_DEVICE](./ni-pointofservicedriverinterface-ioctl_point_of_service_msr_deauthenticate_device.md).
 
 ### -field MsrUpdateKey
 
-Represents [IOCTL_POINT_OF_SERVICE_MSR_UPDATE_KEY](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_msr_update_key).
+Represents [IOCTL_POINT_OF_SERVICE_MSR_UPDATE_KEY](./ni-pointofservicedriverinterface-ioctl_point_of_service_msr_update_key.md).
 
 ### -field StartBarcodeScannerSoftwareTrigger
 

--- a/wdk-ddi-src/content/pointofservicedriverinterface/ne-pointofservicedriverinterface-_pospropertyid.md
+++ b/wdk-ddi-src/content/pointofservicedriverinterface/ne-pointofservicedriverinterface-_pospropertyid.md
@@ -66,15 +66,15 @@ When set to **TRUE**, the driver must return decoded bar code data in the form o
 
 ### -field BarcodeScannerCapabilities
 
-Contains information about what functionality the barcode scanner supports. For example, a barcode scanner may support imaging and standard power reporting but not statistics updating and reporting. For more information about the values for barcode capabilities, see [PosBarcodeScannerCapabilitiesType](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ns-pointofservicedriverinterface-_posbarcodescannercapabilitiestype). (Read-only).
+Contains information about what functionality the barcode scanner supports. For example, a barcode scanner may support imaging and standard power reporting but not statistics updating and reporting. For more information about the values for barcode capabilities, see [PosBarcodeScannerCapabilitiesType](./ns-pointofservicedriverinterface-_posbarcodescannercapabilitiestype.md). (Read-only).
 
 ### -field BarcodeScannerSupportedSymbologies
 
-Contains an array representing the complete list of symbologies that the barcode scanner is capable of reading. Also returns the number of bytes required for the array of symbologies. For symbology definitions, see [BarcodeSymbology](/windows-hardware/drivers/ddi/pointofservicecommontypes/ne-pointofservicecommontypes-_barcodesymbology). (Read-only).
+Contains an array representing the complete list of symbologies that the barcode scanner is capable of reading. Also returns the number of bytes required for the array of symbologies. For symbology definitions, see [BarcodeSymbology](../pointofservicecommontypes/ne-pointofservicecommontypes-_barcodesymbology.md). (Read-only).
 
 ### -field BarcodeScannerActiveSymbologies
 
-Indicates the symbologies that the barcode scanner is actively handling. (Write-only). For symbology definitions, see [BarcodeSymbology](/windows-hardware/drivers/ddi/pointofservicecommontypes/ne-pointofservicecommontypes-_barcodesymbology).
+Indicates the symbologies that the barcode scanner is actively handling. (Write-only). For symbology definitions, see [BarcodeSymbology](../pointofservicecommontypes/ne-pointofservicecommontypes-_barcodesymbology.md).
 
 ### -field BarcodeScannerSupportedProfiles
 
@@ -90,11 +90,11 @@ Indicates whether to provide raw or decoded data from the most recently swiped c
 
 ### -field MagneticStripeReaderCapabilities
 
-Returns a [PosMagneticStripeReaderCapabilitiesType](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ns-pointofservicedriverinterface-_posmagneticstripereadercapabilitiestype) that describes the capabilities of the MSR. (Read-Only).
+Returns a [PosMagneticStripeReaderCapabilitiesType](./ns-pointofservicedriverinterface-_posmagneticstripereadercapabilitiestype.md) that describes the capabilities of the MSR. (Read-Only).
 
 ### -field MagneticStripeReaderSupportedCardTypes
 
-Returns an array of [MsrCardType](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ne-pointofservicedriverinterface-_msrcardtype)s supported by the MSR. (Read-only).
+Returns an array of [MsrCardType](./ne-pointofservicedriverinterface-_msrcardtype.md)s supported by the MSR. (Read-only).
 
 ### -field MagneticStripeReaderDeviceAuthenticationProtocol
 
@@ -102,11 +102,11 @@ The driver must return a [MsrAuthenticationProtocolType](/previous-versions/wind
 
 ### -field MagneticStripeReaderErrorReportingType
 
-Specifies the level of error reporting that the MSR supports. For more information about the values for error reporting levels, see [MsrErrorReportingType](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ne-pointofservicedriverinterface-_msrerrorreportingtype). (Read/write).
+Specifies the level of error reporting that the MSR supports. For more information about the values for error reporting levels, see [MsrErrorReportingType](./ne-pointofservicedriverinterface-_msrerrorreportingtype.md). (Read/write).
 
 ### -field MagneticStripeReaderTracksToRead
 
-Specifies which tracks the application will receive following a card swipe. Does not indicate the capability of the device hardware; instead, it is an application-configurable property representing the tracks to be read. For more information about track values, see [MsrTrackIds](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ne-pointofservicedriverinterface-_msrtrackids). (Read/write).
+Specifies which tracks the application will receive following a card swipe. Does not indicate the capability of the device hardware; instead, it is an application-configurable property representing the tracks to be read. For more information about track values, see [MsrTrackIds](./ne-pointofservicedriverinterface-_msrtrackids.md). (Read/write).
 
 ### -field MagneticStripeReaderIsTransmitSentinelsEnabled
 
@@ -118,7 +118,7 @@ Indicates whether the device is authenticated. (Read-only).
 
 ### -field MagneticStripeReaderDataEncryptionAlgorithm
 
-Specifies the [MsrDataEncryption](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ne-pointofservicedriverinterface-_msrdataencryption) that will be used to encrypt the track data. (Read/write).
+Specifies the [MsrDataEncryption](./ne-pointofservicedriverinterface-_msrdataencryption.md) that will be used to encrypt the track data. (Read/write).
 
 ### -field BarcodeScannerVideoDeviceId
 
@@ -126,6 +126,6 @@ Defines the **BarcodeScannerVideoDeviceId** constant.
 
 ## -see-also
 
-[IOCTL_POINT_OF_SERVICE_GET_PROPERTY](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_get_property)
+[IOCTL_POINT_OF_SERVICE_GET_PROPERTY](./ni-pointofservicedriverinterface-ioctl_point_of_service_get_property.md)
 
-[IOCTL_POINT_OF_SERVICE_SET_PROPERTY](/windows-hardware/drivers/ddi/pointofservicedriverinterface/ni-pointofservicedriverinterface-ioctl_point_of_service_set_property)
+[IOCTL_POINT_OF_SERVICE_SET_PROPERTY](./ni-pointofservicedriverinterface-ioctl_point_of_service_set_property.md)

--- a/wdk-ddi-src/content/sti/nf-sti-istidevice-getlasterrorinfo.md
+++ b/wdk-ddi-src/content/sti/nf-sti-istidevice-getlasterrorinfo.md
@@ -47,7 +47,7 @@ The **IStiDevice::GetLastErrorInfo** method returns information about the last k
 
 ### -param pLastErrorInfo [out]
 
-Caller-supplied pointer to an [STI_ERROR_INFO](/windows-hardware/drivers/ddi/sti/ns-sti-_error_infow) structure to receive error information.
+Caller-supplied pointer to an [STI_ERROR_INFO](./ns-sti-_error_infow.md) structure to receive error information.
 
 ## -returns
 
@@ -55,6 +55,6 @@ If the operation succeeds, the method returns S_OK. Otherwise, it returns one of
 
 ## -remarks
 
-The **IStiDevice::GetLastErrorInfo** method returns information about the most recent error by filling in the caller-supplied [STI_ERROR_INFO](/windows-hardware/drivers/ddi/sti/ns-sti-_error_infow) structure. The method calls [IStiUSD::GetLastErrorInfo](/windows-hardware/drivers/ddi/stiusd/nf-stiusd-istiusd-getlasterrorinfo), which is exported by vendor-supplied minidrivers.
+The **IStiDevice::GetLastErrorInfo** method returns information about the most recent error by filling in the caller-supplied [STI_ERROR_INFO](./ns-sti-_error_infow.md) structure. The method calls [IStiUSD::GetLastErrorInfo](../stiusd/nf-stiusd-istiusd-getlasterrorinfo.md), which is exported by vendor-supplied minidrivers.
 
 Before calling **IStiDevice::GetLastErrorInfo**, clients of the **IStiDevice** COM interface must call [IStillImage::CreateDevice](/previous-versions/windows/hardware/drivers/ff543778(v=vs.85)) to obtain an **IStiDevice** interface pointer, which provides access to a specified device.

--- a/wdk-ddi-src/content/sti/nf-sti-istidevice-subscribe.md
+++ b/wdk-ddi-src/content/sti/nf-sti-istidevice-subscribe.md
@@ -47,7 +47,7 @@ The **IStiDevice::Subscribe** method registers the caller to receive notificatio
 
 ### -param lpSubsribe [in, out]
 
-Caller-supplied pointer to an [STISUBSCRIBE](/windows-hardware/drivers/ddi/sti/ns-sti-_stisubscribe) structure containing subscription parameter values.
+Caller-supplied pointer to an [STISUBSCRIBE](./ns-sti-_stisubscribe.md) structure containing subscription parameter values.
 
 ## -returns
 
@@ -57,16 +57,16 @@ If the operation succeeds, the method returns S_OK. Otherwise, it returns one of
 
 The **IStiDevice::Subscribe** method is typically called by applications that intercept events from devices and reroute them. The method allows these applications to be notified of [Still Image Device Events](/windows-hardware/drivers/image/still-image-device-events) so they can then dispatch control to appropriate display applications.
 
-Based on contents supplied in the [STISUBSCRIBE](/windows-hardware/drivers/ddi/sti/ns-sti-_stisubscribe) structure, the caller can request to be notified of device events by Windows messages or by Win32 events (by means of **SetEvent** calls).
+Based on contents supplied in the [STISUBSCRIBE](./ns-sti-_stisubscribe.md) structure, the caller can request to be notified of device events by Windows messages or by Win32 events (by means of **SetEvent** calls).
 
-When the application receives notification of an event, it can call [IStiDevice::GetLastNotificationData](/windows-hardware/drivers/ddi/sti/nf-sti-istidevice-getlastnotificationdata) to find out which event occurred.
+When the application receives notification of an event, it can call [IStiDevice::GetLastNotificationData](./nf-sti-istidevice-getlastnotificationdata.md) to find out which event occurred.
 
 Before calling **IStiDevice::Subscribe**, clients of the **IStiDevice** COM interface must call [IStillImage::CreateDevice](/previous-versions/windows/hardware/drivers/ff543778(v=vs.85)) to obtain an **IStiDevice** interface pointer, which provides access to a specified device.
 
 ## -see-also
 
-[IStiDevice](/windows-hardware/drivers/ddi/_image/index)
+[IStiDevice](../_image/index.md)
 
-[IStiDevice::UnSubscribe](/windows-hardware/drivers/ddi/sti/nf-sti-istidevice-unsubscribe)
+[IStiDevice::UnSubscribe](./nf-sti-istidevice-unsubscribe.md)
 
 [IStillImage::LaunchApplicationForDevice](/previous-versions/windows/hardware/drivers/ff543796(v=vs.85))

--- a/wdk-ddi-src/content/sti/nf-sti-istillimagew-setupdeviceparameters.md
+++ b/wdk-ddi-src/content/sti/nf-sti-istillimagew-setupdeviceparameters.md
@@ -55,7 +55,7 @@ If the operation succeeds, the method returns S_OK. Otherwise, it returns one of
 
 ## -remarks
 
-The **IStillImage::SetupDeviceParameters** method only allows modification of device parameters associated with still image devices for which a bus has not been identified. For such devices, the still image server sets the **dwHardwareConfiguration** member of the device's [STI_DEVICE_INFORMATION](/windows-hardware/drivers/ddi/sti/ns-sti-_sti_device_informationw) structure to STI_HW_CONFIG_UNKNOWN when [IStillImage::GetDeviceInfo](/previous-versions/windows/hardware/drivers/ff543782(v=vs.85)) is called.
+The **IStillImage::SetupDeviceParameters** method only allows modification of device parameters associated with still image devices for which a bus has not been identified. For such devices, the still image server sets the **dwHardwareConfiguration** member of the device's [STI_DEVICE_INFORMATION](./ns-sti-_sti_device_informationw.md) structure to STI_HW_CONFIG_UNKNOWN when [IStillImage::GetDeviceInfo](/previous-versions/windows/hardware/drivers/ff543782(v=vs.85)) is called.
 
 Currently, the only device parameter that can be modified is the device's port name. When calling this method to modify the port name, the **dwSize**, **szDeviceInternalName**, and **pszPortName** members of the STI_DEVICE_INFORMATION must be specified. All other members are ignored.
 

--- a/wdk-ddi-src/content/stiusd/nf-stiusd-istiusd-escape.md
+++ b/wdk-ddi-src/content/stiusd/nf-stiusd-istiusd-escape.md
@@ -75,10 +75,10 @@ If the operation succeeds, the method should return S_OK. Otherwise, it should r
 
 ## -remarks
 
-A still image minidriver only needs to implement **IStiUSD::Escape** if I/O operations are required that cannot be implemented within [IStiUSD::RawReadData](/windows-hardware/drivers/ddi/stiusd/nf-stiusd-istiusd-rawreaddata), [IStiUSD::RawWriteData](/windows-hardware/drivers/ddi/stiusd/nf-stiusd-istiusd-rawwritedata), [IStiUSD::RawReadCommand](/windows-hardware/drivers/ddi/stiusd/nf-stiusd-istiusd-rawreadcommand), or [IStiUSD::RawWriteCommand](/windows-hardware/drivers/ddi/stiusd/nf-stiusd-istiusd-rawwritecommand) methods. The minidriver defines parameter usage for **IStiUSD::Escape**.
+A still image minidriver only needs to implement **IStiUSD::Escape** if I/O operations are required that cannot be implemented within [IStiUSD::RawReadData](./nf-stiusd-istiusd-rawreaddata.md), [IStiUSD::RawWriteData](./nf-stiusd-istiusd-rawwritedata.md), [IStiUSD::RawReadCommand](./nf-stiusd-istiusd-rawreadcommand.md), or [IStiUSD::RawWriteCommand](./nf-stiusd-istiusd-rawwritecommand.md) methods. The minidriver defines parameter usage for **IStiUSD::Escape**.
 
 ## -see-also
 
-[IStiDevice::Escape](/windows-hardware/drivers/ddi/sti/nf-sti-istidevice-escape)
+[IStiDevice::Escape](../sti/nf-sti-istidevice-escape.md)
 
-[IStiUSD](/windows-hardware/drivers/ddi/_image/index)
+[IStiUSD](../_image/index.md)

--- a/wdk-ddi-src/content/stiusd/nf-stiusd-istiusd-getcapabilities.md
+++ b/wdk-ddi-src/content/stiusd/nf-stiusd-istiusd-getcapabilities.md
@@ -47,7 +47,7 @@ A still image minidriver's **IStiUSD::GetCapabilities** method returns a still i
 
 ### -param pDevCaps
 
-Caller-supplied pointer to an empty [STI_USD_CAPS](/windows-hardware/drivers/ddi/stiusd/ns-stiusd-_sti_usd_caps) structure.
+Caller-supplied pointer to an empty [STI_USD_CAPS](./ns-stiusd-_sti_usd_caps.md) structure.
 
 ## -returns
 
@@ -55,10 +55,10 @@ If the operation succeeds, the method should return S_OK. Otherwise, it should r
 
 ## -remarks
 
-The **IStiUSD::GetCapabilities** method should set appropriate device capability flags in the caller-supplied [STI_USD_CAPS](/windows-hardware/drivers/ddi/stiusd/ns-stiusd-_sti_usd_caps) structure. It should also set the version number to STI_VERSION.
+The **IStiUSD::GetCapabilities** method should set appropriate device capability flags in the caller-supplied [STI_USD_CAPS](./ns-stiusd-_sti_usd_caps.md) structure. It should also set the version number to STI_VERSION.
 
 ## -see-also
 
-[IStiDevice::GetCapabilities](/windows-hardware/drivers/ddi/sti/nf-sti-istidevice-getcapabilities)
+[IStiDevice::GetCapabilities](../sti/nf-sti-istidevice-getcapabilities.md)
 
-[IStiUSD](/windows-hardware/drivers/ddi/_image/index)
+[IStiUSD](../_image/index.md)

--- a/wdk-ddi-src/content/stiusd/nf-stiusd-istiusd-getnotificationdata.md
+++ b/wdk-ddi-src/content/stiusd/nf-stiusd-istiusd-getnotificationdata.md
@@ -47,7 +47,7 @@ A still image minidriver's **IStiUSD::GetNotificationData* method returns a desc
 
 ### -param lpNotify
 
-Caller-supplied pointer to an [STINOTIFY](/windows-hardware/drivers/ddi/sti/ns-sti-_stinotify) structure to receive event information.
+Caller-supplied pointer to an [STINOTIFY](../sti/ns-sti-_stinotify.md) structure to receive event information.
 
 ## -returns
 
@@ -55,4 +55,4 @@ If the operation succeeds, the method should return S_OK. Otherwise, it should r
 
 ## -remarks
 
-Each time a device event occurs, the still image event monitor calls**IStiUSD::GetNotificationData</b> to obtain an event description. These descriptions are added to a linked list and when an application calls [IStiDevice::GetLastNotificationData](/windows-hardware/drivers/ddi/sti/nf-sti-istidevice-getlastnotificationdata), the most recent addition to the list is returned.
+Each time a device event occurs, the still image event monitor calls**IStiUSD::GetNotificationData</b> to obtain an event description. These descriptions are added to a linked list and when an application calls [IStiDevice::GetLastNotificationData](../sti/nf-sti-istidevice-getlastnotificationdata.md), the most recent addition to the list is returned.

--- a/wdk-ddi-src/content/stiusd/nf-stiusd-istiusd-rawwritedata.md
+++ b/wdk-ddi-src/content/stiusd/nf-stiusd-istiusd-rawwritedata.md
@@ -67,6 +67,6 @@ A still image minidriver typically implements this method by calling **WriteFile
 
 ## -see-also
 
-[IStiDevice::RawWriteData](/windows-hardware/drivers/ddi/sti/nf-sti-istidevice-rawwritedata)
+[IStiDevice::RawWriteData](../sti/nf-sti-istidevice-rawwritedata.md)
 
-[IStiUSD](/windows-hardware/drivers/ddi/_image/index)
+[IStiUSD](../_image/index.md)

--- a/wdk-ddi-src/content/usbcamdi/nc-usbcamdi-pcam_free_bw_routine_ex.md
+++ b/wdk-ddi-src/content/usbcamdi/nc-usbcamdi-pcam_free_bw_routine_ex.md
@@ -73,6 +73,6 @@ This function is required.
 
 ## -see-also
 
-[USBCAMD_DEVICE_DATA2](/windows-hardware/drivers/ddi/usbcamdi/ns-usbcamdi-_usbcamd_device_data2)
+[USBCAMD_DEVICE_DATA2](./ns-usbcamdi-_usbcamd_device_data2.md)
 
-[USBCAMD_SelectAlternateInterface](/windows-hardware/drivers/ddi/usbcamdi/nf-usbcamdi-usbcamd_selectalternateinterface)
+[USBCAMD_SelectAlternateInterface](./nf-usbcamdi-usbcamd_selectalternateinterface.md)

--- a/wdk-ddi-src/content/usbcamdi/nf-usbcamdi-usbcamd_driverentry.md
+++ b/wdk-ddi-src/content/usbcamdi/nf-usbcamdi-usbcamd_driverentry.md
@@ -64,7 +64,7 @@ Specifies the size, in bytes, required for the minidriver's frame-specific conte
 
 ### -param ReceivePacket [in]
 
-Pointer to the minidriver-defined [AdapterReceivePacket](/windows-hardware/drivers/ddi/usbcamdi/nc-usbcamdi-padapter_receive_packet_routine) function that handles adapter-based SRB requests.
+Pointer to the minidriver-defined [AdapterReceivePacket](./nc-usbcamdi-padapter_receive_packet_routine.md) function that handles adapter-based SRB requests.
 
 ## -returns
 
@@ -74,12 +74,12 @@ Pointer to the minidriver-defined [AdapterReceivePacket](/windows-hardware/drive
 
 A camera minidriver must call **USBCAMD_DriverEntry** from the minidriver's **DriverEntry** routine. For more information, see [DriverEntry for Stream Class Minidrivers](/previous-versions/ff558717(v=vs.85))
 
-*FrameContextSize* is optional. A non-**NULL** value should be provided only with calls to [CamNewVideoFrame](/windows-hardware/drivers/ddi/usbcamdi/nc-usbcamdi-pcam_new_frame_routine) or [CamProcessRawVideoFrame](/windows-hardware/drivers/ddi/usbcamdi/nc-usbcamdi-pcam_process_raw_frame_routine).
+*FrameContextSize* is optional. A non-**NULL** value should be provided only with calls to [CamNewVideoFrame](./nc-usbcamdi-pcam_new_frame_routine.md) or [CamProcessRawVideoFrame](./nc-usbcamdi-pcam_process_raw_frame_routine.md).
 
 ## -see-also
 
-[AdapterReceivePacket](/windows-hardware/drivers/ddi/usbcamdi/nc-usbcamdi-padapter_receive_packet_routine)
+[AdapterReceivePacket](./nc-usbcamdi-padapter_receive_packet_routine.md)
 
-[CamNewVideoFrame](/windows-hardware/drivers/ddi/usbcamdi/nc-usbcamdi-pcam_new_frame_routine)
+[CamNewVideoFrame](./nc-usbcamdi-pcam_new_frame_routine.md)
 
-[CamProcessRawVideoFrame](/windows-hardware/drivers/ddi/usbcamdi/nc-usbcamdi-pcam_process_raw_frame_routine)
+[CamProcessRawVideoFrame](./nc-usbcamdi-pcam_process_raw_frame_routine.md)

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdeviceassigninterfaceproperty.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdeviceassigninterfaceproperty.md
@@ -60,7 +60,7 @@ A handle to a framework device object.
 
 ### -param PropertyData [in]
 
-A pointer to [WDF_DEVICE_INTERFACE_PROPERTY_DATA](/windows-hardware/drivers/ddi/wdfdevice/ns-wdfdevice-_wdf_device_interface_property_data) structure.
+A pointer to [WDF_DEVICE_INTERFACE_PROPERTY_DATA](./ns-wdfdevice-_wdf_device_interface_property_data.md) structure.
 
 ### -param Type [in]
 
@@ -90,7 +90,7 @@ For information about related methods, see [Accessing the Unified Device Propert
 
 ### Examples
 
-The following code example initializes a [WDF_DEVICE_INTERFACE_PROPERTY_DATA](/windows-hardware/drivers/ddi/wdfdevice/ns-wdfdevice-_wdf_device_interface_property_data) structure and then calls **WdfDeviceAssignInterfaceProperty**.
+The following code example initializes a [WDF_DEVICE_INTERFACE_PROPERTY_DATA](./ns-wdfdevice-_wdf_device_interface_property_data.md) structure and then calls **WdfDeviceAssignInterfaceProperty**.
 
 ```cpp
 DEFINE_DEVPROPKEY(DEVPKEY_ToasterCrispLevelDword, 0x5d0ba64a, 0x2396, 0x4bc9, 0xbf, 0x49, 0x52, 0x1d, 0xa6, 0x2b, 0x1b, 0xed, 3);  // DEVPROP_TYPE_UINT32
@@ -117,10 +117,10 @@ if (!NT_SUCCESS(status)) {
 
 ## -see-also
 
-[WDF_DEVICE_INTERFACE_PROPERTY_DATA](/windows-hardware/drivers/ddi/wdfdevice/ns-wdfdevice-_wdf_device_interface_property_data)
+[WDF_DEVICE_INTERFACE_PROPERTY_DATA](./ns-wdfdevice-_wdf_device_interface_property_data.md)
 
-[WDF_DEVICE_INTERFACE_PROPERTY_DATA_INIT](/windows-hardware/drivers/ddi/wdfdevice/nf-wdfdevice-wdf_device_interface_property_data_init)
+[WDF_DEVICE_INTERFACE_PROPERTY_DATA_INIT](./nf-wdfdevice-wdf_device_interface_property_data_init.md)
 
-[WdfDeviceAllocAndQueryInterfaceProperty](/windows-hardware/drivers/ddi/wdfdevice/nf-wdfdevice-wdfdeviceallocandqueryinterfaceproperty)
+[WdfDeviceAllocAndQueryInterfaceProperty](./nf-wdfdevice-wdfdeviceallocandqueryinterfaceproperty.md)
 
-[WdfDeviceQueryInterfaceProperty](/windows-hardware/drivers/ddi/wdfdevice/nf-wdfdevice-wdfdevicequeryinterfaceproperty)
+[WdfDeviceQueryInterfaceProperty](./nf-wdfdevice-wdfdevicequeryinterfaceproperty.md)

--- a/wdk-ddi-src/content/wdm/nf-wdm-iogetdeviceinterfacepropertydata.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iogetdeviceinterfacepropertydata.md
@@ -50,7 +50,7 @@ The **IoGetDeviceInterfacePropertyData** routine retrieves the current value of 
 
 ### -param SymbolicLinkName [in]
 
-A pointer to a string that identifies the device interface instance. This string was obtained from a previous call to the [IoGetDeviceInterfaces](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdeviceinterfaces), [IoGetDeviceInterfaceAlias](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdeviceinterfacealias), or [IoRegisterDeviceInterface](/windows-hardware/drivers/ddi/wdm/nf-wdm-ioregisterdeviceinterface) routine.
+A pointer to a string that identifies the device interface instance. This string was obtained from a previous call to the [IoGetDeviceInterfaces](./nf-wdm-iogetdeviceinterfaces.md), [IoGetDeviceInterfaceAlias](./nf-wdm-iogetdeviceinterfacealias.md), or [IoRegisterDeviceInterface](./nf-wdm-ioregisterdeviceinterface.md) routine.
 
 ### -param PropertyKey [in]
 
@@ -94,7 +94,7 @@ A pointer to a [DEVPROPTYPE](/previous-versions/ff543546(v=vs.85)) variable. If 
 
 Kernel-mode drivers use the **IoGetDeviceInterfacePropertyData** routine to retrieve device interface properties that are defined as part of the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-). For more information about device interface properties, see [Device Properties](/windows-hardware/drivers/image/device-properties).
 
-Drivers can use the [IoSetDeviceInterfacePropertyData](/windows-hardware/drivers/ddi/wdm/nf-wdm-iosetdeviceinterfacepropertydata) routine to modify a device interface property.
+Drivers can use the [IoSetDeviceInterfacePropertyData](./nf-wdm-iosetdeviceinterfacepropertydata.md) routine to modify a device interface property.
 
 Callers of **IoGetDeviceInterfacePropertyData** must be running at IRQL = PASSIVE_LEVEL in the context of a system thread.
 
@@ -104,4 +104,4 @@ Callers of **IoGetDeviceInterfacePropertyData** must be running at IRQL = PASSIV
 
 [DEVPROPTYPE](/previous-versions/ff543546(v=vs.85))
 
-[IoSetDeviceInterfacePropertyData](/windows-hardware/drivers/ddi/wdm/nf-wdm-iosetdeviceinterfacepropertydata)
+[IoSetDeviceInterfacePropertyData](./nf-wdm-iosetdeviceinterfacepropertydata.md)

--- a/wdk-ddi-src/content/wdm/nf-wdm-iosetdeviceinterfacepropertydata.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iosetdeviceinterfacepropertydata.md
@@ -50,7 +50,7 @@ The **IoSetDeviceInterfacePropertyData** routine modifies the current value of a
 
 ### -param SymbolicLinkName [in]
 
-A pointer to a string that identifies the device interface instance. This string was obtained from a previous call to the [IoGetDeviceInterfaces](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdeviceinterfaces), [IoGetDeviceInterfaceAlias](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdeviceinterfacealias), or [IoRegisterDeviceInterface](/windows-hardware/drivers/ddi/wdm/nf-wdm-ioregisterdeviceinterface) routine.
+A pointer to a string that identifies the device interface instance. This string was obtained from a previous call to the [IoGetDeviceInterfaces](./nf-wdm-iogetdeviceinterfaces.md), [IoGetDeviceInterfaceAlias](./nf-wdm-iogetdeviceinterfacealias.md), or [IoRegisterDeviceInterface](./nf-wdm-ioregisterdeviceinterface.md) routine.
 
 ### -param PropertyKey [in]
 
@@ -89,7 +89,7 @@ A pointer to the device interface property data. Set this parameter to **NULL** 
 
 Kernel-mode drivers use the **IoSetDeviceInterfacePropertyData** routine to modify device interface properties that are defined as part of the [unified device property model](/windows-hardware/drivers/install/unified-device-property-model--windows-vista-and-later-). For more information about device interface properties, see [Device Properties](/windows-hardware/drivers/image/device-properties).
 
-Drivers can use the [IoGetDeviceInterfacePropertyData](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdeviceinterfacepropertydata) routine to obtain the current value for a device interface property.
+Drivers can use the [IoGetDeviceInterfacePropertyData](./nf-wdm-iogetdeviceinterfacepropertydata.md) routine to obtain the current value for a device interface property.
 
 Callers of **IoSetDeviceInterfacePropertyData** must be running at IRQL <= APC_LEVEL in the context of a system thread.
 
@@ -99,4 +99,4 @@ Callers of **IoSetDeviceInterfacePropertyData** must be running at IRQL <= APC_L
 
 [DEVPROPTYPE](/previous-versions/ff543546(v=vs.85))
 
-[IoGetDeviceInterfacePropertyData](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdeviceinterfacepropertydata)
+[IoGetDeviceInterfacePropertyData](./nf-wdm-iogetdeviceinterfacepropertydata.md)

--- a/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiasreadpropguid.md
+++ b/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiasreadpropguid.md
@@ -71,12 +71,12 @@ On success, the function returns S_OK. If the function fails, it returns a stand
 
 ## -see-also
 
-[wiasReadPropBin](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiasreadpropbin)
+[wiasReadPropBin](./nf-wiamdef-wiasreadpropbin.md)
 
-[wiasReadPropFloat](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiasreadpropfloat)
+[wiasReadPropFloat](./nf-wiamdef-wiasreadpropfloat.md)
 
-[wiasReadPropLong](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiasreadproplong)
+[wiasReadPropLong](./nf-wiamdef-wiasreadproplong.md)
 
-[wiasReadPropStr](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiasreadpropstr)
+[wiasReadPropStr](./nf-wiamdef-wiasreadpropstr.md)
 
-[wiasWritePropGuid](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiaswritepropguid)
+[wiasWritePropGuid](./nf-wiamdef-wiaswritepropguid.md)

--- a/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiassetitempropnames.md
+++ b/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiassetitempropnames.md
@@ -71,4 +71,4 @@ Minidrivers typically use this function when initializing item properties. The o
 
 ## -see-also
 
-[wiasSetItemPropAttribs](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetitempropattribs)
+[wiasSetItemPropAttribs](./nf-wiamdef-wiassetitempropattribs.md)

--- a/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiassetvalidlistguid.md
+++ b/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiassetvalidlistguid.md
@@ -71,14 +71,14 @@ On success, the function returns S_OK. If the function fails, it returns a stand
 
 ## -see-also
 
-[wiasSetValidFlag](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidflag)
+[wiasSetValidFlag](./nf-wiamdef-wiassetvalidflag.md)
 
-[wiasSetValidListFloat](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidlistfloat)
+[wiasSetValidListFloat](./nf-wiamdef-wiassetvalidlistfloat.md)
 
-[wiasSetValidListLong](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidlistlong)
+[wiasSetValidListLong](./nf-wiamdef-wiassetvalidlistlong.md)
 
-[wiasSetValidListStr](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidliststr)
+[wiasSetValidListStr](./nf-wiamdef-wiassetvalidliststr.md)
 
-[wiasSetValidRangeFloat](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidrangefloat)
+[wiasSetValidRangeFloat](./nf-wiamdef-wiassetvalidrangefloat.md)
 
-[wiasSetValidRangeLong](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidrangelong)
+[wiasSetValidRangeLong](./nf-wiamdef-wiassetvalidrangelong.md)

--- a/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiassetvalidliststr.md
+++ b/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiassetvalidliststr.md
@@ -71,14 +71,14 @@ On success, the function returns S_OK. If the function fails, it returns a stand
 
 ## -see-also
 
-[wiasSetValidFlag](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidflag)
+[wiasSetValidFlag](./nf-wiamdef-wiassetvalidflag.md)
 
-[wiasSetValidListFloat](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidlistfloat)
+[wiasSetValidListFloat](./nf-wiamdef-wiassetvalidlistfloat.md)
 
-[wiasSetValidListGuid](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidlistguid)
+[wiasSetValidListGuid](./nf-wiamdef-wiassetvalidlistguid.md)
 
-[wiasSetValidListLong](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidlistlong)
+[wiasSetValidListLong](./nf-wiamdef-wiassetvalidlistlong.md)
 
-[wiasSetValidRangeFloat](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidrangefloat)
+[wiasSetValidRangeFloat](./nf-wiamdef-wiassetvalidrangefloat.md)
 
-[wiasSetValidRangeLong](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiassetvalidrangelong)
+[wiasSetValidRangeLong](./nf-wiamdef-wiassetvalidrangelong.md)

--- a/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiaswritepropguid.md
+++ b/wdk-ddi-src/content/wiamdef/nf-wiamdef-wiaswritepropguid.md
@@ -63,12 +63,12 @@ On success, the function returns S_OK. If the function fails, it returns a stand
 
 ## -see-also
 
-[wiasReadPropGuid](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiasreadpropguid)
+[wiasReadPropGuid](./nf-wiamdef-wiasreadpropguid.md)
 
-[wiasWritePropBin](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiaswritepropbin)
+[wiasWritePropBin](./nf-wiamdef-wiaswritepropbin.md)
 
-[wiasWritePropFloat](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiaswritepropfloat)
+[wiasWritePropFloat](./nf-wiamdef-wiaswritepropfloat.md)
 
-[wiasWritePropLong](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiaswriteproplong)
+[wiasWritePropLong](./nf-wiamdef-wiaswriteproplong.md)
 
-[wiasWritePropStr](/windows-hardware/drivers/ddi/wiamdef/nf-wiamdef-wiaswritepropstr)
+[wiasWritePropStr](./nf-wiamdef-wiaswritepropstr.md)

--- a/wdk-ddi-src/content/winddiui/nf-winddiui-drvspldevicecaps.md
+++ b/wdk-ddi-src/content/winddiui/nf-winddiui-drvspldevicecaps.md
@@ -110,10 +110,10 @@ The return value depends on the *Capability* parameter. If *Capability* indicate
 
 ## -remarks
 
-For descriptions of the DC_*XXX* flags, see [DrvDeviceCapabilities](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdevicecapabilities).
+For descriptions of the DC_*XXX* flags, see [DrvDeviceCapabilities](./nf-winddiui-drvdevicecapabilities.md).
 
 This function must be defined in the .def file as DrvSplDeviceCaps @ 254, because the spooler uses the ordinal number 254 to obtain the driver function pointer.
 
 ## -see-also
 
-[DrvDeviceCapabilities](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdevicecapabilities)
+[DrvDeviceCapabilities](./nf-winddiui-drvdevicecapabilities.md)

--- a/wdk-ddi-src/content/wpprecorder/nf-wpprecorder-wpprecorderconfigure.md
+++ b/wdk-ddi-src/content/wpprecorder/nf-wpprecorder-wpprecorderconfigure.md
@@ -59,7 +59,7 @@ VOID WppRecorderConfigure(
 
 ### -param ConfigureParams
 
-Pointer to a caller-allocated [**RECORDER_CONFIGURE_PARAMS**](/windows-hardware/drivers/ddi/wpprecorder/ns-wpprecorder-_recorder_configure_params) structure.
+Pointer to a caller-allocated [**RECORDER_CONFIGURE_PARAMS**](./ns-wpprecorder-_recorder_configure_params.md) structure.
 
 ## -remarks
 

--- a/wdk-ddi-src/content/wpprecorder/nf-wpprecorder-wpprecorderlogcreate.md
+++ b/wdk-ddi-src/content/wpprecorder/nf-wpprecorder-wpprecorderlogcreate.md
@@ -60,7 +60,7 @@ NTSTATUS WppRecorderLogCreate(
 
 ### -param CreateParams
 
-A pointer to a [**RECORDER_LOG_CREATE_PARAMS**](/windows-hardware/drivers/ddi/wpprecorder/ns-wpprecorder-_recorder_log_create_params) structure.
+A pointer to a [**RECORDER_LOG_CREATE_PARAMS**](./ns-wpprecorder-_recorder_log_create_params.md) structure.
 
 ### -param RecorderLog
 

--- a/wdk-ddi-src/content/wpprecorder/ns-wpprecorder-_recorder_configure_params.md
+++ b/wdk-ddi-src/content/wpprecorder/ns-wpprecorder-_recorder_configure_params.md
@@ -65,7 +65,7 @@ Indicates whether WPP should use the default log for trace messages. TRUE (defau
 
 ### -field UseTimeStamp
 
-A [WPP_RECORDER_TRI_STATE](/windows-hardware/drivers/ddi/wpprecorder/ne-wpprecorder-wpp_recorder_tri_state)-typed value that indicates:
+A [WPP_RECORDER_TRI_STATE](./ne-wpprecorder-wpp_recorder_tri_state.md)-typed value that indicates:
 
 * If set to **WppRecorderTrue**, timestamps of millisecond granularity will be added to WPP log entries.
 * If set to **WppRecorderFalse**, the timestamp will not be recorded.
@@ -75,7 +75,7 @@ This field is available starting in WDK Insider Preview build 22557. For more in
 
 ### -field PreciseTimeStamp
 
-A [WPP_RECORDER_TRI_STATE](/windows-hardware/drivers/ddi/wpprecorder/ne-wpprecorder-wpp_recorder_tri_state)-typed value that indicates:
+A [WPP_RECORDER_TRI_STATE](./ne-wpprecorder-wpp_recorder_tri_state.md)-typed value that indicates:
 
 * If set to **WppRecorderTrue**, timestamps of a tenth of a microsecond granularity will be added to WPP log entries.
 * If set to **WppRecorderFalse**, the timestamp will not be recorded.
@@ -86,4 +86,3 @@ This field is available starting in WDK Insider Preview build 22557. For more in
 ## -remarks
 
 To initialize this structure, the caller must call <a href="/windows-hardware/drivers/ddi/wpprecorder/nf-wpprecorder-recorder_configure_params_init">RECORDER_CONFIGURE_PARAMS_INIT</a>.
-

--- a/wdk-ddi-src/content/wpprecorder/ns-wpprecorder-_recorder_log_create_params.md
+++ b/wdk-ddi-src/content/wpprecorder/ns-wpprecorder-_recorder_log_create_params.md
@@ -89,7 +89,7 @@ Identifier to print when debug messages are merged. Lives at end of structure so
 
 ### -field UseTimeStamp
 
-A [WPP_RECORDER_TRI_STATE](/windows-hardware/drivers/ddi/wpprecorder/ne-wpprecorder-wpp_recorder_tri_state)-typed value that indicates:
+A [WPP_RECORDER_TRI_STATE](./ne-wpprecorder-wpp_recorder_tri_state.md)-typed value that indicates:
 
 * If set to **WppRecorderTrue**, timestamps of millisecond granularity will be added to WPP log entries.
 * If set to **WppRecorderFalse**, the timestamp will not be recorded.
@@ -99,7 +99,7 @@ This field is available starting in WDK Insider Preview build 22557. For more in
 
 ### -field PreciseTimeStamp
 
-A [WPP_RECORDER_TRI_STATE](/windows-hardware/drivers/ddi/wpprecorder/ne-wpprecorder-wpp_recorder_tri_state)-typed value that indicates:
+A [WPP_RECORDER_TRI_STATE](./ne-wpprecorder-wpp_recorder_tri_state.md)-typed value that indicates:
 
 * If set to **WppRecorderTrue**, timestamps of a tenth of a microsecond granularity will be added to WPP log entries.
 * If set to **WppRecorderFalse**, the timestamp will not be recorded.
@@ -110,4 +110,3 @@ This field is available starting in WDK Insider Preview build 22557. For more in
 ## -see-also
 
 <a href="/windows-hardware/drivers/ddi/wpprecorder/nf-wpprecorder-recorder_log_create_params_init">RECORDER_LOG_CREATE_PARAMS_INIT</a>
-

--- a/wdk-ddi-src/content/xpsrassvc/nf-xpsrassvc-ixpsrasterizationfactory2-createrasterizer.md
+++ b/wdk-ddi-src/content/xpsrassvc/nf-xpsrassvc-ixpsrasterizationfactory2-createrasterizer.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-The **CreateRasterizer** method creates an XPS rasterizer object that can convert content from XPS to PWG Raster using the [XPS Rasterization Service](/windows-hardware/drivers/ddi/_print/index). PWG Raster supports non-square DPIs.
+The **CreateRasterizer** method creates an XPS rasterizer object that can convert content from XPS to PWG Raster using the [XPS Rasterization Service](../_print/index.md). PWG Raster supports non-square DPIs.
 
 ## -parameters
 
@@ -59,7 +59,7 @@ Dots per inch which is applied to y dimension of the rasterized output bitmap.
 
 ### -param nonTextRenderingMode [in]
 
-Rendering mode for nontext items in the rasterized output. This parameter indicates whether to generate antialiased output. Set this parameter to one of the following [XPSRAS_RENDERING_MODE](/windows-hardware/drivers/ddi/xpsrassvc/ne-xpsrassvc-__midl___midl_itf_xpsrassvc_0000_0001_0001) enumeration values:
+Rendering mode for nontext items in the rasterized output. This parameter indicates whether to generate antialiased output. Set this parameter to one of the following [XPSRAS_RENDERING_MODE](./ne-xpsrassvc-__midl___midl_itf_xpsrassvc_0000_0001_0001.md) enumeration values:
 
 - XPSRAS_RENDERING_MODE_ANTIALIASED
 
@@ -75,7 +75,7 @@ Rendering mode for text in the rasterized output. This parameter indicates wheth
 
 ### -param pixelFormat [in]
 
-Allows a caller to select the pixel format used by the IWICBitmap returned by [IXpsRasterizer::RasterizeRect](/windows-hardware/drivers/ddi/xpsrassvc/nf-xpsrassvc-ixpsrasterizer-rasterizerect). Set this parameter to one of the following [XPSRAS_PIXEL_FORMAT](/windows-hardware/drivers/ddi/xpsrassvc/ne-xpsrassvc-__midl___midl_itf_xpsrassvc_0000_0003_0001) enumeration values:
+Allows a caller to select the pixel format used by the IWICBitmap returned by [IXpsRasterizer::RasterizeRect](./nf-xpsrassvc-ixpsrasterizer-rasterizerect.md). Set this parameter to one of the following [XPSRAS_PIXEL_FORMAT](./ne-xpsrassvc-__midl___midl_itf_xpsrassvc_0000_0003_0001.md) enumeration values:
 
 - XPSRAS_PIXEL_FORMAT_32BPP_PBGRA_UINT_SRGB
 
@@ -85,7 +85,7 @@ Allows a caller to select the pixel format used by the IWICBitmap returned by [I
 
 ### -param backgroundColor [in]
 
-Allows a caller to select background color. Set this parameter to one of the following [XPSRAS_BACKGROUND_COLOR](/windows-hardware/drivers/ddi/xpsrassvc/ne-xpsrassvc-__midl___midl_itf_xpsrassvc_0000_0004_0001) enumeration values:
+Allows a caller to select background color. Set this parameter to one of the following [XPSRAS_BACKGROUND_COLOR](./ne-xpsrassvc-__midl___midl_itf_xpsrassvc_0000_0004_0001.md) enumeration values:
 
 - XPSRAS_BACKGROUND_COLOR_TRANSPARENT
 
@@ -95,7 +95,7 @@ Allows a caller to select background color. Set this parameter to one of the fol
 
 ### -param ppIXpsRasterizer [out, optional]
 
-This parameter points to a location into which the method writes a pointer to the [IXpsRasterizer](/windows-hardware/drivers/ddi/xpsrassvc/nn-xpsrassvc-ixpsrasterizer) interface of the newly created XPS rasterizer object. If the method fails, it writes **NULL** to this location and returns an error code.
+This parameter points to a location into which the method writes a pointer to the [IXpsRasterizer](./nn-xpsrassvc-ixpsrasterizer.md) interface of the newly created XPS rasterizer object. If the method fails, it writes **NULL** to this location and returns an error code.
 
 ## -returns
 
@@ -103,4 +103,4 @@ If this method succeeds, it returns **S_OK**. Otherwise, it returns an **HRESULT
 
 ## -see-also
 
-[IXpsRasterizationFactory2](/windows-hardware/drivers/ddi/xpsrassvc/nn-xpsrassvc-ixpsrasterizationfactory2)
+[IXpsRasterizationFactory2](./nn-xpsrassvc-ixpsrasterizationfactory2.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 