### PR TITLE
HID: Add info on how to get correct `ReportBufferLength` size.

### DIFF
--- a/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_getfeature.md
+++ b/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_getfeature.md
@@ -68,6 +68,8 @@ If **HidD_GetFeature** succeeds, it returns **TRUE**; otherwise, it returns **FA
 
 ## -remarks
 
+The correct _ReportBufferLength_ is specified by the _FeatureReportByteLength_ member of a top-level collection's [HIDP_CAPS](../hidpi/ns-hidpi-_hidp_caps.md) structure returned from [HidP_GetCaps](../hidpi/nf-hidpi-hidp_getcaps.md) call.
+
 Before it calls the **HidD_GetFeature** routine, the caller must do the following:
 
 - If the [top-level collection](/windows-hardware/drivers/hid/top-level-collections) includes report IDs, the caller must set the first byte of the *ReportBuffer* parameter to a nonzero report ID.
@@ -98,6 +100,8 @@ Only user-mode applications can call **HidD_GetFeature**. Kernel-mode drivers ca
 - [HidD_GetInputReport](/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_getinputreport)
 - [HidD_SetFeature](/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_setfeature)
 - [HidD_SetOutputReport](/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_setoutputreport)
+- [HIDP_CAPS](../hidpi/ns-hidpi-_hidp_caps.md)
+- [HidP_GetCaps](../hidpi/nf-hidpi-hidp_getcaps.md)
 - [IOCTL_HID_GET_FEATURE](/windows-hardware/drivers/ddi/hidclass/ni-hidclass-ioctl_hid_get_feature)
 - [IOCTL_HID_GET_INPUT_REPORT](/windows-hardware/drivers/ddi/hidclass/ni-hidclass-ioctl_hid_get_input_report)
 - [IOCTL_HID_SET_FEATURE](/windows-hardware/drivers/ddi/hidclass/ni-hidclass-ioctl_hid_set_feature)

--- a/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_getinputreport.md
+++ b/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_getinputreport.md
@@ -70,6 +70,8 @@ The size of the report buffer in bytes. The report buffer must be large enough t
 
 ## -remarks
 
+The correct _ReportBufferLength_ is specified by the _InputReportByteLength_ member of a top-level collection's [HIDP_CAPS](../hidpi/ns-hidpi-_hidp_caps.md) structure returned from [HidP_GetCaps](../hidpi/nf-hidpi-hidp_getcaps.md) call.
+
 Before it calls the **HidD_GetInputReport** routine, the caller must do the following:
 
 - If the [top-level collection](/windows-hardware/drivers/hid/top-level-collections) includes report IDs, the caller must set the first byte of the *ReportBuffer* parameter to a nonzero report ID.
@@ -100,6 +102,8 @@ For more information, see [Interpreting HID Reports](/windows-hardware/drivers/h
 - [HidD_GetFeature](./nf-hidsdi-hidd_getfeature.md)
 - [HidD_SetFeature](./nf-hidsdi-hidd_setfeature.md)
 - [HidD_SetOutputReport](./nf-hidsdi-hidd_setoutputreport.md)
+- [HIDP_CAPS](../hidpi/ns-hidpi-_hidp_caps.md)
+- [HidP_GetCaps](../hidpi/nf-hidpi-hidp_getcaps.md)
 - [IOCTL_HID_GET_FEATURE](../hidclass/ni-hidclass-ioctl_hid_get_feature.md)
 - [IOCTL_HID_GET_INPUT_REPORT](../hidclass/ni-hidclass-ioctl_hid_get_input_report.md)
 - [IOCTL_HID_SET_FEATURE](../hidclass/ni-hidclass-ioctl_hid_set_feature.md)

--- a/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_setfeature.md
+++ b/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_setfeature.md
@@ -68,6 +68,8 @@ If **HidD_SetFeature** succeeds, it returns **TRUE**; otherwise, it returns **FA
 
 ## -remarks
 
+The correct _ReportBufferLength_ is specified by the _FeatureReportByteLength_ member of a top-level collection's [HIDP_CAPS](../hidpi/ns-hidpi-_hidp_caps.md) structure returned from [HidP_GetCaps](../hidpi/nf-hidpi-hidp_getcaps.md) call.
+
 Before it calls the **HidD_SetFeature** routine, the caller must do the following:
 
 - If the [top-level collection](/windows-hardware/drivers/hid/top-level-collections) includes report IDs, the caller must set the first byte of the _ReportBuffer_ parameter to a nonzero report ID.
@@ -90,6 +92,8 @@ Only user-mode applications can call **HidD_SetFeature**. Kernel-mode drivers ca
 - [HidD_GetFeature](/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_getfeature)
 - [HidD_GetInputReport](/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_getinputreport)
 - [HidD_SetOutputReport](/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_setoutputreport)
+- [HIDP_CAPS](../hidpi/ns-hidpi-_hidp_caps.md)
+- [HidP_GetCaps](../hidpi/nf-hidpi-hidp_getcaps.md)
 - [IOCTL_HID_GET_FEATURE](/windows-hardware/drivers/ddi/hidclass/ni-hidclass-ioctl_hid_get_feature)
 - [IOCTL_HID_GET_INPUT_REPORT](/windows-hardware/drivers/ddi/hidclass/ni-hidclass-ioctl_hid_get_input_report)
 - [IOCTL_HID_SET_FEATURE](/windows-hardware/drivers/ddi/hidclass/ni-hidclass-ioctl_hid_set_feature)

--- a/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_setoutputreport.md
+++ b/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_setoutputreport.md
@@ -68,6 +68,8 @@ If **HidD_SetOutputReport** succeeds, it returns **TRUE**; otherwise, it returns
 
 ## -remarks
 
+The correct _ReportBufferLength_ is specified by the _OutputReportByteLength_ member of a top-level collection's [HIDP_CAPS](../hidpi/ns-hidpi-_hidp_caps.md) structure returned from [HidP_GetCaps](../hidpi/nf-hidpi-hidp_getcaps.md) call.
+
 Before it calls the **HidD_SetOutputReport** routine, the caller must do the following:
 
 - If the [top-level collection](/windows-hardware/drivers/hid/top-level-collections) includes report IDs, the caller must set the first byte of the *ReportBuffer* parameter to a nonzero report ID.
@@ -90,6 +92,8 @@ Only user-mode applications can call **HidD_SetOutputReport**. Kernel-mode drive
 - [HidD_GetFeature](/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_getfeature)
 - [HidD_GetInputReport](/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_getinputreport)
 - [HidD_SetFeature](/windows-hardware/drivers/ddi/hidsdi/nf-hidsdi-hidd_setfeature)
+- [HIDP_CAPS](../hidpi/ns-hidpi-_hidp_caps.md)
+- [HidP_GetCaps](../hidpi/nf-hidpi-hidp_getcaps.md)
 - [IOCTL_HID_GET_FEATURE](/windows-hardware/drivers/ddi/hidclass/ni-hidclass-ioctl_hid_get_feature)
 - [IOCTL_HID_GET_INPUT_REPORT](/windows-hardware/drivers/ddi/hidclass/ni-hidclass-ioctl_hid_get_input_report)
 - [IOCTL_HID_SET_FEATURE](/windows-hardware/drivers/ddi/hidclass/ni-hidclass-ioctl_hid_set_feature)


### PR DESCRIPTION
See https://github.com/MicrosoftDocs/windows-driver-docs-ddi/issues/1296#issuecomment-1113277507 for more info.