### PR TITLE
LinkFix: windows-driver-docs-ddi (2022-08)

### DIFF
--- a/wdk-ddi-src/content/1394/ns-1394-_notification_info_w2k.md
+++ b/wdk-ddi-src/content/1394/ns-1394-_notification_info_w2k.md
@@ -82,7 +82,7 @@ Pointer to specific context data for this allocated address range. The driver su
 
 ### -field Fifo
 
-Pointer to the [ADDRESS_FIFO](/windows-hardware/drivers/ddi/1394/ns-1394-_address_fifo) structure that contains the FIFO element just completed. Only used if the driver submitted an ADDRESS_FIFO list in the original REQUEST_ALLOCATE_ADDRESS_RANGE request.
+Pointer to the [ADDRESS_FIFO](./ns-1394-_address_fifo.md) structure that contains the FIFO element just completed. Only used if the driver submitted an ADDRESS_FIFO list in the original REQUEST_ALLOCATE_ADDRESS_RANGE request.
 
 ### -field RequestPacket
 
@@ -106,7 +106,7 @@ If non-**NULL**, **ResponseEvent** points to a memory location that the driver f
 
 ## -remarks
 
-When a driver allocates an address range on the computer's IEEE 1394 address space, it may require that the bus driver notify it for some or all request packets sent to the allocated addresses. As part of the original allocate request, the driver may either require that the bus driver forward each packet for handling, or it may require that the bus driver handle the packet and notify the device driver when it has finished. For more information, see [REQUEST_ALLOCATE_ADDRESS_RANGE](/windows-hardware/drivers/ddi/1394/ni-1394-ioctl_1394_class).
+When a driver allocates an address range on the computer's IEEE 1394 address space, it may require that the bus driver notify it for some or all request packets sent to the allocated addresses. As part of the original allocate request, the driver may either require that the bus driver forward each packet for handling, or it may require that the bus driver handle the packet and notify the device driver when it has finished. For more information, see [REQUEST_ALLOCATE_ADDRESS_RANGE](./ni-1394-ioctl_1394_class.md).
 
 If the device driver provides no backing store, the bus driver forwards each packet to the device driver for handling. The bus driver passes **NULL** for **Mdl**, and passes the packet in **RequestPacket**. The bus driver also passes pointers to memory locations that the device driver must fill in with the buffer for the response packet (in **ResponsePacket**), the buffer length (in **ResponseLength**), and an MDL for the buffer (in **ResponseMdl**). The bus driver also supplies a memory location that the driver can use to pass a kernel event object in **ResponseEvent**. If the device driver provides an event object, the bus driver uses it to signal the driver when it has finished sending the response packet.
 
@@ -116,4 +116,4 @@ If the device driver is using a linked list of ADDRESS_FIFO's as the backing sto
 
 ## -see-also
 
-[REQUEST_ALLOCATE_ADDRESS_RANGE](/windows-hardware/drivers/ddi/1394/ni-1394-ioctl_1394_class)
+[REQUEST_ALLOCATE_ADDRESS_RANGE](./ni-1394-ioctl_1394_class.md)

--- a/wdk-ddi-src/content/61883/ns-61883-_cip_data_format_ver2.md
+++ b/wdk-ddi-src/content/61883/ns-61883-_cip_data_format_ver2.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-This structure is a CIP data format which is used by [CMP_CONNECT_VER2](/windows-hardware/drivers/ddi/61883/ns-61883-_cmp_connect_ver2).
+This structure is a CIP data format which is used by [CMP_CONNECT_VER2](./ns-61883-_cmp_connect_ver2.md).
 
 ## -struct-fields
 
@@ -74,4 +74,4 @@ This structure is a CIP data format which is used by [CMP_CONNECT_VER2](/windows
 
 ## -see-also
 
-- [AV_61883_REQUEST](/windows-hardware/drivers/ddi/61883/ns-61883-_av_61883_request)
+- [AV_61883_REQUEST](./ns-61883-_av_61883_request.md)

--- a/wdk-ddi-src/content/arrayofelements/nf-arrayofelements-arrayofelements-operator-assign.md
+++ b/wdk-ddi-src/content/arrayofelements/nf-arrayofelements-arrayofelements-operator-assign.md
@@ -50,7 +50,7 @@ The **operator=** overloaded assignment operator sets the typed data represented
 
 ## -param unnamedParam1
 
-A pointer to a **[DEBUG_TYPED_DATA](/windows-hardware/drivers/ddi/wdbgexts/ns-wdbgexts-_debug_typed_data)** structure that describes the data and type to be assigned to this object.
+A pointer to a **[DEBUG_TYPED_DATA](../wdbgexts/ns-wdbgexts-_debug_typed_data.md)** structure that describes the data and type to be assigned to this object.
 
 ## -returns
 

--- a/wdk-ddi-src/content/gpioclx/nc-gpioclx-gpio_client_enable_interrupt.md
+++ b/wdk-ddi-src/content/gpioclx/nc-gpioclx-gpio_client_enable_interrupt.md
@@ -54,7 +54,7 @@ A pointer to the GPIO controller driver's [device context](/windows-hardware/dri
 
 ### -param EnableParameters [in]
 
-A pointer to a [GPIO_ENABLE_INTERRUPT_PARAMETERS](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_gpio_enable_interrupt_parameters) structure that specifies a GPIO pin and describes the interrupt attributes of this pin.
+A pointer to a [GPIO_ENABLE_INTERRUPT_PARAMETERS](./ns-gpioclx-_gpio_enable_interrupt_parameters.md) structure that specifies a GPIO pin and describes the interrupt attributes of this pin.
 
 ## -returns
 
@@ -64,9 +64,9 @@ The *CLIENT_EnableInterrupt* function returns STATUS_SUCCESS if the call is succ
 
 This callback function is implemented by the GPIO controller driver. The GPIO framework extension (GpioClx) calls this function to enable interrupts on a GPIO pin that is configured as an interrupt request input.
 
-To register your driver's *CLIENT_EnableInterrupt* callback function, call the [GPIO_CLX_RegisterClient](/windows-hardware/drivers/ddi/gpioclx/nf-gpioclx-gpio_clx_registerclient) method. This method accepts, as an input parameter, a pointer to a [GPIO_CLIENT_REGISTRATION_PACKET](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_gpio_client_registration_packet) structure that contains a *CLIENT_EnableInterrupt* function pointer.
+To register your driver's *CLIENT_EnableInterrupt* callback function, call the [GPIO_CLX_RegisterClient](./nf-gpioclx-gpio_clx_registerclient.md) method. This method accepts, as an input parameter, a pointer to a [GPIO_CLIENT_REGISTRATION_PACKET](./ns-gpioclx-_gpio_client_registration_packet.md) structure that contains a *CLIENT_EnableInterrupt* function pointer.
 
-GpioClx always calls the *CLIENT_EnableInterrupt* and [CLIENT_DisableInterrupt](/windows-hardware/drivers/ddi/gpioclx/nc-gpioclx-gpio_client_disable_interrupt) callback functions at IRQL = PASSIVE_LEVEL. However, if the GPIO registers are memory-mapped, GpioClx calls the other interrupt-related callback functions from its ISR at DIRQL. In this case, the *CLIENT_EnableInterrupt* and *CLIENT_DisableInterrupt* functions should use the GPIO interrupt lock to synchronize their interrupt-related operations to the ISR. For more information, see [Interrupt Synchronization for GPIO Controller Drivers](/windows-hardware/drivers/gpio/interrupt-synchronization-for-gpio-controller-drivers).
+GpioClx always calls the *CLIENT_EnableInterrupt* and [CLIENT_DisableInterrupt](./nc-gpioclx-gpio_client_disable_interrupt.md) callback functions at IRQL = PASSIVE_LEVEL. However, if the GPIO registers are memory-mapped, GpioClx calls the other interrupt-related callback functions from its ISR at DIRQL. In this case, the *CLIENT_EnableInterrupt* and *CLIENT_DisableInterrupt* functions should use the GPIO interrupt lock to synchronize their interrupt-related operations to the ISR. For more information, see [Interrupt Synchronization for GPIO Controller Drivers](/windows-hardware/drivers/gpio/interrupt-synchronization-for-gpio-controller-drivers).
 
 ### Examples
 
@@ -94,7 +94,7 @@ The GPIO_CLIENT_ENABLE_INTERRUPT function type is defined in the Gpioclx.h heade
 
 ## -see-also
 
-- [CLIENT_DisableInterrupt](/windows-hardware/drivers/ddi/gpioclx/nc-gpioclx-gpio_client_disable_interrupt)
-- [GPIO_CLIENT_REGISTRATION_PACKET](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_gpio_client_registration_packet)
-- [GPIO_CLX_RegisterClient](/windows-hardware/drivers/ddi/gpioclx/nf-gpioclx-gpio_clx_registerclient)
-- [GPIO_ENABLE_INTERRUPT_PARAMETERS](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_gpio_enable_interrupt_parameters)
+- [CLIENT_DisableInterrupt](./nc-gpioclx-gpio_client_disable_interrupt.md)
+- [GPIO_CLIENT_REGISTRATION_PACKET](./ns-gpioclx-_gpio_client_registration_packet.md)
+- [GPIO_CLX_RegisterClient](./nf-gpioclx-gpio_clx_registerclient.md)
+- [GPIO_ENABLE_INTERRUPT_PARAMETERS](./ns-gpioclx-_gpio_enable_interrupt_parameters.md)

--- a/wdk-ddi-src/content/gpioclx/ns-gpioclx-_client_controller_query_set_information_input.md
+++ b/wdk-ddi-src/content/gpioclx/ns-gpioclx-_client_controller_query_set_information_input.md
@@ -56,7 +56,7 @@ The **CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT** structure contains a reque
 
 ### -field RequestType
 
-The type of attribute information that is being requested. This member is set to a [CLIENT_CONTROLLER_QUERY_SET_REQUEST_TYPE](/windows-hardware/drivers/ddi/gpioclx/ne-gpioclx-_client_controller_query_set_request_type) enumeration value.
+The type of attribute information that is being requested. This member is set to a [CLIENT_CONTROLLER_QUERY_SET_REQUEST_TYPE](./ne-gpioclx-_client_controller_query_set_request_type.md) enumeration value.
 
 ### -field Size
 
@@ -72,7 +72,7 @@ A structure that contains information about the GPIO bank whose power attributes
 
 ### -field BankPowerInformation.BankId
 
-The identifier for a bank of GPIO pins. If M is the number of banks in the GPIO controller, **BankId** is an integer in the range 0 to M–1\. The GPIO framework extension (GpioClx) previously obtained the number of banks in the controller from the [CLIENT_QueryControllerBasicInformation](/windows-hardware/drivers/ddi/gpioclx/nc-gpioclx-gpio_client_query_controller_basic_information) event callback function. For more information, see Remarks in [CLIENT_CONTROLLER_BASIC_INFORMATION](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_basic_information).
+The identifier for a bank of GPIO pins. If M is the number of banks in the GPIO controller, **BankId** is an integer in the range 0 to M–1\. The GPIO framework extension (GpioClx) previously obtained the number of banks in the controller from the [CLIENT_QueryControllerBasicInformation](./nc-gpioclx-gpio_client_query_controller_basic_information.md) event callback function. For more information, see Remarks in [CLIENT_CONTROLLER_BASIC_INFORMATION](./ns-gpioclx-_client_controller_basic_information.md).
 
 ### -field BankInterruptBinding
 
@@ -88,7 +88,7 @@ A handle to a framework resource-list object that identifies the raw hardware re
 
 ### -field BankInterruptBinding.TotalBanks
 
-The number of banks in the GPIO controller. This member indicates the expected length of the **BankInterruptBinding.ResourceMapping** array in the caller-allocated [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_query_set_information_output) structure, if the caller supplies a non-NULL pointer to this structure.
+The number of banks in the GPIO controller. This member indicates the expected length of the **BankInterruptBinding.ResourceMapping** array in the caller-allocated [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](./ns-gpioclx-_client_controller_query_set_information_output.md) structure, if the caller supplies a non-NULL pointer to this structure.
 
 ### -field ControllerFunctionBankMapping
 
@@ -108,7 +108,7 @@ The size, in bytes, of the output buffer for the IOCTL.
 
 ### -field ControllerFunctionBankMapping.TotalBanks
 
-The number of banks in the GPIO controller. This member indicates the expected length of the **ControllerFunctionBankMapping.Mapping** array in the caller-allocated [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_query_set_information_output) structure, if the caller supplies a non-NULL pointer to this structure.
+The number of banks in the GPIO controller. This member indicates the expected length of the **ControllerFunctionBankMapping.Mapping** array in the caller-allocated [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](./ns-gpioclx-_client_controller_query_set_information_output.md) structure, if the caller supplies a non-NULL pointer to this structure.
 
 ## -remarks
 
@@ -120,11 +120,11 @@ The unnamed union contains input information for the various types of attribute 
 | QueryBankInterruptBindingInformation | BankInterruptBinding |
 | QueryControllerFunctionBankMappingInformation | ControllerFunctionBankMapping |
 
-The *InputBuffer* parameter of the [CLIENT_QuerySetControllerInformation](/windows-hardware/drivers/ddi/gpioclx/nc-gpioclx-gpio_client_query_set_controller_information) function is a pointer to a **CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT** structure.
+The *InputBuffer* parameter of the [CLIENT_QuerySetControllerInformation](./nc-gpioclx-gpio_client_query_set_controller_information.md) function is a pointer to a **CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT** structure.
 
 ## -see-also
 
-- [CLIENT_CONTROLLER_BASIC_INFORMATION](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_basic_information)
-- [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_query_set_information_output)
-- [CLIENT_QueryControllerBasicInformation](/windows-hardware/drivers/ddi/gpioclx/nc-gpioclx-gpio_client_query_controller_basic_information)
-- [CLIENT_QuerySetControllerInformation](/windows-hardware/drivers/ddi/gpioclx/nc-gpioclx-gpio_client_query_set_controller_information)
+- [CLIENT_CONTROLLER_BASIC_INFORMATION](./ns-gpioclx-_client_controller_basic_information.md)
+- [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](./ns-gpioclx-_client_controller_query_set_information_output.md)
+- [CLIENT_QueryControllerBasicInformation](./nc-gpioclx-gpio_client_query_controller_basic_information.md)
+- [CLIENT_QuerySetControllerInformation](./nc-gpioclx-gpio_client_query_set_controller_information.md)

--- a/wdk-ddi-src/content/gpioclx/ns-gpioclx-_client_controller_query_set_information_output.md
+++ b/wdk-ddi-src/content/gpioclx/ns-gpioclx-_client_controller_query_set_information_output.md
@@ -64,7 +64,7 @@ Specifies the size, in bytes, of this structure.
 
 ### -field BankPowerInformation
 
-A [CLIENT_QUERY_BANK_POWER_INFORMATION_OUTPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_query_bank_power_information_output) structure that contains the power attributes of the GPIO bank that is identified by the **BankPowerInformation.BankId** member of the corresponding **CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT** structure.
+A [CLIENT_QUERY_BANK_POWER_INFORMATION_OUTPUT](./ns-gpioclx-_client_query_bank_power_information_output.md) structure that contains the power attributes of the GPIO bank that is identified by the **BankPowerInformation.BankId** member of the corresponding **CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT** structure.
 
 ### -field BankInterruptBinding
 
@@ -74,7 +74,7 @@ A structure that contains information about the binding of interrupt resources t
 
 An array of interrupt resource numbers. The number of elements in the array equals the number of GPIO banks. If N is the number of banks in the GPIO controller, the banks are numbered 0 to N–1. Element 0 of the array contains the interrupt resource number that is bound to bank 0, element 1 contains the interrupt resource number that is bound to bank 1, and so on. No more than one interrupt resource can be bound to a GPIO bank, but two or more banks might share an interrupt resource. If a bank is not bound to an interrupt resource, the corresponding array element is set to **GPIO_BANK_INTERRUPT_BINDING_RESERVED_INDEX** (0xffff).
 
-An interrupt resource is identified by its resource number, which is the index of the resource in the **ResourcesTranslated** or **ResourcesRaw** resource list in the **BankInterruptBinding** member of the [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_query_set_information_input) structure. If a list contains M resources, the resources are numbered 0 to M-1\. Only resource numbers that correspond to interrupt resources in the resource list can appear in the **ResourceMapping** array.
+An interrupt resource is identified by its resource number, which is the index of the resource in the **ResourcesTranslated** or **ResourcesRaw** resource list in the **BankInterruptBinding** member of the [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT](./ns-gpioclx-_client_controller_query_set_information_input.md) structure. If a list contains M resources, the resources are numbered 0 to M-1\. Only resource numbers that correspond to interrupt resources in the resource list can appear in the **ResourceMapping** array.
 
 ### -field ControllerFunctionBankMapping
 
@@ -86,12 +86,12 @@ An array of BOOLEAN values that indicates the mapping of required F0 power state
 
 ## -remarks
 
-The unnamed union contains output information for the various types of attribute requests. The **RequestType** member of the corresponding [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_query_set_information_input) structure determines which of these members is used.
+The unnamed union contains output information for the various types of attribute requests. The **RequestType** member of the corresponding [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT](./ns-gpioclx-_client_controller_query_set_information_input.md) structure determines which of these members is used.
 
-The optional *OutputBuffer* parameter of the [CLIENT_QuerySetControllerInformation](/windows-hardware/drivers/ddi/gpioclx/nc-gpioclx-gpio_client_query_set_controller_information) function is a pointer to a caller-allocated **CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT** structure. The function writes the requested attribute information to this structure, if *OutputBuffer* is non-NULL.
+The optional *OutputBuffer* parameter of the [CLIENT_QuerySetControllerInformation](./nc-gpioclx-gpio_client_query_set_controller_information.md) function is a pointer to a caller-allocated **CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT** structure. The function writes the requested attribute information to this structure, if *OutputBuffer* is non-NULL.
 
 ## -see-also
 
-- [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_query_set_information_input)
-- [CLIENT_QUERY_BANK_POWER_INFORMATION_OUTPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_query_bank_power_information_output)
-- [CLIENT_QuerySetControllerInformation](/windows-hardware/drivers/ddi/gpioclx/nc-gpioclx-gpio_client_query_set_controller_information)
+- [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_INPUT](./ns-gpioclx-_client_controller_query_set_information_input.md)
+- [CLIENT_QUERY_BANK_POWER_INFORMATION_OUTPUT](./ns-gpioclx-_client_query_bank_power_information_output.md)
+- [CLIENT_QuerySetControllerInformation](./nc-gpioclx-gpio_client_query_set_controller_information.md)

--- a/wdk-ddi-src/content/gpioclx/ns-gpioclx-_client_query_bank_power_information_output.md
+++ b/wdk-ddi-src/content/gpioclx/ns-gpioclx-_client_query_bank_power_information_output.md
@@ -64,17 +64,17 @@ Not used.
 
 ### -field F1IdleStateParameters
 
-A **PO_FX_COMPONENT_IDLE_STATE** structure that describes the parameters (transition latency, residency requirement, and so on) for the F1 power state of the GPIO bank. For more information about these parameters, see [PO_FX_COMPONENT_IDLE_STATE](/windows-hardware/drivers/ddi/wdm/ns-wdm-_po_fx_component_idle_state).
+A **PO_FX_COMPONENT_IDLE_STATE** structure that describes the parameters (transition latency, residency requirement, and so on) for the F1 power state of the GPIO bank. For more information about these parameters, see [PO_FX_COMPONENT_IDLE_STATE](../wdm/ns-wdm-_po_fx_component_idle_state.md).
 
 ## -remarks
 
 The unnamed struct inside _CLIENT_QUERY_BANK_POWER_INFORMATION_OUTPUT contains a set of power-management flag bits.
 
-The **BankPowerInformation** member of the [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_query_set_information_output) structure is a structure of type **CLIENT_QUERY_BANK_POWER_INFORMATION_OUTPUT**.
+The **BankPowerInformation** member of the [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](./ns-gpioclx-_client_controller_query_set_information_output.md) structure is a structure of type **CLIENT_QUERY_BANK_POWER_INFORMATION_OUTPUT**.
 
 For more information about GPIO banks, see [Partioning a GPIO Controller into Banks of Pins](/windows-hardware/drivers/gpio/partitioning-a-gpio-controller-into-banks-of-pins).
 
 ## -see-also
 
-- [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](/windows-hardware/drivers/ddi/gpioclx/ns-gpioclx-_client_controller_query_set_information_output)
-- [PO_FX_COMPONENT_IDLE_STATE](/windows-hardware/drivers/ddi/wdm/ns-wdm-_po_fx_component_idle_state)
+- [CLIENT_CONTROLLER_QUERY_SET_INFORMATION_OUTPUT](./ns-gpioclx-_client_controller_query_set_information_output.md)
+- [PO_FX_COMPONENT_IDLE_STATE](../wdm/ns-wdm-_po_fx_component_idle_state.md)

--- a/wdk-ddi-src/content/ks/nc-ks-pfnksfilterprocess.md
+++ b/wdk-ddi-src/content/ks/nc-ks-pfnksfilterprocess.md
@@ -47,11 +47,11 @@ An AVStream minidriver's *AVStrMiniFilterProcess* routine is called when the fil
 
 ### -param Filter [in]
 
-Pointer to the [KSFILTER](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter) structure that must process frames.
+Pointer to the [KSFILTER](./ns-ks-_ksfilter.md) structure that must process frames.
 
 ### -param Index
 
-Pointer to an array of [KSPROCESSPIN_INDEXENTRY](/windows-hardware/drivers/ddi/ks/ns-ks-_ksprocesspin_indexentry) structures that AVStream orders by pin ID.
+Pointer to an array of [KSPROCESSPIN_INDEXENTRY](./ns-ks-_ksprocesspin_indexentry.md) structures that AVStream orders by pin ID.
 
 ## -returns
 
@@ -59,7 +59,7 @@ Return STATUS_SUCCESS to continue processing. Return STATUS_PENDING to stop proc
 
 ## -remarks
 
-The minidriver specifies this routine's address in the **Process** member of its [KSFILTER_DISPATCH](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter_dispatch) structure.
+The minidriver specifies this routine's address in the **Process** member of its [KSFILTER_DISPATCH](./ns-ks-_ksfilter_dispatch.md) structure.
 
 The routine is called at either IRQL = DISPATCH_LEVEL or PASSIVE_LEVEL depending on the preference expressed in the filter descriptor. Filter descriptors that specify KSFILTER_FLAG_DISPATCH_LEVEL_PROCESSING may have their process callback at DISPATCH_LEVEL; filter descriptors that do not specify this flag will have their process callback at PASSIVE_LEVEL.
 
@@ -69,6 +69,6 @@ This routine is optional.
 
 ## -see-also
 
-[KSFILTER_DISPATCH](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter_dispatch)
+[KSFILTER_DISPATCH](./ns-ks-_ksfilter_dispatch.md)
 
-[KSPROCESSPIN_INDEXENTRY](/windows-hardware/drivers/ddi/ks/ns-ks-_ksprocesspin_indexentry)
+[KSPROCESSPIN_INDEXENTRY](./ns-ks-_ksprocesspin_indexentry.md)

--- a/wdk-ddi-src/content/ks/nc-ks-pfnkspinframereturn.md
+++ b/wdk-ddi-src/content/ks/nc-ks-pfnkspinframereturn.md
@@ -47,19 +47,19 @@ An AVStream minidriver's *AVStrMiniFrameReturn* routine is called when an inject
 
 ### -param Pin [in]
 
-Pointer to a [KSPIN](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin) structure representing the pin on which the frame was injected.
+Pointer to a [KSPIN](./ns-ks-_kspin.md) structure representing the pin on which the frame was injected.
 
 ### -param Data [in, optional]
 
-Pointer to the buffer originally specified in the call to [KsPinSubmitFrame](/windows-hardware/drivers/ddi/ks/nf-ks-kspinsubmitframe).
+Pointer to the buffer originally specified in the call to [KsPinSubmitFrame](./nf-ks-kspinsubmitframe.md).
 
 ### -param Size [in, optional]
 
-Specifies the size in bytes of*Data* as originally specified in [KsPinSubmitFrame](/windows-hardware/drivers/ddi/ks/nf-ks-kspinsubmitframe).
+Specifies the size in bytes of*Data* as originally specified in [KsPinSubmitFrame](./nf-ks-kspinsubmitframe.md).
 
 ### -param Mdl [in, optional]
 
-Pointer to a memory descriptor list describing the injected frame as in the call to [KsPinSubmitFrameMdl](/windows-hardware/drivers/ddi/ks/nf-ks-kspinsubmitframemdl).
+Pointer to a memory descriptor list describing the injected frame as in the call to [KsPinSubmitFrameMdl](./nf-ks-kspinsubmitframemdl.md).
 
 ### -param Context [in, optional]
 
@@ -71,10 +71,10 @@ Contains a copy of*Irp->IoStatus.Status* for the IRP to which the requested fram
 
 ## -remarks
 
-The minidriver specifies this routine's address in the*FrameReturn* parameter of a call to [KsPinRegisterFrameReturnCallback](/windows-hardware/drivers/ddi/ks/nf-ks-kspinregisterframereturncallback).
+The minidriver specifies this routine's address in the*FrameReturn* parameter of a call to [KsPinRegisterFrameReturnCallback](./nf-ks-kspinregisterframereturncallback.md).
 
 ## -see-also
 
-[KsPinRegisterFrameReturnCallback](/windows-hardware/drivers/ddi/ks/nf-ks-kspinregisterframereturncallback)
+[KsPinRegisterFrameReturnCallback](./nf-ks-kspinregisterframereturncallback.md)
 
-[KsPinSubmitFrameMdl](/windows-hardware/drivers/ddi/ks/nf-ks-kspinsubmitframemdl)
+[KsPinSubmitFrameMdl](./nf-ks-kspinsubmitframemdl.md)

--- a/wdk-ddi-src/content/ks/nf-ks-ksdeviceregisteradapterobject.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksdeviceregisteradapterobject.md
@@ -42,17 +42,17 @@ api_name:
 
 ## -description
 
-The **KsDeviceRegisterAdapterObject** function registers a DMA adapter object with AVStream for performing scatter/gather DMA on the specified device. All drivers compiled for Win64 should use [IKsDeviceFunctions::RegisterAdapterObjectEx](/windows-hardware/drivers/ddi/ks/nf-ks-iksdevicefunctions-registeradapterobjectex) instead.
+The **KsDeviceRegisterAdapterObject** function registers a DMA adapter object with AVStream for performing scatter/gather DMA on the specified device. All drivers compiled for Win64 should use [IKsDeviceFunctions::RegisterAdapterObjectEx](./nf-ks-iksdevicefunctions-registeradapterobjectex.md) instead.
 
 ## -parameters
 
 ### -param Device [in]
 
-A pointer to the [KSDEVICE](/windows-hardware/drivers/ddi/ks/ns-ks-_ksdevice) structure representing the AVStream device for which to register an adapter object.
+A pointer to the [KSDEVICE](./ns-ks-_ksdevice.md) structure representing the AVStream device for which to register an adapter object.
 
 ### -param AdapterObject [in]
 
-A pointer to the [DMA_ADAPTER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_dma_adapter) structure returned by [IoGetDmaAdapter](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdmaadapter) that represents the DMA controller..
+A pointer to the [DMA_ADAPTER](../wdm/ns-wdm-_dma_adapter.md) structure returned by [IoGetDmaAdapter](../wdm/nf-wdm-iogetdmaadapter.md) that represents the DMA controller..
 
 ### -param MaxMappingsByteCount [in]
 
@@ -60,15 +60,15 @@ This parameter specifies the maximum number of bytes that the device can handle 
 
 ### -param MappingTableStride [in]
 
-This parameter specifies how many bytes each entry in the mapping table requires. This must be at least **sizeof** ([KSMAPPING](/windows-hardware/drivers/ddi/ks/ns-ks-_ksmapping)) and can be as large as necessary.
+This parameter specifies how many bytes each entry in the mapping table requires. This must be at least **sizeof** ([KSMAPPING](./ns-ks-_ksmapping.md)) and can be as large as necessary.
 
 Additional space can be used by the minidriver as context information.
 
 ## -remarks
 
-A minidriver that calls **KsDeviceRegisterAdapterObject** is responsible for previously acquiring the adapter object through [IoGetDmaAdapter](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdmaadapter).
+A minidriver that calls **KsDeviceRegisterAdapterObject** is responsible for previously acquiring the adapter object through [IoGetDmaAdapter](../wdm/nf-wdm-iogetdmaadapter.md).
 
-Also note that if the minidriver specifies the KSPIN_FLAG_GENERATE_MAPPINGS flag for any pin on any filter on the device, the minidriver must call **KsDeviceRegisterAdapterObject** before processing any data. More information about this flag can be found in the reference page for [KSPIN_DESCRIPTOR_EX](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin_descriptor_ex). Also see [AVStream DMA Services](/windows-hardware/drivers/stream/avstream-dma-services).
+Also note that if the minidriver specifies the KSPIN_FLAG_GENERATE_MAPPINGS flag for any pin on any filter on the device, the minidriver must call **KsDeviceRegisterAdapterObject** before processing any data. More information about this flag can be found in the reference page for [KSPIN_DESCRIPTOR_EX](./ns-ks-_kspin_descriptor_ex.md). Also see [AVStream DMA Services](/windows-hardware/drivers/stream/avstream-dma-services).
 
 > [!IMPORTANT]
 > Essential information required for user successIf you set *MaxMappingByteCount* to one physical page in length, mappings are not guaranteed to reside on a single physical page. In addition, as noted in the member description above, setting *MaxMappingsByteCount* does not guarantee that breaks will occur on page boundaries. If you require breaks on page boundaries, consider not specifying a limit on mapping sizes; instead, break the returned scatter/gather mappings into page-aligned chunks manually.
@@ -77,10 +77,10 @@ Also see [Supporting DMA in 64-Bit AVStream Drivers](/windows-hardware/drivers/s
 
 ## -see-also
 
-[IoGetDmaAdapter](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdmaadapter)
+[IoGetDmaAdapter](../wdm/nf-wdm-iogetdmaadapter.md)
 
-[KSFILTER_DESCRIPTOR](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter_descriptor)
+[KSFILTER_DESCRIPTOR](./ns-ks-_ksfilter_descriptor.md)
 
-[KSMAPPING](/windows-hardware/drivers/ddi/ks/ns-ks-_ksmapping)
+[KSMAPPING](./ns-ks-_ksmapping.md)
 
-[KSPIN_DESCRIPTOR_EX](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin_descriptor_ex)
+[KSPIN_DESCRIPTOR_EX](./ns-ks-_kspin_descriptor_ex.md)

--- a/wdk-ddi-src/content/ks/nf-ks-ksenableeventwithallocator.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksenableeventwithallocator.md
@@ -66,7 +66,7 @@ If the enabling event's KSEVENT_SET.AddHandler for the event set is **NULL**, it
 
 ### -param EventsFlags [in, optional]
 
-Specifies [KSEVENTS_LOCKTYPE](/windows-hardware/drivers/ddi/ks/ne-ks-ksevents_locktype) flags specifying the type of exclusion lock to be used in accessing the event list, if any. If no flag is set, then no lock is taken. If a handler is specified already, this parameter is ignored.
+Specifies [KSEVENTS_LOCKTYPE](./ne-ks-ksevents_locktype.md) flags specifying the type of exclusion lock to be used in accessing the event list, if any. If no flag is set, then no lock is taken. If a handler is specified already, this parameter is ignored.
 
 ### -param EventsLock [in, optional]
 

--- a/wdk-ddi-src/content/ks/nf-ks-ksinitializedriver.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksinitializedriver.md
@@ -48,7 +48,7 @@ The **KsInitializeDriver** function initializes the driver object of an AVStream
 
 ### -param DriverObject [in]
 
-A pointer to the [DRIVER_OBJECT](/windows-hardware/drivers/ddi/wdm/ns-wdm-_driver_object) structure for the AVStream driver being initialized. Minidrivers that call **KsInitializeDriver** should use the driver object passed to **DriverEntry** by the operating system.
+A pointer to the [DRIVER_OBJECT](../wdm/ns-wdm-_driver_object.md) structure for the AVStream driver being initialized. Minidrivers that call **KsInitializeDriver** should use the driver object passed to **DriverEntry** by the operating system.
 
 ### -param RegistryPathName [in]
 
@@ -56,11 +56,11 @@ A pointer to a Unicode string containing the registry path string passed into th
 
 ### -param Descriptor [in, optional]
 
-A pointer to a [KSDEVICE_DESCRIPTOR](/windows-hardware/drivers/ddi/ks/ns-ks-_ksdevice_descriptor) structure that specifies the characteristics of the device being initialized. If this pointer is **NULL**, a device is created with default characteristics and no associated filter factories.
+A pointer to a [KSDEVICE_DESCRIPTOR](./ns-ks-_ksdevice_descriptor.md) structure that specifies the characteristics of the device being initialized. If this pointer is **NULL**, a device is created with default characteristics and no associated filter factories.
 
 ## -returns
 
-**KsInitializeDriver** returns STATUS_SUCCESS or an appropriate error code as returned by [IoCreateDevice](/windows-hardware/drivers/ddi/wdm/nf-wdm-iocreatedevice) or internal AVStream device initialization routines.
+**KsInitializeDriver** returns STATUS_SUCCESS or an appropriate error code as returned by [IoCreateDevice](../wdm/nf-wdm-iocreatedevice.md) or internal AVStream device initialization routines.
 
 ## -remarks
 
@@ -68,18 +68,18 @@ This function is typically called from **DriverEntry**. If the minidriver passes
 
 ## -see-also
 
-[DEVICE_OBJECT](/windows-hardware/drivers/ddi/wdm/ns-wdm-_device_object)
+[DEVICE_OBJECT](../wdm/ns-wdm-_device_object.md)
 
-[DRIVER_OBJECT](/windows-hardware/drivers/ddi/wdm/ns-wdm-_driver_object)
+[DRIVER_OBJECT](../wdm/ns-wdm-_driver_object.md)
 
 [DriverEntry of AVStream](/previous-versions/ff558721(v=vs.85))
 
-[IoCreateDevice](/windows-hardware/drivers/ddi/wdm/nf-wdm-iocreatedevice)
+[IoCreateDevice](../wdm/nf-wdm-iocreatedevice.md)
 
-[KSDEVICE_DESCRIPTOR](/windows-hardware/drivers/ddi/ks/ns-ks-_ksdevice_descriptor)
+[KSDEVICE_DESCRIPTOR](./ns-ks-_ksdevice_descriptor.md)
 
-[KSDEVICE_DISPATCH](/windows-hardware/drivers/ddi/ks/ns-ks-_ksdevice_dispatch)
+[KSDEVICE_DISPATCH](./ns-ks-_ksdevice_dispatch.md)
 
-[KSFILTER_DESCRIPTOR](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter_descriptor)
+[KSFILTER_DESCRIPTOR](./ns-ks-_ksfilter_descriptor.md)
 
-[KsInitializeDevice](/windows-hardware/drivers/ddi/ks/nf-ks-ksinitializedevice)
+[KsInitializeDevice](./nf-ks-ksinitializedevice.md)

--- a/wdk-ddi-src/content/ks/nf-ks-kspinsubmitframe.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspinsubmitframe.md
@@ -42,13 +42,13 @@ api_name:
 
 ## -description
 
-If a pin has been placed into injection mode by a call to [KsPinRegisterFrameReturnCallback](/windows-hardware/drivers/ddi/ks/nf-ks-kspinregisterframereturncallback), the **KsPinSubmitFrame** function submits a frame directly into the transport circuit.
+If a pin has been placed into injection mode by a call to [KsPinRegisterFrameReturnCallback](./nf-ks-kspinregisterframereturncallback.md), the **KsPinSubmitFrame** function submits a frame directly into the transport circuit.
 
 ## -parameters
 
 ### -param Pin [in]
 
-A pointer to the [KSPIN](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin) structure on which to submit a frame.
+A pointer to the [KSPIN](./ns-ks-_kspin.md) structure on which to submit a frame.
 
 ### -param Data [in, optional]
 
@@ -60,11 +60,11 @@ The size in bytes of the frame buffer to which the *Data* field points. If the *
 
 ### -param StreamHeader [in, optional]
 
-A pointer to a [KSSTREAM_HEADER](/windows-hardware/drivers/ddi/ks/ns-ks-ksstream_header) structure. The stream header is copied if this parameter is supplied. Optional.
+A pointer to a [KSSTREAM_HEADER](./ns-ks-ksstream_header.md) structure. The stream header is copied if this parameter is supplied. Optional.
 
 ### -param Context [in, optional]
 
-A pointer to a caller-allocated buffer. AVStream provides this pointer to the frame return callback registered through a call to [KsPinRegisterFrameReturnCallback](/windows-hardware/drivers/ddi/ks/nf-ks-kspinregisterframereturncallback). Optional.
+A pointer to a caller-allocated buffer. AVStream provides this pointer to the frame return callback registered through a call to [KsPinRegisterFrameReturnCallback](./nf-ks-kspinregisterframereturncallback.md). Optional.
 
 ## -returns
 
@@ -72,6 +72,6 @@ Returns STATUS_SUCCESS if frame submission is successful. Otherwise returns an a
 
 ## -see-also
 
-[KsPinRegisterFrameReturnCallback](/windows-hardware/drivers/ddi/ks/nf-ks-kspinregisterframereturncallback)
+[KsPinRegisterFrameReturnCallback](./nf-ks-kspinregisterframereturncallback.md)
 
-[KsPinSubmitFrameMdl](/windows-hardware/drivers/ddi/ks/nf-ks-kspinsubmitframemdl)
+[KsPinSubmitFrameMdl](./nf-ks-kspinsubmitframemdl.md)

--- a/wdk-ddi-src/content/ks/nf-ks-kspropertyhandlerwithallocator.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspropertyhandlerwithallocator.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-The **KsPropertyHandlerWithAllocator** performs the same handling as [KsPropertyHandler](/windows-hardware/drivers/ddi/ks/nf-ks-kspropertyhandler), with the same restrictions, but allows an optional allocator callback to be used to provide a buffer for the parameters. If used, the filter may need to free the buffer in some nonconventional manner. IRP_BUFFERED_IO and IRP_DEALLOCATE_BUFFER flags are not set when using a custom allocator.
+The **KsPropertyHandlerWithAllocator** performs the same handling as [KsPropertyHandler](./nf-ks-kspropertyhandler.md), with the same restrictions, but allows an optional allocator callback to be used to provide a buffer for the parameters. If used, the filter may need to free the buffer in some nonconventional manner. IRP_BUFFERED_IO and IRP_DEALLOCATE_BUFFER flags are not set when using a custom allocator.
 
 ## -parameters
 
@@ -77,6 +77,6 @@ On 64-bit platforms, if the *PropertyItemSize* parameter is not a multiple of 8,
 
 ## -see-also
 
-[KsFastPropertyHandler](/windows-hardware/drivers/ddi/ks/nf-ks-ksfastpropertyhandler)
+[KsFastPropertyHandler](./nf-ks-ksfastpropertyhandler.md)
 
-[KsPropertyHandler](/windows-hardware/drivers/ddi/ks/nf-ks-kspropertyhandler)
+[KsPropertyHandler](./nf-ks-kspropertyhandler.md)

--- a/wdk-ddi-src/content/ks/nf-ks-kssetdevicepnpandbaseobject.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kssetdevicepnpandbaseobject.md
@@ -64,6 +64,6 @@ None
 
 ## -see-also
 
-[KsAllocateDeviceHeader](/windows-hardware/drivers/ddi/ks/nf-ks-ksallocatedeviceheader)
+[KsAllocateDeviceHeader](./nf-ks-ksallocatedeviceheader.md)
 
-[KsRecalculateStackDepth](/windows-hardware/drivers/ddi/ks/nf-ks-ksrecalculatestackdepth)
+[KsRecalculateStackDepth](./nf-ks-ksrecalculatestackdepth.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_aer_capabilities.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_aer_capabilities.md
@@ -99,12 +99,12 @@ A ULONG representation of the contents of the PCI_EXPRESS_AER_CAPABILITIES struc
 
 The PCI_EXPRESS_AER_CAPABILITIES structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_AER_CAPABILITIES structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structures.
+A PCI_EXPRESS_AER_CAPABILITIES structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md) structures.
 
 ## -see-also
 
-[PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability)
+[PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md)
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_capabilities_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_capabilities_register.md
@@ -57,7 +57,7 @@ The **DUMMYSTRUCTNAME** structure.
 
 ### -field DUMMYSTRUCTNAME.CapabilityVersion
 
-The version number of the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure that contains the PCI_EXPRESS_CAPABILITIES_REGISTER structure.
+The version number of the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure that contains the PCI_EXPRESS_CAPABILITIES_REGISTER structure.
 
 ### -field DUMMYSTRUCTNAME.DeviceType
 
@@ -110,8 +110,8 @@ A USHORT representation of the contents of the PCI_EXPRESS_CAPABILITIES_REGISTER
 
 The PCI_EXPRESS_CAPABILITIES_REGISTER structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_CAPABILITIES_REGISTER structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A PCI_EXPRESS_CAPABILITIES_REGISTER structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_correctable_error_mask.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_correctable_error_mask.md
@@ -107,12 +107,12 @@ A ULONG representation of the contents of the PCI_EXPRESS_CORRECTABLE_ERROR_MASK
 
 The PCI_EXPRESS_CORRECTABLE_ERROR_MASK structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_CORRECTABLE_ERROR_MASK structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structures.
+A PCI_EXPRESS_CORRECTABLE_ERROR_MASK structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md) structures.
 
 ## -see-also
 
-[PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability)
+[PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md)
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_correctable_error_status.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_correctable_error_status.md
@@ -107,12 +107,12 @@ A ULONG representation of the contents of the PCI_EXPRESS_CORRECTABLE_ERROR_STAT
 
 The PCI_EXPRESS_CORRECTABLE_ERROR_STATUS structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_CORRECTABLE_ERROR_STATUS structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structures.
+A PCI_EXPRESS_CORRECTABLE_ERROR_STATUS structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md) structures.
 
 ## -see-also
 
-[PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability)
+[PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md)
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_device_capabilities_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_device_capabilities_register.md
@@ -201,8 +201,8 @@ A ULONG representation of the contents of the PCI_EXPRESS_DEVICE_CAPABILITIES_RE
 
 The PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_device_control_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_device_control_register.md
@@ -155,8 +155,8 @@ A **USHORT** representation of the contents of the **PCI_EXPRESS_DEVICE_CONTROL_
 
 The **PCI_EXPRESS_DEVICE_CONTROL_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_DEVICE_CONTROL_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_DEVICE_CONTROL_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_device_status_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_device_status_register.md
@@ -91,8 +91,8 @@ A **USHORT** representation of the contents of the **PCI_EXPRESS_DEVICE_STATUS_R
 
 The **PCI_EXPRESS_DEVICE_STATUS_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_DEVICE_STATUS_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_DEVICE_STATUS_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_error_source_id.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_error_source_id.md
@@ -87,8 +87,8 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_ERROR_SOURCE_ID*
 
 The **PCI_EXPRESS_ERROR_SOURCE_ID** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_ERROR_SOURCE_ID** structure is contained in the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structure.
+A **PCI_EXPRESS_ERROR_SOURCE_ID** structure is contained in the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_link_capabilities_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_link_capabilities_register.md
@@ -197,8 +197,8 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_LINK_CAPABILITIE
 
 The **PCI_EXPRESS_LINK_CAPABILITIES_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_LINK_CAPABILITIES_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_LINK_CAPABILITIES_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_link_control_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_link_control_register.md
@@ -111,8 +111,8 @@ A **USHORT** representation of the contents of the **PCI_EXPRESS_LINK_CONTROL_RE
 
 The **PCI_EXPRESS_LINK_CONTROL_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_LINK_CONTROL_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_LINK_CONTROL_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_link_status_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_link_status_register.md
@@ -108,8 +108,8 @@ A USHORT representation of the contents of the PCI_EXPRESS_LINK_STATUS_REGISTER 
 
 The PCI_EXPRESS_LINK_STATUS_REGISTER structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_LINK_STATUS_REGISTER structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A PCI_EXPRESS_LINK_STATUS_REGISTER structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_pme_requestor_id.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_pme_requestor_id.md
@@ -75,8 +75,8 @@ A USHORT representation of the contents of the **PCI_EXPRESS_PME_REQUESTOR_ID** 
 
 The **PCI_EXPRESS_PME_REQUESTOR_ID** structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_PME_REQUESTOR_ID structure is contained in the **PMERequestorId** member of the [PCI_EXPRESS_ROOT_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_root_status_register) structure.
+A PCI_EXPRESS_PME_REQUESTOR_ID structure is contained in the **PMERequestorId** member of the [PCI_EXPRESS_ROOT_STATUS_REGISTER](../ntddk/ns-ntddk-_pci_express_root_status_register.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_ROOT_STATUS_REGISTER](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_root_status_register)
+[PCI_EXPRESS_ROOT_STATUS_REGISTER](../ntddk/ns-ntddk-_pci_express_root_status_register.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_capabilities_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_capabilities_register.md
@@ -71,8 +71,8 @@ A **USHORT** representation of the contents of the **PCI_EXPRESS_ROOT_CAPABILITI
 
 The **PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_control_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_control_register.md
@@ -87,8 +87,8 @@ A **USHORT** representation of the contents of the **PCI_EXPRESS_ROOT_CONTROL_RE
 
 The **PCI_EXPRESS_ROOT_CONTROL_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_ROOT_CONTROL_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_ROOT_CONTROL_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_error_command.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_error_command.md
@@ -79,8 +79,8 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_ROOT_ERROR_COMMA
 
 The **PCI_EXPRESS_ROOT_ERROR_COMMAND** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_ROOT_ERROR_COMMAND** structure is contained in the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structure.
+A **PCI_EXPRESS_ROOT_ERROR_COMMAND** structure is contained in the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_error_status.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_error_status.md
@@ -99,8 +99,8 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_ROOT_ERROR_STATU
 
 The **PCI_EXPRESS_ROOT_ERROR_STATUS** union is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_ROOT_ERROR_STATUS** union is contained in the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structure.
+A **PCI_EXPRESS_ROOT_ERROR_STATUS** union is contained in the [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_status_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_root_status_register.md
@@ -57,7 +57,7 @@ The **DUMMYSTRUCTNAME** structure.
 
 ### -field DUMMYSTRUCTNAME.PMERequestorId
 
-A [PCI_EXPRESS_PME_REQUESTOR_ID](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_pme_requestor_id) structure that describes the power management event (PME) requester identifier of the last PME requester.
+A [PCI_EXPRESS_PME_REQUESTOR_ID](../ntddk/ns-ntddk-_pci_express_pme_requestor_id.md) structure that describes the power management event (PME) requester identifier of the last PME requester.
 
 ### -field DUMMYSTRUCTNAME.PMEStatus
 
@@ -79,10 +79,10 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_ROOT_STATUS_REGI
 
 The **PCI_EXPRESS_ROOT_STATUS_REGISTER** union is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_ROOT_STATUS_REGISTER** union is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_ROOT_STATUS_REGISTER** union is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)
 
-[PCI_EXPRESS_PME_REQUESTOR_ID](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_pme_requestor_id)
+[PCI_EXPRESS_PME_REQUESTOR_ID](../ntddk/ns-ntddk-_pci_express_pme_requestor_id.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_sec_aer_capabilities.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_sec_aer_capabilities.md
@@ -71,8 +71,8 @@ A ULONG representation of the contents of the **PCI_EXPRESS_SEC_AER_CAPABILITIES
 
 The **PCI_EXPRESS_SEC_AER_CAPABILITIES** union is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_SEC_AER_CAPABILITIES** union is contained in the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability) structure.
+A **PCI_EXPRESS_SEC_AER_CAPABILITIES** union is contained in the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_sec_uncorrectable_error_mask.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_sec_uncorrectable_error_mask.md
@@ -123,8 +123,8 @@ A ULONG representation of the contents of the **PCI_EXPRESS_SEC_UNCORRECTABLE_ER
 
 The **PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK** structure is contained in the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability) structure.
+A **PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK** structure is contained in the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_sec_uncorrectable_error_severity.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_sec_uncorrectable_error_severity.md
@@ -123,8 +123,8 @@ A ULONG representation of the contents of the **PCI_EXPRESS_SEC_UNCORRECTABLE_ER
 
 The **PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY** structure is contained in the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability) structure.
+A **PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY** structure is contained in the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_sec_uncorrectable_error_status.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_sec_uncorrectable_error_status.md
@@ -123,8 +123,8 @@ A ULONG representation of the contents of the **PCI_EXPRESS_SEC_UNCORRECTABLE_ER
 
 The **PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS** structure is contained in the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability) structure.
+A **PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS** structure is contained in the [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_slot_capabilities_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_slot_capabilities_register.md
@@ -123,8 +123,8 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_SLOT_CAPABILITIE
 
 The **PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_slot_control_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_slot_control_register.md
@@ -135,8 +135,8 @@ A **USHORT** representation of the contents of the **PCI_EXPRESS_SLOT_CONTROL_RE
 
 The **PCI_EXPRESS_SLOT_CONTROL_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_SLOT_CONTROL_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_SLOT_CONTROL_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_slot_status_register.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_slot_status_register.md
@@ -115,8 +115,8 @@ A **USHORT** representation of the contents of the **PCI_EXPRESS_SLOT_STATUS_REG
 
 The **PCI_EXPRESS_SLOT_STATUS_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_SLOT_STATUS_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability) structure.
+A **PCI_EXPRESS_SLOT_STATUS_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-[PCI_EXPRESS_CAPABILITY](/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability)
+[PCI_EXPRESS_CAPABILITY](../ntddk/ns-ntddk-_pci_express_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_uncorrectable_error_mask.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_uncorrectable_error_mask.md
@@ -143,12 +143,12 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_UNCORRECTABLE_ER
 
 The **PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK** structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structures.
+A **PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK** structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md) structures.
 
 ## -see-also
 
-[PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability)
+[PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md)
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_uncorrectable_error_severity.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_uncorrectable_error_severity.md
@@ -143,12 +143,12 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_UNCORRECTABLE_ER
 
 The PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structures.
+A PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md) structures.
 
 ## -see-also
 
-[PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability)
+[PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md)
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_uncorrectable_error_status.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_express_uncorrectable_error_status.md
@@ -143,12 +143,12 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_UNCORRECTABLE_ER
 
 The **PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS** structure is available in Windows Server 2008 and later versions of Windows.
 
-A **PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS** structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability) structures.
+A **PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS** structure is contained in the [PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md), [PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md), and [PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md) structures.
 
 ## -see-also
 
-[PCI_EXPRESS_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_aer_capability)
+[PCI_EXPRESS_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_aer_capability.md)
 
-[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_bridge_aer_capability)
+[PCI_EXPRESS_BRIDGE_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_bridge_aer_capability.md)
 
-[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_express_rootport_aer_capability)
+[PCI_EXPRESS_ROOTPORT_AER_CAPABILITY](../wdm/ns-wdm-_pci_express_rootport_aer_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_pm_capability.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_pm_capability.md
@@ -53,7 +53,7 @@ The **PCI_PM_CAPABILITY** structure reports the power management capabilities of
 
 ### -field Header
 
-Contains a structure of type [PCI_CAPABILITIES_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_capabilities_header) that identifies the capability and provides a link to the next capability description.
+Contains a structure of type [PCI_CAPABILITIES_HEADER](../wdm/ns-wdm-_pci_capabilities_header.md) that identifies the capability and provides a link to the next capability description.
 
 ### -field PMC
 
@@ -61,7 +61,7 @@ The power management capabilities union (offset = 2).
 
 ### -field PMC.Capabilities
 
-Contains a structure of type [PCI_PMC](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_pmc) that specifies the power management capabilities of the device. This information was retrieved from the power management capabilities register (offset 2 in the power management register block). For more information about the contents of the power management capabilities register, see the *PCI Power Management Specification*.
+Contains a structure of type [PCI_PMC](../wdm/ns-wdm-_pci_pmc.md) that specifies the power management capabilities of the device. This information was retrieved from the power management capabilities register (offset 2 in the power management register block). For more information about the contents of the power management capabilities register, see the *PCI Power Management Specification*.
 
 ### -field PMC.AsUSHORT
 
@@ -73,7 +73,7 @@ The power management control/status union (offset = 4).
 
 ### -field PMCSR.ControlStatus
 
-Contains a structure of type [PCI_PMCSR](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_pmcsr) that reports the contents of the power management control status register. This register is used to monitor power management event signals and manage the device's power state. For more information about the contents of the power management control status register, see the *PCI Power Management Specification*.
+Contains a structure of type [PCI_PMCSR](../wdm/ns-wdm-_pci_pmcsr.md) that reports the contents of the power management control status register. This register is used to monitor power management event signals and manage the device's power state. For more information about the contents of the power management control status register, see the *PCI Power Management Specification*.
 
 ### -field PMCSR.AsUSHORT
 
@@ -85,7 +85,7 @@ The PMCSR PCI-PCI bridge support extensions union.
 
 ### -field PMCSR_BSE.BridgeSupport
 
-Contains a structure of type [PCI_PMCSR_BSE](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_pmcsr_bse) that reports the contents of the power management control status register for PCI bridge support extensions.
+Contains a structure of type [PCI_PMCSR_BSE](../wdm/ns-wdm-_pci_pmcsr_bse.md) that reports the contents of the power management control status register for PCI bridge support extensions.
 
 ### -field PMCSR_BSE.AsUCHAR
 
@@ -97,10 +97,10 @@ Holds the contents of an optional data register that the device uses to report s
 
 ## -see-also
 
-[PCI_PMCSR](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_pmcsr)
+[PCI_PMCSR](../wdm/ns-wdm-_pci_pmcsr.md)
 
-[PCI_CAPABILITIES_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_capabilities_header)
+[PCI_CAPABILITIES_HEADER](../wdm/ns-wdm-_pci_capabilities_header.md)
 
-[PCI_PMC](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_pmc)
+[PCI_PMC](../wdm/ns-wdm-_pci_pmc.md)
 
-[PCI_PMCSR_BSE](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_pmcsr_bse)
+[PCI_PMCSR_BSE](../wdm/ns-wdm-_pci_pmcsr_bse.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_pci_pmc.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_pci_pmc.md
@@ -117,4 +117,4 @@ The power management capabilities register, whose contents are reported in the *
 
 ## -see-also
 
-[PCI_PM_CAPABILITY](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_pm_capability)
+[PCI_PM_CAPABILITY](../wdm/ns-wdm-_pci_pm_capability.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-pci_x_capability.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-pci_x_capability.md
@@ -50,7 +50,7 @@ The **PCI_X_CAPABILITY** structure reports the contents of the command and statu
 
 ### -field Header
 
-Contains a structure of type [PCI_CAPABILITIES_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_capabilities_header) that identifies the capability and provides a link to the next capability description.
+Contains a structure of type [PCI_CAPABILITIES_HEADER](../wdm/ns-wdm-_pci_capabilities_header.md) that identifies the capability and provides a link to the next capability description.
 
 ### -field Command
 
@@ -154,4 +154,4 @@ Reports the data in the device's status register in the form of a unsigned long 
 
 ## -see-also
 
-[PCI_CAPABILITIES_HEADER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_pci_capabilities_header)
+[PCI_CAPABILITIES_HEADER](../wdm/ns-wdm-_pci_capabilities_header.md)

--- a/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_aid_routing_info.md
+++ b/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_aid_routing_info.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-SECURE_ELEMENT_AID_ROUTING_INFO is a member of [SECURE_ELEMENT_ROUTING_TABLE_ENTRY](/windows-hardware/drivers/ddi/nfcsedev/ns-nfcsedev-_secure_element_routing_table_entry).
+SECURE_ELEMENT_AID_ROUTING_INFO is a member of [SECURE_ELEMENT_ROUTING_TABLE_ENTRY](./ns-nfcsedev-_secure_element_routing_table_entry.md).
 
 ## -struct-fields
 
@@ -68,4 +68,4 @@ Buffer holding ISO 7816 AID.
 
 ## see-also
 
-- [SECURE_ELEMENT_ROUTING_TABLE_ENTRY](/windows-hardware/drivers/ddi/nfcsedev/ns-nfcsedev-_secure_element_routing_table_entry)
+- [SECURE_ELEMENT_ROUTING_TABLE_ENTRY](./ns-nfcsedev-_secure_element_routing_table_entry.md)

--- a/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_endpoint_list.md
+++ b/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_endpoint_list.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-The output parameter for [IOCTL_NFCSE_ENUM_ENDPOINTS](/windows-hardware/drivers/ddi/nfcsedev/ni-nfcsedev-ioctl_nfcse_enum_endpoints).
+The output parameter for [IOCTL_NFCSE_ENUM_ENDPOINTS](./ni-nfcsedev-ioctl_nfcse_enum_endpoints.md).
 
 ## -struct-fields
 
@@ -60,4 +60,4 @@ The number of enumerated endpoints on the NFC controller.
 
 ### -field EndpointList[ANYSIZE_ARRAY]
 
-An array of [SECURE_ELEMENT_ENDPOINT_INFO](/windows-hardware/drivers/ddi/nfcsedev/ns-nfcsedev-_secure_element_endpoint_info) structures.
+An array of [SECURE_ELEMENT_ENDPOINT_INFO](./ns-nfcsedev-_secure_element_endpoint_info.md) structures.

--- a/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_event_info.md
+++ b/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_event_info.md
@@ -60,7 +60,7 @@ This is a unique identifier for the secure element.
 
 ### -field eEventType
 
-This is an event type. For more information about the types, see the [SECURE_ELEMENT_EVENT_TYPE](/windows-hardware/drivers/ddi/nfcsedev/ne-nfcsedev-_secure_element_event_type) enumeration topic.
+This is an event type. For more information about the types, see the [SECURE_ELEMENT_EVENT_TYPE](./ne-nfcsedev-_secure_element_event_type.md) enumeration topic.
 
 ### -field cbEventData
 
@@ -68,7 +68,7 @@ This is the amount of bytes for the pbEventData array.
 
 ### -field pbEventData[ANYSIZE_ARRAY]
 
-This is the event data buffer. When **eEventType** is **HceActivated** or **HceDeactivated**, this member contains a pointer to a [SECURE_ELEMENT_HCE_ACTIVATION_PAYLOAD](/windows-hardware/drivers/ddi/nfcsedev/ns-nfcsedev-_secure_element_hce_activation_payload) structure. The **bConnectionId** member in that structure is the same ID value that's used in [SECURE_ELEMENT_HCE_DATA_PACKET](/windows-hardware/drivers/ddi/nfcsedev/ns-nfcsedev-_secure_element_hce_data_packet) to send and receive an HCE packet with [IOCTL_NFCSE_HCE_REMOTE_SEND](/windows-hardware/drivers/ddi/nfcsedev/ni-nfcsedev-ioctl_nfcse_hce_remote_send) and [IOCTL_NFCSE_HCE_REMOTE_RECV](/windows-hardware/drivers/ddi/nfcsedev/ni-nfcsedev-ioctl_nfcse_hce_remote_recv).
+This is the event data buffer. When **eEventType** is **HceActivated** or **HceDeactivated**, this member contains a pointer to a [SECURE_ELEMENT_HCE_ACTIVATION_PAYLOAD](./ns-nfcsedev-_secure_element_hce_activation_payload.md) structure. The **bConnectionId** member in that structure is the same ID value that's used in [SECURE_ELEMENT_HCE_DATA_PACKET](./ns-nfcsedev-_secure_element_hce_data_packet.md) to send and receive an HCE packet with [IOCTL_NFCSE_HCE_REMOTE_SEND](./ni-nfcsedev-ioctl_nfcse_hce_remote_send.md) and [IOCTL_NFCSE_HCE_REMOTE_RECV](./ni-nfcsedev-ioctl_nfcse_hce_remote_recv.md).
 
 When **eEventType** is **ExternalReaderArrival** or **ExternalReaderDeparture**, **pbEventData** is empty and **cbEventData** is 0.
 

--- a/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_hce_data_packet.md
+++ b/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_hce_data_packet.md
@@ -50,13 +50,13 @@ api_name:
 
 ## -description
 
-**SECURE_ELEMENT_HCE_DATA_PACKET** is an input buffer to [IOCTL_NFCSE_HCE_REMOTE_SEND](/windows-hardware/drivers/ddi/nfcsedev/ni-nfcsedev-ioctl_nfcse_hce_remote_send) and output buffer for [IOCTL_NFCSE_HCE_REMOTE_RECV](/windows-hardware/drivers/ddi/nfcsedev/ni-nfcsedev-ioctl_nfcse_hce_remote_recv).
+**SECURE_ELEMENT_HCE_DATA_PACKET** is an input buffer to [IOCTL_NFCSE_HCE_REMOTE_SEND](./ni-nfcsedev-ioctl_nfcse_hce_remote_send.md) and output buffer for [IOCTL_NFCSE_HCE_REMOTE_RECV](./ni-nfcsedev-ioctl_nfcse_hce_remote_recv.md).
 
 ## -struct-fields
 
 ### -field bConnectionId
 
-The ID of the connection established between the device and the smart card reader, on which to send and receive the HCE packet. This ID is also received from [IOCTL_NFCSE_GET_NEXT_EVENT](/windows-hardware/drivers/ddi/nfcsedev/ni-nfcsedev-ioctl_nfcse_get_next_event) when the event type ([SECURE_ELEMENT_EVENT_TYPE](/windows-hardware/drivers/ddi/nfcsedev/ne-nfcsedev-_secure_element_event_type)) is **HceActivated** or **HceDeactivated**. Then the **pbEventData** field of the returned [SECURE_ELEMENT_EVENT_INFO](/windows-hardware/drivers/ddi/nfcsedev/ns-nfcsedev-_secure_element_event_info) structure is a [SECURE_ELEMENT_HCE_ACTIVATION_PAYLOAD](/windows-hardware/drivers/ddi/nfcsedev/ns-nfcsedev-_secure_element_hce_activation_payload) structure, which contains a **bConnectionId** member.
+The ID of the connection established between the device and the smart card reader, on which to send and receive the HCE packet. This ID is also received from [IOCTL_NFCSE_GET_NEXT_EVENT](./ni-nfcsedev-ioctl_nfcse_get_next_event.md) when the event type ([SECURE_ELEMENT_EVENT_TYPE](./ne-nfcsedev-_secure_element_event_type.md)) is **HceActivated** or **HceDeactivated**. Then the **pbEventData** field of the returned [SECURE_ELEMENT_EVENT_INFO](./ns-nfcsedev-_secure_element_event_info.md) structure is a [SECURE_ELEMENT_HCE_ACTIVATION_PAYLOAD](./ns-nfcsedev-_secure_element_hce_activation_payload.md) structure, which contains a **bConnectionId** member.
 
 ### -field cbPayload
 

--- a/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_routing_table.md
+++ b/wdk-ddi-src/content/nfcsedev/ns-nfcsedev-_secure_element_routing_table.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-SECURE_ELEMENT_ROUTING_TABLE is an input parameter for [IOCTL_NFCSE_SET_ROUTING_TABLE](/windows-hardware/drivers/ddi/nfcsedev/ni-nfcsedev-ioctl_nfcse_set_routing_table).
+SECURE_ELEMENT_ROUTING_TABLE is an input parameter for [IOCTL_NFCSE_SET_ROUTING_TABLE](./ni-nfcsedev-ioctl_nfcse_set_routing_table.md).
 
 ## -struct-fields
 

--- a/wdk-ddi-src/content/ntddpcm/nc-ntddpcm-pcmcia_modify_memory_window.md
+++ b/wdk-ddi-src/content/ntddpcm/nc-ntddpcm-pcmcia_modify_memory_window.md
@@ -95,5 +95,5 @@ Callers of this routine must be running at IRQL <= DISPATCH_LEVEL. To maintain o
 
 ## -see-also
 
-- [PCMCIA_IS_WRITE_PROTECTED](/windows-hardware/drivers/ddi/ntddpcm/nc-ntddpcm-pcmcia_is_write_protected)
-- [PCMCIA_SET_VPP](/windows-hardware/drivers/ddi/ntddpcm/nc-ntddpcm-pcmcia_set_vpp)
+- [PCMCIA_IS_WRITE_PROTECTED](./nc-ntddpcm-pcmcia_is_write_protected.md)
+- [PCMCIA_SET_VPP](./nc-ntddpcm-pcmcia_set_vpp.md)

--- a/wdk-ddi-src/content/ntddsysenv/ns-ntddsysenv-_sysenv_value.md
+++ b/wdk-ddi-src/content/ntddsysenv/ns-ntddsysenv-_sysenv_value.md
@@ -50,7 +50,7 @@ api_name:
 
 ## -description
 
-Stores the value of a system environment variable using SysEnv device. This structure is used in the [IOCTL_SYSENV_GET_VARIABLE](/windows-hardware/drivers/ddi/ntddsysenv/ni-ntddsysenv-ioctl_sysenv_get_variable) request.
+Stores the value of a system environment variable using SysEnv device. This structure is used in the [IOCTL_SYSENV_GET_VARIABLE](./ni-ntddsysenv-ioctl_sysenv_get_variable.md) request.
 
 ## -struct-fields
 
@@ -68,4 +68,4 @@ The value of the system environment variable.
 
 ## -see-also
 
-- [IOCTL_SYSENV_GET_VARIABLE](/windows-hardware/drivers/ddi/ntddsysenv/ni-ntddsysenv-ioctl_sysenv_get_variable)
+- [IOCTL_SYSENV_GET_VARIABLE](./ni-ntddsysenv-ioctl_sysenv_get_variable.md)

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntqueryvolumeinformationfile.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntqueryvolumeinformationfile.md
@@ -92,7 +92,7 @@ If the **FileHandle** represents a direct device open, only **FileFsDeviceInform
 
 **NtQueryVolumeInformationFile** returns zero in any member of a **FILE_**XXX**_INFORMATION** structure that is not supported by the file system.
 
-For information about other file information query routines, see [File Objects](/windows-hardware/drivers/ddi/_kernel/#file-objects).
+For information about other file information query routines, see [File Objects](../_kernel/index.md#file-objects).
 
 Minifilters should use [**FltQueryVolumeInformationFile**](../fltkernel/nf-fltkernel-fltqueryvolumeinformationfile.md) instead of **NtQueryVolumeInformationFile**.
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-zwqueryvolumeinformationfile.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-zwqueryvolumeinformationfile.md
@@ -54,7 +54,7 @@ A handle to a file object returned by [**ZwCreateFile**](../wdm/nf-wdm-zwcreatef
 
 ### -param IoStatusBlock [out]
 
-A pointer to an [**IO_STATUS_BLOCK**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_io_status_block) structure that receives the final completion status and information about the query operation. For successful calls that return data, the number of bytes written to the **FsInformation** buffer is returned in the structure's **Information** member.
+A pointer to an [**IO_STATUS_BLOCK**](../wdm/ns-wdm-_io_status_block.md) structure that receives the final completion status and information about the query operation. For successful calls that return data, the number of bytes written to the **FsInformation** buffer is returned in the structure's **Information** member.
 
 ### -param FsInformation [out]
 
@@ -92,7 +92,7 @@ If the **FileHandle** represents a direct device open, only **FileFsDeviceInform
 
 **ZwQueryVolumeInformationFile** returns zero in any member of a **FILE_**XXX**_INFORMATION** structure that is not supported by the file system.
 
-For information about other file information query routines, see [File Objects](/windows-hardware/drivers/ddi/_kernel/#file-objects).
+For information about other file information query routines, see [File Objects](../_kernel/index.md#file-objects).
 
 Minifilters should use [**FltQueryVolumeInformationFile**](../fltkernel/nf-fltkernel-fltqueryvolumeinformationfile.md) instead of **ZwQueryVolumeInformationFile**.
 

--- a/wdk-ddi-src/content/pcivirt/nc-pcivirt-sriov_get_vendor_and_device_ids.md
+++ b/wdk-ddi-src/content/pcivirt/nc-pcivirt-sriov_get_vendor_and_device_ids.md
@@ -83,7 +83,7 @@ This callback function is implemented by the physical function (PF) driver. It i
 
 The PCI Express SR-IOV Specification requires that all VFs have the same Vendor and Device IDs.  This is a requirement of compliant hardware.  However, it's possible to provision VFs such that their capabilities differ from each other, and it's often useful to load different drivers on different hardware.  So Windows allows the  PF driver to supply separate Device and Vendor IDs (with different class codes, through the configuration space interfaces) such that each VF may appear with the Plug and Play IDs that are most appropriate for its use.
 
-The PF driver registers its implementation by setting the **GetVendorAndDevice** member of the [SRIOV_DEVICE_INTERFACE_STANDARD](/windows-hardware/drivers/ddi/pcivirt/ns-pcivirt-_sriov_device_interface_standard), configuring a [WDF_QUERY_INTERFACE_CONFIG](..\wdfqueryinterface\ns-wdfqueryinterface-_wdf_query_interface_config.md) structure, and calling [WdfDeviceAddQueryInterface](..\wdfqueryinterface\nf-wdfqueryinterface-wdfdeviceaddqueryinterface.md).
+The PF driver registers its implementation by setting the **GetVendorAndDevice** member of the [SRIOV_DEVICE_INTERFACE_STANDARD](./ns-pcivirt-_sriov_device_interface_standard.md), configuring a [WDF_QUERY_INTERFACE_CONFIG](..\wdfqueryinterface\ns-wdfqueryinterface-_wdf_query_interface_config.md) structure, and calling [WdfDeviceAddQueryInterface](..\wdfqueryinterface\nf-wdfqueryinterface-wdfdeviceaddqueryinterface.md).
 
 Here is an example implementation of this callback function.
 

--- a/wdk-ddi-src/content/pepfx/ns-pepfx-_pep_ppm_perf_set_state.md
+++ b/wdk-ddi-src/content/pepfx/ns-pepfx-_pep_ppm_perf_set_state.md
@@ -75,4 +75,4 @@ On input, the new requested energy performance preference for the processor.
 
 ## -see-also
 
-- [Processor power management (PPM) notifications](/windows-hardware/drivers/ddi/index)
+- [Processor power management (PPM) notifications](../index.yml)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelper-enumconstrainedoptions.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelper-enumconstrainedoptions.md
@@ -47,7 +47,7 @@ The **IPrintCoreHelper::EnumConstrainedOptions** method provides a list of all o
 
 ### -param pDevmode [in, optional]
 
-A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelper::EnumConstrainedOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemPS::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-devmode) or [IPrintOemUni::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-devmode) or from a print ticket provider, this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets), is being serviced by the core driver's UI module.
+A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelper::EnumConstrainedOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemPS::DevMode](./nf-prcomoem-iprintoemps-devmode.md) or [IPrintOemUni::DevMode](./nf-prcomoem-iprintoemuni-devmode.md) or from a print ticket provider, this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md), is being serviced by the core driver's UI module.
 
 ### -param cbSize [in]
 
@@ -79,8 +79,8 @@ A pointer to a variable that receives the number of constrained options in the a
 
 ## -see-also
 
-[IPrintCoreHelper](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelper)
+[IPrintCoreHelper](./nn-prcomoem-iprintcorehelper.md)
 
-[IPrintCoreHelper::EnumOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelper-enumoptions)
+[IPrintCoreHelper::EnumOptions](./nf-prcomoem-iprintcorehelper-enumoptions.md)
 
-[IPrintCoreHelper::WhyConstrained](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelper-whyconstrained)
+[IPrintCoreHelper::WhyConstrained](./nf-prcomoem-iprintcorehelper-whyconstrained.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelper-enumfeatures.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelper-enumfeatures.md
@@ -63,6 +63,6 @@ For Unidrv features, the feature list is based on the GPD view of the configurat
 
 ## -see-also
 
-[IPrintCoreHelper](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelper)
+[IPrintCoreHelper](./nn-prcomoem-iprintcorehelper.md)
 
-[IPrintCoreHelper::EnumOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelper-enumoptions)
+[IPrintCoreHelper::EnumOptions](./nf-prcomoem-iprintcorehelper-enumoptions.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelper-enumoptions.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelper-enumoptions.md
@@ -67,6 +67,6 @@ When **IPrintCoreHelper::EnumOptions** returns, the option list contains all opt
 
 ## -see-also
 
-[IPrintCoreHelper](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelper)
+[IPrintCoreHelper](./nn-prcomoem-iprintcorehelper.md)
 
-[IPrintCoreHelper::EnumFeatures](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelper-enumfeatures)
+[IPrintCoreHelper::EnumFeatures](./nf-prcomoem-iprintcorehelper-enumfeatures.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelper-setoptions.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelper-setoptions.md
@@ -47,7 +47,7 @@ The **IPrintCoreHelper::SetOptions** method sets multiple feature-option pairs a
 
 ### -param pDevmode [in, optional]
 
-A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelper::SetOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from either [IPrintOemPS::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-devmode) or [IPrintOemUni::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-devmode), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets), is being serviced by the core driver's UI module.
+A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelper::SetOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from either [IPrintOemPS::DevMode](./nf-prcomoem-iprintoemps-devmode.md) or [IPrintOemUni::DevMode](./nf-prcomoem-iprintoemuni-devmode.md), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md), is being serviced by the core driver's UI module.
 
 ### -param cbSize [in]
 
@@ -59,7 +59,7 @@ A Boolean value that indicates whether **IPrintCoreHelper::SetOptions** should r
 
 ### -param pFOPairs [in]
 
-An array of [PRINT_FEATURE_OPTION](/windows-hardware/drivers/ddi/prcomoem/ns-prcomoem-_print_feature_option) elements, where each element contains a feature-option pair. Each feature-option pair lists a feature and the option to select for that feature. All settings are applied sequentially. Duplicates are not disallowed, but settings that appear later in the array (that is, at a higher index) override those that appear earlier in the array.
+An array of [PRINT_FEATURE_OPTION](./ns-prcomoem-_print_feature_option.md) elements, where each element contains a feature-option pair. Each feature-option pair lists a feature and the option to select for that feature. All settings are applied sequentially. Duplicates are not disallowed, but settings that appear later in the array (that is, at a higher index) override those that appear earlier in the array.
 
 ### -param cPairs [in]
 
@@ -99,6 +99,6 @@ For most scenarios, the *bResolveConflicts* parameter should be set to **TRUE**.
 
 ## -see-also
 
-[IPrintCoreHelper](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelper)
+[IPrintCoreHelper](./nn-prcomoem-iprintcorehelper.md)
 
-[IPrintCoreHelper::GetOption](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelper-getoption)
+[IPrintCoreHelper::GetOption](./nf-prcomoem-iprintcorehelper-getoption.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-enumconstrainedoptions.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-enumconstrainedoptions.md
@@ -47,7 +47,7 @@ The **IPrintCoreHelperPS::EnumConstrainedOptions** method provides a list of all
 
 ### -param pDevmode [in, optional]
 
-A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelperPS::EnumConstrainedOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemPS::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-devmode), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets), is being serviced by the core driver's UI module.
+A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelperPS::EnumConstrainedOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemPS::DevMode](./nf-prcomoem-iprintoemps-devmode.md), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md), is being serviced by the core driver's UI module.
 
 ### -param cbSize [in]
 
@@ -79,6 +79,6 @@ A pointer to a variable that receives the number of constrained options in the a
 
 ## -see-also
 
-[IPrintCoreHelperPS](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperps)
+[IPrintCoreHelperPS](./nn-prcomoem-iprintcorehelperps.md)
 
-[IPrintCoreHelperPS::EnumOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-enumoptions)
+[IPrintCoreHelperPS::EnumOptions](./nf-prcomoem-iprintcorehelperps-enumoptions.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-enumfeatures.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-enumfeatures.md
@@ -59,6 +59,6 @@ Returns **S_OK** if the operation succeeds. Otherwise, this method should return
 
 ## -see-also
 
-[IPrintCoreHelperPS](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperps)
+[IPrintCoreHelperPS](./nn-prcomoem-iprintcorehelperps.md)
 
-[IPrintCoreHelperPS::EnumOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-enumoptions)
+[IPrintCoreHelperPS::EnumOptions](./nf-prcomoem-iprintcorehelperps-enumoptions.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-enumoptions.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-enumoptions.md
@@ -67,8 +67,8 @@ When **IPrintCoreHelperPS::EnumOptions** returns, the option list contains all o
 
 ## -see-also
 
-[IPrintCoreHelperPS](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperps)
+[IPrintCoreHelperPS](./nn-prcomoem-iprintcorehelperps.md)
 
-[IPrintCoreHelperPS::EnumConstrainedOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-enumconstrainedoptions)
+[IPrintCoreHelperPS::EnumConstrainedOptions](./nf-prcomoem-iprintcorehelperps-enumconstrainedoptions.md)
 
-[IPrintCoreHelperPS::EnumFeatures](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-enumfeatures)
+[IPrintCoreHelperPS::EnumFeatures](./nf-prcomoem-iprintcorehelperps-enumfeatures.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-getfeatureattribute.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-getfeatureattribute.md
@@ -47,7 +47,7 @@ The **IPrintCoreHelperPS::GetFeatureAttribute** method retrieves the feature att
 
 ### -param pszFeatureKeyword [in]
 
-A pointer to a caller-supplied buffer that contains an ANSI string that specifies the feature keyword to query for. This value can be obtained from a prior call to [IPrintCoreHelperPS::EnumFeatures](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-enumfeatures).
+A pointer to a caller-supplied buffer that contains an ANSI string that specifies the feature keyword to query for. This value can be obtained from a prior call to [IPrintCoreHelperPS::EnumFeatures](./nf-prcomoem-iprintcorehelperps-enumfeatures.md).
 
 ### -param pszAttribute [in]
 
@@ -55,7 +55,7 @@ A pointer to a caller-supplied buffer that contains an ANSI string that specifie
 
 ### -param pdwDataType [out]
 
-A pointer to a variable that receives a value that specifies the data type of the requested attribute. This value is an enumerator of the [EATTRIBUTE_DATATYPE](/windows-hardware/drivers/ddi/printoem/ne-printoem-_eattribute_datatype) enumeration type, which is defined in printoem.h.
+A pointer to a variable that receives a value that specifies the data type of the requested attribute. This value is an enumerator of the [EATTRIBUTE_DATATYPE](../printoem/ne-printoem-_eattribute_datatype.md) enumeration type, which is defined in printoem.h.
 
 ### -param ppbData [out]
 
@@ -78,14 +78,14 @@ A pointer to a variable that receives the size, in bytes, of the buffer that is 
 
 ## -remarks
 
-If **IPrintCoreHelperPS::GetFeatureAttribute** is called with its *pszAttribute* and *pbData* parameters set to **NULL**, the method returns with *pcbSize* set to the number of bytes that are needed for the list of all of the supported attribute names for the feature. If this method is called a second time, with *pszAttribute* set to **NULL** and *pbData* pointing to a buffer of the size that was specified in *pcbSize* in the previous call, the method returns with *pdwDataType* set to kADT_ASCII (an enumerator of the [EATTRIBUTE_DATATYPE](/windows-hardware/drivers/ddi/printoem/ne-printoem-_eattribute_datatype) enumeration type) and *pbData* pointing to a NULL-delimited list of all of the supported attribute names for the feature. This list is terminated with two null characters.
+If **IPrintCoreHelperPS::GetFeatureAttribute** is called with its *pszAttribute* and *pbData* parameters set to **NULL**, the method returns with *pcbSize* set to the number of bytes that are needed for the list of all of the supported attribute names for the feature. If this method is called a second time, with *pszAttribute* set to **NULL** and *pbData* pointing to a buffer of the size that was specified in *pcbSize* in the previous call, the method returns with *pdwDataType* set to kADT_ASCII (an enumerator of the [EATTRIBUTE_DATATYPE](../printoem/ne-printoem-_eattribute_datatype.md) enumeration type) and *pbData* pointing to a NULL-delimited list of all of the supported attribute names for the feature. This list is terminated with two null characters.
 
 For more information about **IPrintCoreHelperPS::GetFeatureAttribute**, see [Using GetFeatureAttribute](/windows-hardware/drivers/print/using-getfeatureattribute).
 
 ## -see-also
 
-[IPrintCoreHelperPS](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperps)
+[IPrintCoreHelperPS](./nn-prcomoem-iprintcorehelperps.md)
 
-[IPrintCoreHelperPS::GetGlobalAttribute](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-getglobalattribute)
+[IPrintCoreHelperPS::GetGlobalAttribute](./nf-prcomoem-iprintcorehelperps-getglobalattribute.md)
 
-[IPrintCoreHelperPS::GetOptionAttribute](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-getoptionattribute)
+[IPrintCoreHelperPS::GetOptionAttribute](./nf-prcomoem-iprintcorehelperps-getoptionattribute.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-getglobalattribute.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-getglobalattribute.md
@@ -51,7 +51,7 @@ A pointer to a caller-supplied buffer that contains an ANSI string that specifie
 
 ### -param pdwDataType [out]
 
-A pointer to variable that receives a value that specifies the data type of the requested attribute. This value is an enumerator of the [EATTRIBUTE_DATATYPE](/windows-hardware/drivers/ddi/printoem/ne-printoem-_eattribute_datatype) enumeration type, which is defined in printoem.h.
+A pointer to variable that receives a value that specifies the data type of the requested attribute. This value is an enumerator of the [EATTRIBUTE_DATATYPE](../printoem/ne-printoem-_eattribute_datatype.md) enumeration type, which is defined in printoem.h.
 
 ### -param ppbData [out]
 
@@ -74,14 +74,14 @@ A pointer to a variable that specifies the size, in bytes, of the buffer that is
 
 ## -remarks
 
-If **IPrintCoreHelperPS::GetGlobalAttribute** is called with its *pszAttribute* and *pbData* parameters set to **NULL**, the method returns with *pcbSize* set to the number of bytes that are needed for the list of all of the supported global attribute names. If this method is called a second time, with *pszAttribute* set to **NULL** and *pbData* pointing to a buffer of the size that was specified in *pcbSize* in the previous call, the method returns with *pdwDataType* set to kADT_ASCII (an enumerator of the [EATTRIBUTE_DATATYPE](/windows-hardware/drivers/ddi/printoem/ne-printoem-_eattribute_datatype) enumeration type) and *pbData* pointing to a NULL-delimited list of all of the supported global attribute names. This list is terminated with two null characters.
+If **IPrintCoreHelperPS::GetGlobalAttribute** is called with its *pszAttribute* and *pbData* parameters set to **NULL**, the method returns with *pcbSize* set to the number of bytes that are needed for the list of all of the supported global attribute names. If this method is called a second time, with *pszAttribute* set to **NULL** and *pbData* pointing to a buffer of the size that was specified in *pcbSize* in the previous call, the method returns with *pdwDataType* set to kADT_ASCII (an enumerator of the [EATTRIBUTE_DATATYPE](../printoem/ne-printoem-_eattribute_datatype.md) enumeration type) and *pbData* pointing to a NULL-delimited list of all of the supported global attribute names. This list is terminated with two null characters.
 
 For more information about **IPrintCoreHelperPS::GetGlobalAttribute**, see [Using GetGlobalAttribute](/windows-hardware/drivers/print/using-getglobalattribute).
 
 ## -see-also
 
-[IPrintCoreHelperPS](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperps)
+[IPrintCoreHelperPS](./nn-prcomoem-iprintcorehelperps.md)
 
-[IPrintCoreHelperPS::GetFeatureAttribute](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-getfeatureattribute)
+[IPrintCoreHelperPS::GetFeatureAttribute](./nf-prcomoem-iprintcorehelperps-getfeatureattribute.md)
 
-[IPrintCoreHelperPS::GetOptionAttribute](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-getoptionattribute)
+[IPrintCoreHelperPS::GetOptionAttribute](./nf-prcomoem-iprintcorehelperps-getoptionattribute.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-getoptionattribute.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-getoptionattribute.md
@@ -51,7 +51,7 @@ A pointer to a caller-supplied buffer that contains an ANSI string that specifie
 
 ### -param pszOptionKeyword [in]
 
-A pointer to a caller-supplied buffer that contains an ANSI string that specifies the option keyword to query for. This value can be obtained from a prior call to [IPrintCoreHelperPS::EnumOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-enumoptions).
+A pointer to a caller-supplied buffer that contains an ANSI string that specifies the option keyword to query for. This value can be obtained from a prior call to [IPrintCoreHelperPS::EnumOptions](./nf-prcomoem-iprintcorehelperps-enumoptions.md).
 
 ### -param pszAttribute [in]
 
@@ -59,7 +59,7 @@ A pointer to a caller-supplied buffer that contains an ANSI string that specifie
 
 ### -param pdwDataType [out]
 
-A pointer to a variable that receives a value that specifies the data type of the requested attribute. This value is an enumerator of the [EATTRIBUTE_DATATYPE](/windows-hardware/drivers/ddi/printoem/ne-printoem-_eattribute_datatype) enumeration type, which is defined in printoem.h.
+A pointer to a variable that receives a value that specifies the data type of the requested attribute. This value is an enumerator of the [EATTRIBUTE_DATATYPE](../printoem/ne-printoem-_eattribute_datatype.md) enumeration type, which is defined in printoem.h.
 
 ### -param ppbData [out]
 
@@ -82,14 +82,14 @@ A pointer to a variable that receives the size, in bytes, of the buffer that is 
 
 ## -remarks
 
-If **IPrintCoreHelperPS::GetOptionAttribute**is called with its *pszAttribute* and *pbData* parameters set to **NULL**, the method returns with *pcbSize* set to the number of bytes that are needed for the list of all of the supported attribute names for the option. If this method is called a second time, with *pszAttribute* set to **NULL** and *pbData* pointing to a buffer of the size that was specified in *pcbSize* in the previous call, the method returns with *pdwDataType* set to kADT_ASCII (an enumerator of the [EATTRIBUTE_DATATYPE](/windows-hardware/drivers/ddi/printoem/ne-printoem-_eattribute_datatype) enumeration type) and *pbData* pointing to a NULL-delimited list of all of the supported attribute names for the option. This list is terminated with two null characters.
+If **IPrintCoreHelperPS::GetOptionAttribute**is called with its *pszAttribute* and *pbData* parameters set to **NULL**, the method returns with *pcbSize* set to the number of bytes that are needed for the list of all of the supported attribute names for the option. If this method is called a second time, with *pszAttribute* set to **NULL** and *pbData* pointing to a buffer of the size that was specified in *pcbSize* in the previous call, the method returns with *pdwDataType* set to kADT_ASCII (an enumerator of the [EATTRIBUTE_DATATYPE](../printoem/ne-printoem-_eattribute_datatype.md) enumeration type) and *pbData* pointing to a NULL-delimited list of all of the supported attribute names for the option. This list is terminated with two null characters.
 
 For more information about **IPrintCoreHelperPS::GetOptionAttribute**, see [Using GetOptionAttribute](/windows-hardware/drivers/print/using-getoptionattribute).
 
 ## -see-also
 
-[IPrintCoreHelperPS](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperps)
+[IPrintCoreHelperPS](./nn-prcomoem-iprintcorehelperps.md)
 
-[IPrintCoreHelperPS::GetFeatureAttribute](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-getfeatureattribute)
+[IPrintCoreHelperPS::GetFeatureAttribute](./nf-prcomoem-iprintcorehelperps-getfeatureattribute.md)
 
-[IPrintCoreHelperPS::GetGlobalAttribute](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-getglobalattribute)
+[IPrintCoreHelperPS::GetGlobalAttribute](./nf-prcomoem-iprintcorehelperps-getglobalattribute.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-setoptions.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperps-setoptions.md
@@ -47,7 +47,7 @@ The **IPrintCoreHelperPS::SetOptions** method sets multiple feature-option pairs
 
 ### -param pDevmode [in, optional]
 
-A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelperPS::SetOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* rather than the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemPS::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-devmode), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets), is being serviced by the core driver's UI module.
+A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelperPS::SetOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* rather than the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemPS::DevMode](./nf-prcomoem-iprintoemps-devmode.md), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md), is being serviced by the core driver's UI module.
 
 ### -param cbSize [in]
 
@@ -59,7 +59,7 @@ A Boolean value that indicates whether **IPrintCoreHelperPS::SetOptions** should
 
 ### -param pFOPairs [in]
 
-An array of [PRINT_FEATURE_OPTION](/windows-hardware/drivers/ddi/prcomoem/ns-prcomoem-_print_feature_option) elements, where each element contains a feature-option pair. Each feature-option pair lists a feature and the option to select for that feature. All settings are applied sequentially. Duplicates are not disallowed, but settings that appear later in the array (that is, at a higher index) override those that appear earlier in the array.
+An array of [PRINT_FEATURE_OPTION](./ns-prcomoem-_print_feature_option.md) elements, where each element contains a feature-option pair. Each feature-option pair lists a feature and the option to select for that feature. All settings are applied sequentially. Duplicates are not disallowed, but settings that appear later in the array (that is, at a higher index) override those that appear earlier in the array.
 
 ### -param cPairs [in]
 
@@ -99,6 +99,6 @@ For most scenarios the *bResolveConflicts* parameter should be set to **TRUE**. 
 
 ## -see-also
 
-[IPrintCoreHelperPS](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperps)
+[IPrintCoreHelperPS](./nn-prcomoem-iprintcorehelperps.md)
 
-[IPrintCoreHelperPS::GetOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperps-getoption)
+[IPrintCoreHelperPS::GetOptions](./nf-prcomoem-iprintcorehelperps-getoption.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperuni-enumconstrainedoptions.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperuni-enumconstrainedoptions.md
@@ -47,7 +47,7 @@ The **IPrintCoreHelperUni::EnumConstrainedOptions** method provides a list of al
 
 ### -param pDevmode [in, optional]
 
-A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelperUni::EnumConstrainedOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemUni::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-devmode), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets), is being serviced by the core driver's UI module.
+A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelperUni::EnumConstrainedOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemUni::DevMode](./nf-prcomoem-iprintoemuni-devmode.md), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md), is being serviced by the core driver's UI module.
 
 ### -param cbSize [in]
 
@@ -79,6 +79,6 @@ A pointer to a variable that receives the number of constrained options in the a
 
 ## -see-also
 
-[IPrintCoreHelperUni](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperuni)
+[IPrintCoreHelperUni](./nn-prcomoem-iprintcorehelperuni.md)
 
-[IPrintCoreHelperUni::EnumOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperuni-enumoptions)
+[IPrintCoreHelperUni::EnumOptions](./nf-prcomoem-iprintcorehelperuni-enumoptions.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperuni-enumfeatures.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperuni-enumfeatures.md
@@ -63,6 +63,6 @@ For Unidrv features, the feature list is based on the GPD view of the configurat
 
 ## -see-also
 
-[IPrintCoreHelperUni](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperuni)
+[IPrintCoreHelperUni](./nn-prcomoem-iprintcorehelperuni.md)
 
-[IPrintCoreHelperUni::EnumOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperuni-enumoptions)
+[IPrintCoreHelperUni::EnumOptions](./nf-prcomoem-iprintcorehelperuni-enumoptions.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperuni-enumoptions.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperuni-enumoptions.md
@@ -67,8 +67,8 @@ When **IPrintCoreHelperUni::EnumOptions** returns, the option list contains all 
 
 ## -see-also
 
-[IPrintCoreHelperUni](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperuni)
+[IPrintCoreHelperUni](./nn-prcomoem-iprintcorehelperuni.md)
 
-[IPrintCoreHelperUni::EnumConstrainedOptions](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperuni-enumconstrainedoptions)
+[IPrintCoreHelperUni::EnumConstrainedOptions](./nf-prcomoem-iprintcorehelperuni-enumconstrainedoptions.md)
 
-[IPrintCoreHelperUni::EnumFeatures](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperuni-enumfeatures)
+[IPrintCoreHelperUni::EnumFeatures](./nf-prcomoem-iprintcorehelperuni-enumfeatures.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperuni-setoptions.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintcorehelperuni-setoptions.md
@@ -47,7 +47,7 @@ The **IPrintCoreHelperUni::SetOptions** method sets multiple feature-option pair
 
 ### -param pDevmode [in, optional]
 
-A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelperUni::SetOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemPS::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-devmode), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets), is being serviced by the core driver's UI module.
+A pointer to a [DEVMODEW](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure. If this pointer is provided, **IPrintCoreHelperUni::SetOptions** should use the DEVMODEW structure that is pointed to by *pDevmode* instead of the default or current DEVMODEW structure. If this method is called from the plug-in provider or from [IPrintOemPS::DevMode](./nf-prcomoem-iprintoemps-devmode.md), this parameter is required. In most other situations, the parameter should be **NULL**. When the core driver sets *pDevmode* to **NULL**, it modifies its internal state rather than that of the passed-in DEVMODEW structure. This is required during operations such as full UI replacement, where the DEVMODEW structure returned by a DDI, such as [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md), is being serviced by the core driver's UI module.
 
 ### -param cbSize [in]
 
@@ -59,7 +59,7 @@ A Boolean value that indicates whether **IPrintCoreHelperUni::SetOptions** shoul
 
 ### -param pFOPairs [in]
 
-An array of [PRINT_FEATURE_OPTION](/windows-hardware/drivers/ddi/prcomoem/ns-prcomoem-_print_feature_option) elements, where each element contains a feature-option pair. Each feature-option pair lists a feature and the option to select for that feature. All settings are applied sequentially. Duplicates are not disallowed, but settings that appear later in the array (that is, at a higher index) override those that appear earlier in the array.
+An array of [PRINT_FEATURE_OPTION](./ns-prcomoem-_print_feature_option.md) elements, where each element contains a feature-option pair. Each feature-option pair lists a feature and the option to select for that feature. All settings are applied sequentially. Duplicates are not disallowed, but settings that appear later in the array (that is, at a higher index) override those that appear earlier in the array.
 
 ### -param cPairs [in]
 
@@ -99,6 +99,6 @@ For most scenarios the *bResolveConflicts* parameter should be set to **TRUE**. 
 
 ## -see-also
 
-[IPrintCoreHelperUni](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintcorehelperuni)
+[IPrintCoreHelperUni](./nn-prcomoem-iprintcorehelperuni.md)
 
-[IPrintCoreHelperUni::GetOption](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcorehelperuni-getoption)
+[IPrintCoreHelperUni::GetOption](./nf-prcomoem-iprintcorehelperuni-getoption.md)

--- a/wdk-ddi-src/content/printerextension/ne-printerextension-tagprintjobstatus.md
+++ b/wdk-ddi-src/content/printerextension/ne-printerextension-tagprintjobstatus.md
@@ -114,6 +114,6 @@ It is possible for a job to have multiple  flag values specified simultaneously.
 
 ## -see-also
 
-[IPrintJob::Status](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintjob-get_status)
+[IPrintJob::Status](./nf-printerextension-iprintjob-get_status.md)
 
 [JOB_INFO_1](/windows/win32/printdocs/job-info-1)

--- a/wdk-ddi-src/content/printerextension/ne-printerextension-tagprintschemaconstrainedsetting.md
+++ b/wdk-ddi-src/content/printerextension/ne-printerextension-tagprintschemaconstrainedsetting.md
@@ -66,4 +66,4 @@ The Option is constrained by the device configuration. The Option should not be 
 
 ## -see-also
 
-[IPrintSchemaOption::Constrained](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaoption-get_constrained)
+[IPrintSchemaOption::Constrained](./nf-printerextension-iprintschemaoption-get_constrained.md)

--- a/wdk-ddi-src/content/printerextension/ne-printerextension-tagprintschemaparameterdatatype.md
+++ b/wdk-ddi-src/content/printerextension/ne-printerextension-tagprintschemaparameterdatatype.md
@@ -65,4 +65,4 @@ This maps to the Print Schema's StringParamType parameters, with UnitType not eq
 
 ## -see-also
 
-[IPrintSchemaParameterDefinition::DataType](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaparameterdefinition-get_datatype)
+[IPrintSchemaParameterDefinition::DataType](./nf-printerextension-iprintschemaparameterdefinition-get_datatype.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterbidisetrequestcallback-completed.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterbidisetrequestcallback-completed.md
@@ -59,4 +59,4 @@ This method returns the appropriate **HRESULT** value.
 
 ## -see-also
 
-[IPrinterBidiSetRequestCallback](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterbidisetrequestcallback)
+[IPrinterBidiSetRequestCallback](./nn-printerextension-iprinterbidisetrequestcallback.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionasyncoperation-cancel.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionasyncoperation-cancel.md
@@ -54,4 +54,4 @@ Also, note that this method does not wait for the cancellation to be processed -
 
 ## -see-also
 
-[IPrinterExtensionAsyncOperation](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionasyncoperation)
+[IPrinterExtensionAsyncOperation](./nn-printerextension-iprinterextensionasyncoperation.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontext-get_driverproperties.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontext-get_driverproperties.md
@@ -65,6 +65,6 @@ DEFINE_GUID(FMTID_PrinterPropertyBag, 0x75f9adca, 0x097d, 0x45c3, 0xa6, 0xe4, 0x
 
 ## -see-also
 
-[IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext)
+[IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md)
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontext-get_printerqueue.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontext-get_printerqueue.md
@@ -57,6 +57,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext)
+[IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md)
 
-[IPrinterQueue](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue)
+[IPrinterQueue](./nn-printerextension-iprinterqueue.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontext-get_userproperties.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontext-get_userproperties.md
@@ -59,6 +59,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext)
+[IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md)
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontextcollection-get__newenum.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontextcollection-get__newenum.md
@@ -42,7 +42,7 @@ api_name:
 
 ## -description
 
-Gets a pointer to the enumerants of [IPrinterExtensionContextCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontextcollection) objects.
+Gets a pointer to the enumerants of [IPrinterExtensionContextCollection](./nn-printerextension-iprinterextensioncontextcollection.md) objects.
 
 ## -parameters
 
@@ -56,4 +56,4 @@ Returns an **HRESULT** value. If the property call was not successful,  it retur
 
 ## -see-also
 
-[IPrinterExtensionContextCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontextcollection)
+[IPrinterExtensionContextCollection](./nn-printerextension-iprinterextensioncontextcollection.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontextcollection-get_count.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontextcollection-get_count.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Gets a count of the number of [IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext) objects in the collection.
+Gets a count of the number of [IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md) objects in the collection.
 
 This property is read-only.
 
@@ -57,6 +57,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext)
+[IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md)
 
-[IPrinterExtensionContextCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontextcollection)
+[IPrinterExtensionContextCollection](./nn-printerextension-iprinterextensioncontextcollection.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontextcollection-getat.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioncontextcollection-getat.md
@@ -41,17 +41,17 @@ api_name:
 
 ## -description
 
-Gets a pointer to an [IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext) object.
+Gets a pointer to an [IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md) object.
 
 ## -parameters
 
 ### -param ulIndex [in]
 
-The index of the [IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext) object within the collection.
+The index of the [IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md) object within the collection.
 
 ### -param ppContext [out, retval]
 
-Pointer to an [IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext) interface.
+Pointer to an [IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md) interface.
 
 ## -returns
 
@@ -59,6 +59,6 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext)
+[IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md)
 
-[IPrinterExtensionContextCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontextcollection)
+[IPrinterExtensionContextCollection](./nn-printerextension-iprinterextensioncontextcollection.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionevent-ondriverevent.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionevent-ondriverevent.md
@@ -55,6 +55,6 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterExtensionEvent](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionevent)
+[IPrinterExtensionEvent](./nn-printerextension-iprinterextensionevent.md)
 
-[IPrinterExtensionEventArgs](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioneventargs)
+[IPrinterExtensionEventArgs](./nn-printerextension-iprinterextensioneventargs.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionevent-onprinterqueuesenumerated.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionevent-onprinterqueuesenumerated.md
@@ -47,7 +47,7 @@ Called when printer queues are enumerated.
 
 ### -param pContextCollection [in]
 
-Pointer to [IPrinterExtensionContextCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontextcollection) object.
+Pointer to [IPrinterExtensionContextCollection](./nn-printerextension-iprinterextensioncontextcollection.md) object.
 
 ## -returns
 
@@ -59,8 +59,8 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterExtensionContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontext)
+[IPrinterExtensionContext](./nn-printerextension-iprinterextensioncontext.md)
 
-[IPrinterExtensionContextCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioncontextcollection)
+[IPrinterExtensionContextCollection](./nn-printerextension-iprinterextensioncontextcollection.md)
 
-[IPrinterExtensionEvent](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionevent)
+[IPrinterExtensionEvent](./nn-printerextension-iprinterextensionevent.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_bidinotification.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_bidinotification.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterExtensionEventArgs](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioneventargs)
+[IPrinterExtensionEventArgs](./nn-printerextension-iprinterextensioneventargs.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_detailedreasonid.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_detailedreasonid.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Gets a more detailed activation reason than what can be retrieved from [ReasonId](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensioneventargs-get_reasonid).
+Gets a more detailed activation reason than what can be retrieved from [ReasonId](./nf-printerextension-iprinterextensioneventargs-get_reasonid.md).
 
 This property is read-only.
 
@@ -61,6 +61,6 @@ The value of **DetailedReasonId** is always {5D5A1704-DFD1-4181-8EEE-815C86EDAD3
 
 ## -see-also
 
-[IPrinterExtensionEventArgs](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioneventargs)
+[IPrinterExtensionEventArgs](./nn-printerextension-iprinterextensioneventargs.md)
 
-[ReasonId](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensioneventargs-get_reasonid)
+[ReasonId](./nf-printerextension-iprinterextensioneventargs-get_reasonid.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_reasonid.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_reasonid.md
@@ -71,6 +71,6 @@ In this mode a status monitor for the print queue is expected to be displayed:
 
 ## -see-also
 
-[DetailedReasonId](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensioneventargs-get_detailedreasonid)
+[DetailedReasonId](./nf-printerextension-iprinterextensioneventargs-get_detailedreasonid.md)
 
-[IPrinterExtensionEventArgs](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioneventargs)
+[IPrinterExtensionEventArgs](./nn-printerextension-iprinterextensioneventargs.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_request.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_request.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Gets the [IPrinterExtensionRequest](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionrequest) object for the current event.
+Gets the [IPrinterExtensionRequest](./nn-printerextension-iprinterextensionrequest.md) object for the current event.
 
 This interface is used to complete or cancel the event.
 
@@ -59,6 +59,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterExtensionEventArgs](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioneventargs)
+[IPrinterExtensionEventArgs](./nn-printerextension-iprinterextensioneventargs.md)
 
-[IPrinterExtensionRequest](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionrequest)
+[IPrinterExtensionRequest](./nn-printerextension-iprinterextensionrequest.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_sourceapplication.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_sourceapplication.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterExtensionEventArgs](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioneventargs)
+[IPrinterExtensionEventArgs](./nn-printerextension-iprinterextensioneventargs.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_windowmodal.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_windowmodal.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterExtensionEventArgs](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioneventargs)
+[IPrinterExtensionEventArgs](./nn-printerextension-iprinterextensioneventargs.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_windowparent.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensioneventargs-get_windowparent.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterExtensionEventArgs](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensioneventargs)
+[IPrinterExtensionEventArgs](./nn-printerextension-iprinterextensioneventargs.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionmanager-disableevents.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionmanager-disableevents.md
@@ -49,6 +49,6 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[EnableEvents](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensionmanager-enableevents)
+[EnableEvents](./nf-printerextension-iprinterextensionmanager-enableevents.md)
 
-[IPrinterExtensionManager](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionmanager)
+[IPrinterExtensionManager](./nn-printerextension-iprinterextensionmanager.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionmanager-enableevents.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionmanager-enableevents.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-The EnableEvents method allows events to be generated for the specified printer driver until  [DisableEvents](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterextensionmanager-disableevents) is called.
+The EnableEvents method allows events to be generated for the specified printer driver until  [DisableEvents](./nf-printerextension-iprinterextensionmanager-disableevents.md) is called.
 
 ## -parameters
 
@@ -61,4 +61,4 @@ In the case of a driver event like, for example, Print Preferences or Printer No
 
 ## -see-also
 
-[IPrinterExtensionManager](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionmanager)
+[IPrinterExtensionManager](./nn-printerextension-iprinterextensionmanager.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionrequest-cancel.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionrequest-cancel.md
@@ -59,4 +59,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterExtensionRequest](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionrequest)
+[IPrinterExtensionRequest](./nn-printerextension-iprinterextensionrequest.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionrequest-complete.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterextensionrequest-complete.md
@@ -49,4 +49,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterExtensionRequest](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionrequest)
+[IPrinterExtensionRequest](./nn-printerextension-iprinterextensionrequest.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getbool.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getbool.md
@@ -59,4 +59,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getbytes.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getbytes.md
@@ -43,7 +43,7 @@ api_name:
 
 Reads a byte array property.
 
-The [IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag) interface is used by all the printer property bags, including driver property bag, user property bag, queue property bag, and DEVMODE property bag.
+The [IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md) interface is used by all the printer property bags, including driver property bag, user property bag, queue property bag, and DEVMODE property bag.
 
 ## -parameters
 
@@ -65,4 +65,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getint32.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getint32.md
@@ -59,4 +59,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getreadstream.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getreadstream.md
@@ -63,4 +63,4 @@ This method does not work with non-stream properties.
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getstring.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getstring.md
@@ -59,4 +59,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getwritestream.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-getwritestream.md
@@ -63,4 +63,4 @@ This method does not work with non-stream properties.
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-setbool.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-setbool.md
@@ -69,4 +69,4 @@ A call to set a property on a queue property bag will fail with ERROR_ACCESS_DEN
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-setbytes.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-setbytes.md
@@ -73,4 +73,4 @@ A call to set a property on a queue property bag will fail with ERROR_ACCESS_DEN
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-setint32.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-setint32.md
@@ -71,4 +71,4 @@ A call to set a property on a queue property bag will fail with ERROR_ACCESS_DEN
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-setstring.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterpropertybag-setstring.md
@@ -69,4 +69,4 @@ A call to set a property on a queue property bag will fail with ERROR_ACCESS_DEN
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue-get_handle.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue-get_handle.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterQueue](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue)
+[IPrinterQueue](./nn-printerextension-iprinterqueue.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue-get_name.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue-get_name.md
@@ -59,4 +59,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterQueue](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue)
+[IPrinterQueue](./nn-printerextension-iprinterqueue.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue-getproperties.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue-getproperties.md
@@ -57,6 +57,6 @@ This method returns and **HRESULT** value.
 
 ## -see-also
 
-[IPrinterPropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterpropertybag)
+[IPrinterPropertyBag](./nn-printerextension-iprinterpropertybag.md)
 
-[IPrinterQueue](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue)
+[IPrinterQueue](./nn-printerextension-iprinterqueue.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue-sendbidiquery.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue-sendbidiquery.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Performs an asynchronous refresh operation with the specified query, and invokes the [IPrinterQueueEvent::OnBidiResponseReceived](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueueevent-onbidiresponsereceived) method.
+Performs an asynchronous refresh operation with the specified query, and invokes the [IPrinterQueueEvent::OnBidiResponseReceived](./nf-printerextension-iprinterqueueevent-onbidiresponsereceived.md) method.
 
 ## -parameters
 
@@ -55,7 +55,7 @@ This method returns an **HRESULT** value.
 
 ## -remarks
 
-When the **SendBidiQuery** method is called, it immediately raises the [IPrinterQueueEvent::OnBidiResponseReceived](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueueevent-onbidiresponsereceived) event, if there is a cached response available.  The print system then starts an asynchronous operation to use the [Bidi Communication Interfaces](/previous-versions/dd183365(v=vs.85)). At this point **SendBidiQuery** returns, thus unblocking the caller.  When the asynchronous operation completes, the print system raises the **IPrinterQueueEvent::OnBidiResponseReceived** event again. **SendBidiQuery** is decoupled from its associated response on purpose. The decoupling is done because, in the case where there is no cached data, the resulting latency can be due to many factors and an immediate response cannot be expected.  Additionally the caller may receive multiple responses based on whether there is cached data, and whether there is a response from the device.
+When the **SendBidiQuery** method is called, it immediately raises the [IPrinterQueueEvent::OnBidiResponseReceived](./nf-printerextension-iprinterqueueevent-onbidiresponsereceived.md) event, if there is a cached response available.  The print system then starts an asynchronous operation to use the [Bidi Communication Interfaces](/previous-versions/dd183365(v=vs.85)). At this point **SendBidiQuery** returns, thus unblocking the caller.  When the asynchronous operation completes, the print system raises the **IPrinterQueueEvent::OnBidiResponseReceived** event again. **SendBidiQuery** is decoupled from its associated response on purpose. The decoupling is done because, in the case where there is no cached data, the resulting latency can be due to many factors and an immediate response cannot be expected.  Additionally the caller may receive multiple responses based on whether there is cached data, and whether there is a response from the device.
 
 Using the [Bidi Communication Interfaces](/previous-versions/dd183365(v=vs.85)) causes the port monitor to refresh the underlying requested values. In the case of USB, if a JavaScript component is available, then the JavaScript code is invoked to refresh the requested values.
 
@@ -77,6 +77,6 @@ The cache is also updated in the following situations:
 
 [Bidi Communication Interfaces](/previous-versions/dd183365(v=vs.85))
 
-[IPrinterQueue](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue)
+[IPrinterQueue](./nn-printerextension-iprinterqueue.md)
 
-[IPrinterQueueEvent::OnBidiResponseReceived](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueueevent-onbidiresponsereceived)
+[IPrinterQueueEvent::OnBidiResponseReceived](./nf-printerextension-iprinterqueueevent-onbidiresponsereceived.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue2-getprinterqueueview.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue2-getprinterqueueview.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Retrieves an [IPrinterQueueView](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueueview) object, and initializes the object with the range of jobs to be monitored.
+Retrieves an [IPrinterQueueView](./nn-printerextension-iprinterqueueview.md) object, and initializes the object with the range of jobs to be monitored.
 
 This method allows the user to perform job management tasks from within a UWP device app for printers.
 
@@ -72,14 +72,14 @@ Otherwise, if a call to **GetPrinterQueueView** results in an error condition, t
 
 ## -remarks
 
-Only one [IPrinterQueueView](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueueview) object can be retrieved per [IPrinterQueue2](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue2) object.
-However it is possible to move around the single view that you retrieve. In other words, it is possible to  change the positions of the monitored jobs by invoking [IPrinterQueueView::SetViewRange](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueueview-setviewrange).
+Only one [IPrinterQueueView](./nn-printerextension-iprinterqueueview.md) object can be retrieved per [IPrinterQueue2](./nn-printerextension-iprinterqueue2.md) object.
+However it is possible to move around the single view that you retrieve. In other words, it is possible to  change the positions of the monitored jobs by invoking [IPrinterQueueView::SetViewRange](./nf-printerextension-iprinterqueueview-setviewrange.md).
 
 > [!NOTE]
 > There is work underway to implement a cap on the maximum size of the printer queue view.
 
 ## -see-also
 
-[IPrinterQueue2](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue2)
+[IPrinterQueue2](./nn-printerextension-iprinterqueue2.md)
 
-[IPrinterQueueView](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueueview)
+[IPrinterQueueView](./nn-printerextension-iprinterqueueview.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue2-sendbidisetrequestasync.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueue2-sendbidisetrequestasync.md
@@ -65,8 +65,8 @@ This method returns the appropriate **HRESULT** value.
 
 ## -see-also
 
-[IPrinterBidiSetRequestCallback](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterbidisetrequestcallback)
+[IPrinterBidiSetRequestCallback](./nn-printerextension-iprinterbidisetrequestcallback.md)
 
-[IPrinterExtensionAsyncOperation](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterextensionasyncoperation)
+[IPrinterExtensionAsyncOperation](./nn-printerextension-iprinterextensionasyncoperation.md)
 
-[IPrinterQueue2](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue2)
+[IPrinterQueue2](./nn-printerextension-iprinterqueue2.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueueevent-onbidiresponsereceived.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueueevent-onbidiresponsereceived.md
@@ -65,8 +65,8 @@ The *bstrResponse* parameter is formatted according to the schema that is descri
 
 [Bidi Request and Response Schemas](/previous-versions/dd183368(v=vs.85))
 
-[IPrinterQueue](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueue)
+[IPrinterQueue](./nn-printerextension-iprinterqueue.md)
 
-[IPrinterQueue::SendBidiQuery](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueue-sendbidiquery)
+[IPrinterQueue::SendBidiQuery](./nf-printerextension-iprinterqueue-sendbidiquery.md)
 
-[IPrinterQueueEvent](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueueevent)
+[IPrinterQueueEvent](./nn-printerextension-iprinterqueueevent.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueueview-setviewrange.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueueview-setviewrange.md
@@ -59,15 +59,15 @@ This method returns the appropriate **HRESULT** value.
 
 ## -remarks
 
-Invoking this method causes the events for status change to the jobs to be fired. The [IPrinterQueueViewEvent::OnChanged](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueueviewevent-onchanged) event method returns the live queue in response, using the specified maximum range size.
+Invoking this method causes the events for status change to the jobs to be fired. The [IPrinterQueueViewEvent::OnChanged](./nf-printerextension-iprinterqueueviewevent-onchanged.md) event method returns the live queue in response, using the specified maximum range size.
 
 > [!NOTE]
 > *ulViewSize* must be specified as a value less than or equal to 25. If the caller specifies a size which exceeds 25,  this method will return E_INVALIDARG.
 
 ## -see-also
 
-[IPrinterQueue2::GetPrinterQueueView](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueue2-getprinterqueueview)
+[IPrinterQueue2::GetPrinterQueueView](./nf-printerextension-iprinterqueue2-getprinterqueueview.md)
 
-[IPrinterQueueView](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueueview)
+[IPrinterQueueView](./nn-printerextension-iprinterqueueview.md)
 
-[IPrinterQueueViewEvent::OnChanged](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueueviewevent-onchanged)
+[IPrinterQueueViewEvent::OnChanged](./nf-printerextension-iprinterqueueviewevent-onchanged.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueueviewevent-onchanged.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterqueueviewevent-onchanged.md
@@ -41,13 +41,13 @@ api_name:
 
 ## -description
 
-Provides an [IPrintJobCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjobcollection) object that provides a snapshot of a range of print jobs in the queue.
+Provides an [IPrintJobCollection](./nn-printerextension-iprintjobcollection.md) object that provides a snapshot of a range of print jobs in the queue.
 
 ## -parameters
 
 ### -param pCollection [in]
 
-An [IPrintJobCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjobcollection) object.
+An [IPrintJobCollection](./nn-printerextension-iprintjobcollection.md) object.
 
 ### -param ulViewOffset [in]
 
@@ -67,14 +67,14 @@ This method returns the appropriate **HRESULT** value.
 
 ## -remarks
 
-The job range is controlled by the [IPrinterQueueView](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueueview) interface. Additionally, this method provides the current number of jobs in the print queue, and the indices of the job range being monitored. Information about the number of jobs, and the indices of the jobs is provided in response to the [IPrinterQueueView::SetViewRange](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueueview-setviewrange) method being invoked.
+The job range is controlled by the [IPrinterQueueView](./nn-printerextension-iprinterqueueview.md) interface. Additionally, this method provides the current number of jobs in the print queue, and the indices of the job range being monitored. Information about the number of jobs, and the indices of the jobs is provided in response to the [IPrinterQueueView::SetViewRange](./nf-printerextension-iprinterqueueview-setviewrange.md) method being invoked.
 
 ## -see-also
 
-[IPrintJobCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjobcollection)
+[IPrintJobCollection](./nn-printerextension-iprintjobcollection.md)
 
-[IPrinterQueueView](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueueview)
+[IPrinterQueueView](./nn-printerextension-iprinterqueueview.md)
 
-[IPrinterQueueView::SetViewRange](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprinterqueueview-setviewrange)
+[IPrinterQueueView::SetViewRange](./nf-printerextension-iprinterqueueview-setviewrange.md)
 
-[IPrinterQueueViewEvent](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterqueueviewevent)
+[IPrinterQueueViewEvent](./nn-printerextension-iprinterqueueviewevent.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getbool.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getbool.md
@@ -63,4 +63,4 @@ A call to **GetBool** will throw an exception, if the specified property is not 
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getbytes.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getbytes.md
@@ -63,4 +63,4 @@ A call to **GetBytes** will throw an exception, if the specified property is not
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getint32.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getint32.md
@@ -63,4 +63,4 @@ A call to **GetInt32** will throw an exception, if the specified property is not
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getreadstream.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getreadstream.md
@@ -65,6 +65,6 @@ A call to **GetReadStream** will throw an exception, if the specified property i
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)
 
-[IPrinterScriptableStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablestream)
+[IPrinterScriptableStream](./nn-printerextension-iprinterscriptablestream.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getstring.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getstring.md
@@ -63,4 +63,4 @@ A call to **GetString** will throw an exception, if the specified property is no
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getwritestream.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-getwritestream.md
@@ -65,6 +65,6 @@ A call to **GetWriteStream** will throw an exception, if the specified property 
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)
 
-[IPrinterScriptableStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablestream)
+[IPrinterScriptableStream](./nn-printerextension-iprinterscriptablestream.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-setbool.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-setbool.md
@@ -63,4 +63,4 @@ A call to **SetBool** will throw an exception, if the specified property is not 
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-setbytes.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-setbytes.md
@@ -63,4 +63,4 @@ A call to **SetBytes** will throw an exception, if the specified property is not
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-setint32.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-setint32.md
@@ -63,4 +63,4 @@ A call to **SetInt32** will throw an exception, if the specified property is not
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-setstring.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablepropertybag-setstring.md
@@ -63,4 +63,4 @@ A call to **SetString** will throw an exception, if the specified property is no
 
 ## -see-also
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablesequentialstream-read.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablesequentialstream-read.md
@@ -59,4 +59,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterScriptableSequentialStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablesequentialstream)
+[IPrinterScriptableSequentialStream](./nn-printerextension-iprinterscriptablesequentialstream.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablesequentialstream-write.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablesequentialstream-write.md
@@ -59,4 +59,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterScriptableSequentialStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablesequentialstream)
+[IPrinterScriptableSequentialStream](./nn-printerextension-iprinterscriptablesequentialstream.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablestream-commit.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablestream-commit.md
@@ -49,4 +49,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterScriptableStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablestream)
+[IPrinterScriptableStream](./nn-printerextension-iprinterscriptablestream.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablestream-seek.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablestream-seek.md
@@ -63,4 +63,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterScriptableStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablestream)
+[IPrinterScriptableStream](./nn-printerextension-iprinterscriptablestream.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablestream-setsize.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptablestream-setsize.md
@@ -55,4 +55,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrinterScriptableStream](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablestream)
+[IPrinterScriptableStream](./nn-printerextension-iprinterscriptablestream.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptcontext-get_driverproperties.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptcontext-get_driverproperties.md
@@ -57,6 +57,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterScriptContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptcontext)
+[IPrinterScriptContext](./nn-printerextension-iprinterscriptcontext.md)
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptcontext-get_queueproperties.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptcontext-get_queueproperties.md
@@ -57,6 +57,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrinterScriptContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptcontext)
+[IPrinterScriptContext](./nn-printerextension-iprinterscriptcontext.md)
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptcontext-get_userproperties.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprinterscriptcontext-get_userproperties.md
@@ -64,6 +64,6 @@ The user property bag is not available in (constraint) JavaScript functions when
 
 ## -see-also
 
-[IPrinterScriptContext](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptcontext)
+[IPrinterScriptContext](./nn-printerextension-iprinterscriptcontext.md)
 
-[IPrinterScriptablePropertyBag](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprinterscriptablepropertybag)
+[IPrinterScriptablePropertyBag](./nn-printerextension-iprinterscriptablepropertybag.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_id.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_id.md
@@ -61,4 +61,4 @@ You must not use the **IPrintJob::Id** property to invoke spooler Job APIs. This
 
 ## -see-also
 
-[IPrintJob](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjob)
+[IPrintJob](./nn-printerextension-iprintjob.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_name.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_name.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrintJob](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjob)
+[IPrintJob](./nn-printerextension-iprintjob.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_printedpages.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_printedpages.md
@@ -57,10 +57,10 @@ Returns an **HRESULT** value.
 
 ## -remarks
 
-If the **PrintedPages** and [IPrintJob::TotalPages](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintjob-get_totalpages) properties are both zero, then page delimiting is not supported for the print job.
+If the **PrintedPages** and [IPrintJob::TotalPages](./nf-printerextension-iprintjob-get_totalpages.md) properties are both zero, then page delimiting is not supported for the print job.
 
 ## -see-also
 
-[IPrintJob::IPrintJob](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjob)
+[IPrintJob::IPrintJob](./nn-printerextension-iprintjob.md)
 
-[TotalPages](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintjob-get_totalpages)
+[TotalPages](./nf-printerextension-iprintjob-get_totalpages.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_status.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_status.md
@@ -58,6 +58,6 @@ Returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrintJob](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjob)
+[IPrintJob](./nn-printerextension-iprintjob.md)
 
-[PrintJobStatus](/windows-hardware/drivers/ddi/printerextension/ne-printerextension-tagprintjobstatus)
+[PrintJobStatus](./ne-printerextension-tagprintjobstatus.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_submissiontime.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_submissiontime.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrintJob](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjob)
+[IPrintJob](./nn-printerextension-iprintjob.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_totalpages.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-get_totalpages.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrintJob](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjob)
+[IPrintJob](./nn-printerextension-iprintjob.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-requestcancel.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjob-requestcancel.md
@@ -53,4 +53,4 @@ The **RequestCancel** method does not wait for the cancellation of a print job t
 
 ## -see-also
 
-[IPrintJob](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjob)
+[IPrintJob](./nn-printerextension-iprintjob.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjobcollection-get__newenum.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjobcollection-get__newenum.md
@@ -42,7 +42,7 @@ api_name:
 
 ## -description
 
-Gets a pointer to the enumerants of [IPrintJobCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjobcollection) objects.
+Gets a pointer to the enumerants of [IPrintJobCollection](./nn-printerextension-iprintjobcollection.md) objects.
 
 This property is read-only.
 
@@ -58,4 +58,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintJobCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjobcollection)
+[IPrintJobCollection](./nn-printerextension-iprintjobcollection.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjobcollection-get_count.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjobcollection-get_count.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintJobCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjobcollection)
+[IPrintJobCollection](./nn-printerextension-iprintjobcollection.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjobcollection-getat.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintjobcollection-getat.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Gets a pointer to an [IPrintJob](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjob) object.
+Gets a pointer to an [IPrintJob](./nn-printerextension-iprintjob.md) object.
 
 ## -parameters
 
@@ -59,6 +59,6 @@ Returns an **HRESULT** value. If the method call was not successful, it returns 
 
 ## -see-also
 
-[IPrintJob](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjob)
+[IPrintJob](./nn-printerextension-iprintjob.md)
 
-[IPrintJobCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintjobcollection)
+[IPrintJobCollection](./nn-printerextension-iprintjobcollection.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaasyncoperation-cancel.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaasyncoperation-cancel.md
@@ -49,4 +49,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrintSchemaAsyncOperation](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaasyncoperation)
+[IPrintSchemaAsyncOperation](./nn-printerextension-iprintschemaasyncoperation.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaasyncoperation-start.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaasyncoperation-start.md
@@ -49,4 +49,4 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrintSchemaAsyncOperation](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaasyncoperation)
+[IPrintSchemaAsyncOperation](./nn-printerextension-iprintschemaasyncoperation.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaasyncoperationevent-completed.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaasyncoperationevent-completed.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Is called when asynchronous PrintSchema operation that is represented by an [IPrintSchemaAsyncOperation](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaasyncoperation) context is completed.
+Is called when asynchronous PrintSchema operation that is represented by an [IPrintSchemaAsyncOperation](./nn-printerextension-iprintschemaasyncoperation.md) context is completed.
 
 ## -parameters
 
@@ -63,6 +63,6 @@ The print ticket passed to the **Completed** method is the final validated, merg
 
 ## -see-also
 
-[IPrintSchemaAsyncOperationEvent](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaasyncoperationevent)
+[IPrintSchemaAsyncOperationEvent](./nn-printerextension-iprintschemaasyncoperationevent.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-get_jobcopiesalldocumentsmaxvalue.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-get_jobcopiesalldocumentsmaxvalue.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-get_jobcopiesalldocumentsminvalue.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-get_jobcopiesalldocumentsminvalue.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-get_pageimageablesize.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-get_pageimageablesize.md
@@ -57,6 +57,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaPageImageableSize](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapageimageablesize)
+[IPrintSchemaPageImageableSize](./nn-printerextension-iprintschemapageimageablesize.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-getfeature.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-getfeature.md
@@ -66,12 +66,12 @@ This method returns an **HRESULT** value.
 
 When the requested feature, option or property is not found, this method returns S_FALSE and sets a NULL pointer on the output object of the feature, option or property.
 
-So if the [IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities) object and query it via [IPrintSchemaCapabilities::GetFeatureByKeyName](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeaturebykeyname) or via **IPrintSchemaCapabilities::GetFeature**.
+So if the [IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md) object and query it via [IPrintSchemaCapabilities::GetFeatureByKeyName](./nf-printerextension-iprintschemacapabilities-getfeaturebykeyname.md) or via **IPrintSchemaCapabilities::GetFeature**.
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaFeature](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemafeature)
+[IPrintSchemaFeature](./nn-printerextension-iprintschemafeature.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-getfeaturebykeyname.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-getfeaturebykeyname.md
@@ -59,7 +59,7 @@ This method returns an **HRESULT** value.
 
 ## -remarks
 
-Only the following feature key names are recognized. The key names are equivalent to public Print Schema feature names as shown in the following table. The table also shows the features that have specialized option types (by default the option type is [IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)).
+Only the following feature key names are recognized. The key names are equivalent to public Print Schema feature names as shown in the following table. The table also shows the features that have specialized option types (by default the option type is [IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)).
 
 | Name | Print schema feature public name | Specialized option type |
 |--|--|--|
@@ -68,9 +68,9 @@ Only the following feature key names are recognized. The key names are equivalen
 | DocumentDuplex | JobDuplexAllDocumentsContiguously |  |
 | DocumentHolePunch | DocumentHolePunch or JobHolePunch |  |
 | DocumentInputBin | JobInputBin, DocumentInputBin or PageInputBin |  |
-| DocumentNUp | JobNUpAllDocumentsContiguously | [IPrintSchemaNUpOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemanupoption) |
+| DocumentNUp | JobNUpAllDocumentsContiguously | [IPrintSchemaNUpOption](./nn-printerextension-iprintschemanupoption.md) |
 | DocumentStaple | JobStapleAllDocuments or DocumentStaple |  |
-| PageMediaSize | PageMediaSize | [IPrintSchemaPageMediaSizeOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapagemediasizeoption) |
+| PageMediaSize | PageMediaSize | [IPrintSchemaPageMediaSizeOption](./nn-printerextension-iprintschemapagemediasizeoption.md) |
 | PageMediaType | PageMediaType |  |
 | PageOrientation | PageOrientation |  |
 | PageOutputColor | PageOutputColor |  |
@@ -78,14 +78,14 @@ Only the following feature key names are recognized. The key names are equivalen
 
 When the requested feature, option or property is not found, this method returns S_FALSE and sets a NULL pointer on the output object of the feature, option or property.
 
-So if the [IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities) object and query it via **IPrintSchemaCapabilities::GetFeatureByKeyName** or via [IPrintSchemaCapabilities::GetFeature](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeature).
+So if the [IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md) object and query it via **IPrintSchemaCapabilities::GetFeatureByKeyName** or via [IPrintSchemaCapabilities::GetFeature](./nf-printerextension-iprintschemacapabilities-getfeature.md).
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaNUpOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemanupoption)
+[IPrintSchemaNUpOption](./nn-printerextension-iprintschemanupoption.md)
 
-[IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)
+[IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)
 
-[IPrintSchemaPageMediaSizeOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapagemediasizeoption)
+[IPrintSchemaPageMediaSizeOption](./nn-printerextension-iprintschemapagemediasizeoption.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-getoptions.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-getoptions.md
@@ -59,6 +59,6 @@ This method returns an **HRESULT** value.
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaOptionCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoptioncollection)
+[IPrintSchemaOptionCollection](./nn-printerextension-iprintschemaoptioncollection.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-getselectedoptioninprintticket.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemacapabilities-getselectedoptioninprintticket.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Gets the selected option for a feature in [IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket).
+Gets the selected option for a feature in [IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md).
 
 ## -parameters
 
@@ -61,10 +61,10 @@ This method returns an **HRESULT** value.
 
 When the requested feature, option or property is not found, this method returns S_FALSE and sets a NULL pointer on the output object of the feature, option or property.
 
-So if the [IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities) object and query it via [IPrintSchemaCapabilities::GetFeatureByKeyName](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeaturebykeyname) or via [IPrintSchemaCapabilities::GetFeature](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeature).
+So if the [IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md) object and query it via [IPrintSchemaCapabilities::GetFeatureByKeyName](./nf-printerextension-iprintschemacapabilities-getfeaturebykeyname.md) or via [IPrintSchemaCapabilities::GetFeature](./nf-printerextension-iprintschemacapabilities-getfeature.md).
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemadisplayableelement-get_displayname.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemadisplayableelement-get_displayname.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaDisplayableElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemadisplayableelement)
+[IPrintSchemaDisplayableElement](./nn-printerextension-iprintschemadisplayableelement.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaelement-get_xmlnode.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaelement-get_xmlnode.md
@@ -61,14 +61,14 @@ When you dereference the *ppXmlNode* parameter (using *ppXmlNode ), you obtain a
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaElement](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaelement)
+[IPrintSchemaElement](./nn-printerextension-iprintschemaelement.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)
 
-[IPrintSchemaTicket::NotifyXmlChanged](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschematicket-notifyxmlchanged)
+[IPrintSchemaTicket::NotifyXmlChanged](./nf-printerextension-iprintschematicket-notifyxmlchanged.md)
 
-[IPrintSchemaTicket_GetCapabilities](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschematicket-getcapabilities)
+[IPrintSchemaTicket_GetCapabilities](./nf-printerextension-iprintschematicket-getcapabilities.md)
 
 [IXMLDOMElement](/previous-versions/windows/desktop/ms760248(v=vs.85))

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-get_displayui.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-get_displayui.md
@@ -61,4 +61,4 @@ Note that the **DisplayUI** property  corresponds to the psk:DisplayUI element. 
 
 ## -see-also
 
-[IPrintSchemaFeature](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemafeature)
+[IPrintSchemaFeature](./nn-printerextension-iprintschemafeature.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-get_selectedoption.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-get_selectedoption.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Gets an [IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption) representing the selected option.
+Gets an [IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md) representing the selected option.
 
 This property is read-only.
 
@@ -57,8 +57,8 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaFeature](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemafeature)
+[IPrintSchemaFeature](./nn-printerextension-iprintschemafeature.md)
 
-[IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)
+[IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)
 
-[IPrintSchemaTicket_GetCapabilities](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschematicket-getcapabilities)
+[IPrintSchemaTicket_GetCapabilities](./nf-printerextension-iprintschematicket-getcapabilities.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-get_selectiontype.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-get_selectiontype.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaFeature](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemafeature)
+[IPrintSchemaFeature](./nn-printerextension-iprintschemafeature.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-getoption.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-getoption.md
@@ -65,14 +65,14 @@ This method returns an **HRESULT** value, if the call was successful. Otherwise 
 
 When the requested feature, option or property is not found, this method returns S_FALSE and sets a NULL pointer on the output object of the feature, option or property.
 
-So if the [IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities) object and query it via [IPrintSchemaCapabilities::GetFeatureByKeyName](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeaturebykeyname) or via [IPrintSchemaCapabilities::GetFeature](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeature).
+So if the [IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md) object and query it via [IPrintSchemaCapabilities::GetFeatureByKeyName](./nf-printerextension-iprintschemacapabilities-getfeaturebykeyname.md) or via [IPrintSchemaCapabilities::GetFeature](./nf-printerextension-iprintschemacapabilities-getfeature.md).
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaFeature](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemafeature)
+[IPrintSchemaFeature](./nn-printerextension-iprintschemafeature.md)
 
-[IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)
+[IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-put_selectedoption.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemafeature-put_selectedoption.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Changes the selected option of the Print Schema Feature element to the specified [IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption) element.
+Changes the selected option of the Print Schema Feature element to the specified [IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md) element.
 
 This property is write-only.
 
@@ -57,6 +57,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaFeature](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemafeature)
+[IPrintSchemaFeature](./nn-printerextension-iprintschemafeature.md)
 
-[IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)
+[IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemanupoption-get_pagespersheet.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemanupoption-get_pagespersheet.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaNUpOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemanupoption)
+[IPrintSchemaNUpOption](./nn-printerextension-iprintschemanupoption.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaoption-get_constrained.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaoption-get_constrained.md
@@ -57,6 +57,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)
+[IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)
 
-[PrintSchemaConstrainedSetting](/windows-hardware/drivers/ddi/printerextension/ne-printerextension-tagprintschemaconstrainedsetting)
+[PrintSchemaConstrainedSetting](./ne-printerextension-tagprintschemaconstrainedsetting.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaoption-get_selected.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaoption-get_selected.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)
+[IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaoptioncollection-get_count.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaoptioncollection-get_count.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Gets a count of the number of [IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption) objects in the collection.
+Gets a count of the number of [IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md) objects in the collection.
 
 This property is read-only.
 
@@ -57,6 +57,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)
+[IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)
 
-[IPrintSchemaOptionCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoptioncollection)
+[IPrintSchemaOptionCollection](./nn-printerextension-iprintschemaoptioncollection.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaoptioncollection-getat.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaoptioncollection-getat.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-Gets a pointer to an [IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption) object.
+Gets a pointer to an [IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md) object.
 
 ## -parameters
 
@@ -51,7 +51,7 @@ Index of the **IPrintSchemaOption** object within the collection.
 
 ### -param ppOption [out, retval, optional]
 
-Pointer to an [IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption) object.
+Pointer to an [IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md) object.
 
 ## -returns
 
@@ -59,6 +59,6 @@ Returns an **HRESULT** value. If the method call was not successful,  it returns
 
 ## -see-also
 
-[IPrintSchemaOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoption)
+[IPrintSchemaOption](./nn-printerextension-iprintschemaoption.md)
 
-[IPrintSchemaOptionCollection](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaoptioncollection)
+[IPrintSchemaOptionCollection](./nn-printerextension-iprintschemaoptioncollection.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_extentheightinmicrons.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_extentheightinmicrons.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaPageImageableSize](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapageimageablesize)
+[IPrintSchemaPageImageableSize](./nn-printerextension-iprintschemapageimageablesize.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_extentwidthinmicrons.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_extentwidthinmicrons.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaPageImageableSize](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapageimageablesize)
+[IPrintSchemaPageImageableSize](./nn-printerextension-iprintschemapageimageablesize.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_imageablesizeheightinmicrons.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_imageablesizeheightinmicrons.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaPageImageableSize](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapageimageablesize)
+[IPrintSchemaPageImageableSize](./nn-printerextension-iprintschemapageimageablesize.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_imageablesizewidthinmicrons.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_imageablesizewidthinmicrons.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaPageImageableSize](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapageimageablesize)
+[IPrintSchemaPageImageableSize](./nn-printerextension-iprintschemapageimageablesize.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_originheightinmicrons.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_originheightinmicrons.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaPageImageableSize](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapageimageablesize)
+[IPrintSchemaPageImageableSize](./nn-printerextension-iprintschemapageimageablesize.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_originwidthinmicrons.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapageimageablesize-get_originwidthinmicrons.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaPageImageableSize](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapageimageablesize)
+[IPrintSchemaPageImageableSize](./nn-printerextension-iprintschemapageimageablesize.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapagemediasizeoption-get_heightinmicrons.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapagemediasizeoption-get_heightinmicrons.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaPageMediaSizeOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapagemediasizeoption)
+[IPrintSchemaPageMediaSizeOption](./nn-printerextension-iprintschemapagemediasizeoption.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapagemediasizeoption-get_widthinmicrons.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemapagemediasizeoption-get_widthinmicrons.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaPageMediaSizeOption](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemapagemediasizeoption)
+[IPrintSchemaPageMediaSizeOption](./nn-printerextension-iprintschemapagemediasizeoption.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaparameterdefinition-get_datatype.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaparameterdefinition-get_datatype.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-The **DataType** property gets the [PrintSchemaParameterDataType](/windows-hardware/drivers/ddi/printerextension/ne-printerextension-tagprintschemaparameterdatatype) enumerated value that indicates the expected data type for the Print Schema parameter.
+The **DataType** property gets the [PrintSchemaParameterDataType](./ne-printerextension-tagprintschemaparameterdatatype.md) enumerated value that indicates the expected data type for the Print Schema parameter.
 
 This property is read-only.
 
@@ -57,6 +57,6 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaParameterDefinition](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaparameterdefinition)
+[IPrintSchemaParameterDefinition](./nn-printerextension-iprintschemaparameterdefinition.md)
 
-[PrintSchemaParameterDataType](/windows-hardware/drivers/ddi/printerextension/ne-printerextension-tagprintschemaparameterdatatype)
+[PrintSchemaParameterDataType](./ne-printerextension-tagprintschemaparameterdatatype.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaparameterdefinition-get_unittype.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaparameterdefinition-get_unittype.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaParameterDefinition](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaparameterdefinition)
+[IPrintSchemaParameterDefinition](./nn-printerextension-iprintschemaparameterdefinition.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaparameterdefinition-get_userinputrequired.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschemaparameterdefinition-get_userinputrequired.md
@@ -61,4 +61,4 @@ The print dialog can use **UserInputRequired** to determine whether or not it sh
 
 ## -see-also
 
-[IPrintSchemaParameterDefinition](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaparameterdefinition)
+[IPrintSchemaParameterDefinition](./nn-printerextension-iprintschemaparameterdefinition.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-commitasync.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-commitasync.md
@@ -59,12 +59,12 @@ This method returns an **HRESULT** value.
 
 ## -remarks
 
-To perform the commit operation, call the [IPrintSchemaAsyncOperation::Start](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaasyncoperation-start) method to validate the given *pPrintTicketCommit* and then apply the validated PrintTicket settings to the current PrintTicket object. When the commit operation is completed or if an error occurs during the commit operation, the [IPrintSchemaAsyncOperationEvent::Completed](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaasyncoperationevent-completed) event is fired.
+To perform the commit operation, call the [IPrintSchemaAsyncOperation::Start](./nf-printerextension-iprintschemaasyncoperation-start.md) method to validate the given *pPrintTicketCommit* and then apply the validated PrintTicket settings to the current PrintTicket object. When the commit operation is completed or if an error occurs during the commit operation, the [IPrintSchemaAsyncOperationEvent::Completed](./nf-printerextension-iprintschemaasyncoperationevent-completed.md) event is fired.
 
 ## -see-also
 
-[IPrintSchemaAsyncOperation::Start](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaasyncoperation-start)
+[IPrintSchemaAsyncOperation::Start](./nf-printerextension-iprintschemaasyncoperation-start.md)
 
-[IPrintSchemaAsyncOperationEvent::Completed](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaasyncoperationevent-completed)
+[IPrintSchemaAsyncOperationEvent::Completed](./nf-printerextension-iprintschemaasyncoperationevent-completed.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-get_jobcopiesalldocuments.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-get_jobcopiesalldocuments.md
@@ -57,4 +57,4 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -see-also
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-getcapabilities.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-getcapabilities.md
@@ -41,13 +41,13 @@ api_name:
 
 ## -description
 
-Gets an [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities) object that represents the printer capabilities based on the current settings of this [IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket) object.
+Gets an [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md) object that represents the printer capabilities based on the current settings of this [IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md) object.
 
 ## -parameters
 
 ### -param ppCapabilities
 
-The returned [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities) object.
+The returned [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md) object.
 
 ## -returns
 
@@ -55,16 +55,16 @@ This method returns an **HRESULT** value.
 
 ## -remarks
 
-Because this method retrieves a new PrintCapabilities document every time it is invoked, it is recommended that you invoke this method only when the [IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket) object has been modified.
+Because this method retrieves a new PrintCapabilities document every time it is invoked, it is recommended that you invoke this method only when the [IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md) object has been modified.
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaElement::XmlNode](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaelement-get_xmlnode)
+[IPrintSchemaElement::XmlNode](./nf-printerextension-iprintschemaelement-get_xmlnode.md)
 
-[IPrintSchemaFeature::SelectedOption](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemafeature-get_selectedoption)
+[IPrintSchemaFeature::SelectedOption](./nf-printerextension-iprintschemafeature-get_selectedoption.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)
 
 [IPrintSchemaTicket::put_JobCopiesAllDocuments](/windows/win32/api/rrascfg/nf-rrascfg-ieapproviderconfig-initialize)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-getfeature.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-getfeature.md
@@ -68,16 +68,16 @@ This method returns an **HRESULT** value.
 
 When the requested feature, option or property is not found, this method returns S_FALSE and sets a NULL pointer on the output object of the feature, option or property.
 
-So if the [IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities) object and query it via [IPrintSchemaCapabilities::GetFeatureByKeyName](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeaturebykeyname) or via [IPrintSchemaCapabilities::GetFeature](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeature).
+So if the [IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md) object and query it via [IPrintSchemaCapabilities::GetFeatureByKeyName](./nf-printerextension-iprintschemacapabilities-getfeaturebykeyname.md) or via [IPrintSchemaCapabilities::GetFeature](./nf-printerextension-iprintschemacapabilities-getfeature.md).
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaCapabilities::GetFeature](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeature)
+[IPrintSchemaCapabilities::GetFeature](./nf-printerextension-iprintschemacapabilities-getfeature.md)
 
-[IPrintSchemaCapabilities::GetFeatureByKeyName](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeaturebykeyname)
+[IPrintSchemaCapabilities::GetFeatureByKeyName](./nf-printerextension-iprintschemacapabilities-getfeaturebykeyname.md)
 
-[IPrintSchemaFeature](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemafeature)
+[IPrintSchemaFeature](./nn-printerextension-iprintschemafeature.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-getfeaturebykeyname.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-getfeaturebykeyname.md
@@ -59,20 +59,20 @@ This method returns an **HRESULT** value.
 
 ## -remarks
 
-See [IPrintSchemaCapabilities::GetFeatureByKeyName](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeaturebykeyname) for the recognized feature key names, the key names' equivalent public Print Schema feature names, and the supported specialized option types.
+See [IPrintSchemaCapabilities::GetFeatureByKeyName](./nf-printerextension-iprintschemacapabilities-getfeaturebykeyname.md) for the recognized feature key names, the key names' equivalent public Print Schema feature names, and the supported specialized option types.
 
 When the requested feature, option or property is not found, this method returns S_FALSE and sets a NULL pointer on the output object of the feature, option or property.
 
-So if the [IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities) object and query it via **IPrintSchemaCapabilities::GetFeatureByKeyName** or via [IPrintSchemaCapabilities::GetFeature](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeature).
+So if the [IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md) object does not contain the specified feature, option or property, the app must obtain an [IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md) object and query it via **IPrintSchemaCapabilities::GetFeatureByKeyName** or via [IPrintSchemaCapabilities::GetFeature](./nf-printerextension-iprintschemacapabilities-getfeature.md).
 
 ## -see-also
 
-[IPrintSchemaCapabilities](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemacapabilities)
+[IPrintSchemaCapabilities](./nn-printerextension-iprintschemacapabilities.md)
 
-[IPrintSchemaCapabilities::GetFeature](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeature)
+[IPrintSchemaCapabilities::GetFeature](./nf-printerextension-iprintschemacapabilities-getfeature.md)
 
-[IPrintSchemaCapabilities::GetFeatureByKeyName](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemacapabilities-getfeaturebykeyname)
+[IPrintSchemaCapabilities::GetFeatureByKeyName](./nf-printerextension-iprintschemacapabilities-getfeaturebykeyname.md)
 
-[IPrintSchemaFeature](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemafeature)
+[IPrintSchemaFeature](./nn-printerextension-iprintschemafeature.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-notifyxmlchanged.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-notifyxmlchanged.md
@@ -49,10 +49,10 @@ This method returns an **HRESULT** value.
 
 ## -remarks
 
-If the client retrieves the XML DOM object of the PrintTicket by calling [IPrintSchemaElement::XmlNode](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaelement-get_xmlnode), and makes direct modifications to the PrintTicket using XMLDOM APIs, then it is the responsibility of the client to call **IPrintSchemaTicket::NotifyXmlChanged** to notify the system that the PrintTicket content has been modified.
+If the client retrieves the XML DOM object of the PrintTicket by calling [IPrintSchemaElement::XmlNode](./nf-printerextension-iprintschemaelement-get_xmlnode.md), and makes direct modifications to the PrintTicket using XMLDOM APIs, then it is the responsibility of the client to call **IPrintSchemaTicket::NotifyXmlChanged** to notify the system that the PrintTicket content has been modified.
 
 ## -see-also
 
-[IPrintSchemaElement::XmlNode](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaelement-get_xmlnode)
+[IPrintSchemaElement::XmlNode](./nf-printerextension-iprintschemaelement-get_xmlnode.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-put_jobcopiesalldocuments.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-put_jobcopiesalldocuments.md
@@ -57,12 +57,12 @@ Returns an **HRESULT** value. If the property call was not successful, it return
 
 ## -remarks
 
-Be aware of the fact that the [IPrintSchemaTicket::GetCapabilities](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschematicket-getcapabilities)  method retrieves a new PrintCapabilities document, which it also caches every time it is invoked. This means that if you use **IPrintSchemaTicket::put_JobCopiesAllDocuments** or [IPrintSchemaFeature::SelectedOption](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemafeature-put_selectedoption) on PrintTicket, the cached PrintCapabilities document gets corrupted or modified and the cache will be purged.
+Be aware of the fact that the [IPrintSchemaTicket::GetCapabilities](./nf-printerextension-iprintschematicket-getcapabilities.md)  method retrieves a new PrintCapabilities document, which it also caches every time it is invoked. This means that if you use **IPrintSchemaTicket::put_JobCopiesAllDocuments** or [IPrintSchemaFeature::SelectedOption](./nf-printerextension-iprintschemafeature-put_selectedoption.md) on PrintTicket, the cached PrintCapabilities document gets corrupted or modified and the cache will be purged.
 
 ## -see-also
 
-[IPrintSchemaFeature::SelectedOption](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemafeature-put_selectedoption)
+[IPrintSchemaFeature::SelectedOption](./nf-printerextension-iprintschemafeature-put_selectedoption.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)
 
-[IPrintSchemaTicket::GetCapabilities](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschematicket-getcapabilities)
+[IPrintSchemaTicket::GetCapabilities](./nf-printerextension-iprintschematicket-getcapabilities.md)

--- a/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-validateasync.md
+++ b/wdk-ddi-src/content/printerextension/nf-printerextension-iprintschematicket-validateasync.md
@@ -55,14 +55,14 @@ This method returns an **HRESULT** value.
 
 ## -remarks
 
- To perform the validation operation, call the [IPrintSchemaAsyncOperation::Start](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaasyncoperation-start) method to validate the settings of the current PrintTicket object and to pass the resulting **PrintTicket** to the [IPrintSchemaAsyncOperationEvent::Completed](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaasyncoperationevent-completed) event. When the validation operation is completed, or if an error occurs during the validation operation, the **IPrintSchemaAsyncOperationEvent::Completed** event is fired. This method will not change the settings of the current **PrintTicket** object.
+ To perform the validation operation, call the [IPrintSchemaAsyncOperation::Start](./nf-printerextension-iprintschemaasyncoperation-start.md) method to validate the settings of the current PrintTicket object and to pass the resulting **PrintTicket** to the [IPrintSchemaAsyncOperationEvent::Completed](./nf-printerextension-iprintschemaasyncoperationevent-completed.md) event. When the validation operation is completed, or if an error occurs during the validation operation, the **IPrintSchemaAsyncOperationEvent::Completed** event is fired. This method will not change the settings of the current **PrintTicket** object.
 
 ## -see-also
 
-[IPrintSchemaAsyncOperation](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschemaasyncoperation)
+[IPrintSchemaAsyncOperation](./nn-printerextension-iprintschemaasyncoperation.md)
 
-[IPrintSchemaAsyncOperation::Start](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaasyncoperation-start)
+[IPrintSchemaAsyncOperation::Start](./nf-printerextension-iprintschemaasyncoperation-start.md)
 
-[IPrintSchemaAsyncOperationEvent::Completed](/windows-hardware/drivers/ddi/printerextension/nf-printerextension-iprintschemaasyncoperationevent-completed)
+[IPrintSchemaAsyncOperationEvent::Completed](./nf-printerextension-iprintschemaasyncoperationevent-completed.md)
 
-[IPrintSchemaTicket](/windows-hardware/drivers/ddi/printerextension/nn-printerextension-iprintschematicket)
+[IPrintSchemaTicket](./nn-printerextension-iprintschematicket.md)

--- a/wdk-ddi-src/content/printoem/nc-printoem-oemcuipcallback.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-oemcuipcallback.md
@@ -41,17 +41,17 @@ api_name:
 
 ## -description
 
-The OEMCUIPCALLBACK function type is used for defining callback functions that are specified by a user interface plug-in's [IPrintOemUI::CommonUIProp](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-commonuiprop) method. The structure is defined in printoem.h.
+The OEMCUIPCALLBACK function type is used for defining callback functions that are specified by a user interface plug-in's [IPrintOemUI::CommonUIProp](../prcomoem/nf-prcomoem-iprintoemui-commonuiprop.md) method. The structure is defined in printoem.h.
 
 ## -parameters
 
 ### -param unnamedParam1
 
-Pointer to a [CPSUICBPARAM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_cpsuicbparam) structure.
+Pointer to a [CPSUICBPARAM](../compstui/ns-compstui-_cpsuicbparam.md) structure.
 
 ### -param unnamedParam2
 
-Pointer to an [OEMCUIPPARAM](/windows-hardware/drivers/ddi/printoem/ns-printoem-_oemcuipparam) structure.
+Pointer to an [OEMCUIPPARAM](./ns-printoem-_oemcuipparam.md) structure.
 
 ## -returns
 
@@ -61,13 +61,13 @@ See the following Remarks section.
 
 A callback function specified by an **IPrintOemUI::CommonUIProp** method is called when a user modifies a printer property sheet. The callback function's purpose is to process user modifications to customized option items.
 
-When a property sheet item is modified, [CPSUI](/windows-hardware/drivers/print/common-property-sheet-user-interface) calls the printer driver's printer interface DLL. This DLL contains its own callback function, of type [_CPSUICALLBACK](/windows-hardware/drivers/ddi/compstui/nc-compstui-_cpsuicallback), which processes option values contained in its own OPTITEM structures. Then the printer interface DLL's callback function calls the user interface plug-in's callback function. If multiple user interface plug-ins are provided, each plug-in's callback function is called, in turn, in the order in which the plug-ins were installed.
+When a property sheet item is modified, [CPSUI](/windows-hardware/drivers/print/common-property-sheet-user-interface) calls the printer driver's printer interface DLL. This DLL contains its own callback function, of type [_CPSUICALLBACK](../compstui/nc-compstui-_cpsuicallback.md), which processes option values contained in its own OPTITEM structures. Then the printer interface DLL's callback function calls the user interface plug-in's callback function. If multiple user interface plug-ins are provided, each plug-in's callback function is called, in turn, in the order in which the plug-ins were installed.
 
-The callback function receives a pointer to a [CPSUICBPARAM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_cpsuicbparam) structure. The structure's **Reason** member identifies the event that caused the callback function to be called. The function also receives a pointer to the same [OEMCUIPPARAM](/windows-hardware/drivers/ddi/printoem/ns-printoem-_oemcuipparam) structure that was used when the **IPrintOemUI::CommonUIProp** method specified the callback function's address.
+The callback function receives a pointer to a [CPSUICBPARAM](../compstui/ns-compstui-_cpsuicbparam.md) structure. The structure's **Reason** member identifies the event that caused the callback function to be called. The function also receives a pointer to the same [OEMCUIPPARAM](./ns-printoem-_oemcuipparam.md) structure that was used when the **IPrintOemUI::CommonUIProp** method specified the callback function's address.
 
 The CPSUICBPARAM structure's **pOptItem** and **pCurItem** members identify the modified option. The callback function can use these pointers, along with the **pOEMOptItems** and **cOEMOptItem** members of the OEMCUIPPARAM structure, to determine if the modified option is one that is owned by the user interface plug-in.
 
-When a callback function is called, it must determine if any of its customized OPTITEM structures are affected by the specified **Reason** value. If they are, the function should process the affected options and return one of the CPSUI_ACTION-prefixed return values described for the [_CPSUICALLBACK](/windows-hardware/drivers/ddi/compstui/nc-compstui-_cpsuicallback) function type. Otherwise it should return CPSUICB_ACTION_NONE.
+When a callback function is called, it must determine if any of its customized OPTITEM structures are affected by the specified **Reason** value. If they are, the function should process the affected options and return one of the CPSUI_ACTION-prefixed return values described for the [_CPSUICALLBACK](../compstui/nc-compstui-_cpsuicallback.md) function type. Otherwise it should return CPSUICB_ACTION_NONE.
 
 The following additional rules apply to callback function return values:
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvgetdriversetting.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvgetdriversetting.md
@@ -43,9 +43,9 @@ api_name:
 
 The **DrvGetDriverSetting** function is obsolete.
 
- Windows 2000 and later printer drivers should use [IPrintOemDriverUI::DrvGetDriverSetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriverui-drvgetdriversetting), [IPrintCoreUI2::DrvGetDriverSetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcoreui2-drvgetdriversetting) (UI plug-ins), [IPrintOemDriverUni::DrvGetDriverSetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriveruni-drvgetdriversetting) (Unidrv plug-ins) or [IPrintOemDriverPS::DrvGetDriverSetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriverps-drvgetdriversetting) (Pscript plug-ins)
+ Windows 2000 and later printer drivers should use [IPrintOemDriverUI::DrvGetDriverSetting](../prcomoem/nf-prcomoem-iprintoemdriverui-drvgetdriversetting.md), [IPrintCoreUI2::DrvGetDriverSetting](../prcomoem/nf-prcomoem-iprintcoreui2-drvgetdriversetting.md) (UI plug-ins), [IPrintOemDriverUni::DrvGetDriverSetting](../prcomoem/nf-prcomoem-iprintoemdriveruni-drvgetdriversetting.md) (Unidrv plug-ins) or [IPrintOemDriverPS::DrvGetDriverSetting](../prcomoem/nf-prcomoem-iprintoemdriverps-drvgetdriversetting.md) (Pscript plug-ins)
 
-This function pointer type defines the type of the **DrvGetDriverSetting** member of the [OEMUIPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_oemuiprocs) and [DRVPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_drvprocs) structures.
+This function pointer type defines the type of the **DrvGetDriverSetting** member of the [OEMUIPROCS](./ns-printoem-_oemuiprocs.md) and [DRVPROCS](./ns-printoem-_drvprocs.md) structures.
 
 ## -parameters
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvgetstandardvariable.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvgetstandardvariable.md
@@ -43,9 +43,9 @@ api_name:
 
 This **DrvGetStandardVariable** function is obsolete.
 
-Windows 2000 and later printer drivers should use [IPrintOemDriverUni::DrvGetStandardVariable](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriveruni-drvgetstandardvariable).
+Windows 2000 and later printer drivers should use [IPrintOemDriverUni::DrvGetStandardVariable](../prcomoem/nf-prcomoem-iprintoemdriveruni-drvgetstandardvariable.md).
 
-This function pointer prototype defines the type of the **BGetStandardVariable** member of the [DRVPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_drvprocs) structure.
+This function pointer prototype defines the type of the **BGetStandardVariable** member of the [DRVPROCS](./ns-printoem-_drvprocs.md) structure.
 
 ## -parameters
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvunidrivertextout.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvunidrivertextout.md
@@ -43,9 +43,9 @@ api_name:
 
 The **DrvUnidriverTextOut** function is obsolete.
 
-Windows 2000 and later printer drivers should use [IPrintOemDriverUni::DrvUniTextOut](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriveruni-drvunitextout).
+Windows 2000 and later printer drivers should use [IPrintOemDriverUni::DrvUniTextOut](../prcomoem/nf-prcomoem-iprintoemdriveruni-drvunitextout.md).
 
-This function pointer prototype defines the type of the **DrvUnidriverTextOut** member of the [DRVPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_drvprocs) structure.
+This function pointer prototype defines the type of the **DrvUnidriverTextOut** member of the [DRVPROCS](./ns-printoem-_drvprocs.md) structure.
 
 ## -parameters
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvupdateuisetting.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvupdateuisetting.md
@@ -43,9 +43,9 @@ api_name:
 
 The **DrvUpdateUISetting** function is obsolete.
 
- Windows 2000 and later UI plug-ins should use [IPrintOemDriverUI::DrvUpdateUISetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriverui-drvupdateuisetting) or [IPrintCoreUI2::DrvUpdateUISetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcoreui2-drvupdateuisetting).
+ Windows 2000 and later UI plug-ins should use [IPrintOemDriverUI::DrvUpdateUISetting](../prcomoem/nf-prcomoem-iprintoemdriverui-drvupdateuisetting.md) or [IPrintCoreUI2::DrvUpdateUISetting](../prcomoem/nf-prcomoem-iprintcoreui2-drvupdateuisetting.md).
 
-This function pointer prototype defines the type of the **DrvUpdateUISetting** member of the [OEMUIPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_oemuiprocs) structure.
+This function pointer prototype defines the type of the **DrvUpdateUISetting** member of the [OEMUIPROCS](./ns-printoem-_oemuiprocs.md) structure.
 
 ## -parameters
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvupgraderegistrysetting.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvupgraderegistrysetting.md
@@ -43,9 +43,9 @@ api_name:
 
 The **DrvUpgradeRegistrySetting** function is obsolete.
 
- Windows 2000 and later UI plug-ins should use [IPrintOemDriverUI::DrvUpgradeRegistrySetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriverui-drvupgraderegistrysetting) or [IPrintCoreUI2::DrvUpgradeRegistrySetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcoreui2-drvupgraderegistrysetting).
+ Windows 2000 and later UI plug-ins should use [IPrintOemDriverUI::DrvUpgradeRegistrySetting](../prcomoem/nf-prcomoem-iprintoemdriverui-drvupgraderegistrysetting.md) or [IPrintCoreUI2::DrvUpgradeRegistrySetting](../prcomoem/nf-prcomoem-iprintcoreui2-drvupgraderegistrysetting.md).
 
-This function pointer prototype defines the type of the *pfnUpgrade* parameter of the [OEMUpgradeRegistry](/windows-hardware/drivers/ddi/printoem/nf-printoem-oemupgraderegistry) function.
+This function pointer prototype defines the type of the *pfnUpgrade* parameter of the [OEMUpgradeRegistry](./nf-printoem-oemupgraderegistry.md) function.
 
 ## -parameters
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvwriteabortbuf.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvwriteabortbuf.md
@@ -43,9 +43,9 @@ api_name:
 
 The **DrvWriteAbortBuf** function is obsolete.
 
-Windows 2000 and later Unidrv render plug-ins should use [IPrintOemDriverUni::DrvWriteAbortBuf](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriveruni-drvwriteabortbuf).
+Windows 2000 and later Unidrv render plug-ins should use [IPrintOemDriverUni::DrvWriteAbortBuf](../prcomoem/nf-prcomoem-iprintoemdriveruni-drvwriteabortbuf.md).
 
-This function pointer prototype defines the type of the **DrvWriteAbortBuf** member of the [DRVPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_drvprocs) structure.
+This function pointer prototype defines the type of the **DrvWriteAbortBuf** member of the [DRVPROCS](./ns-printoem-_drvprocs.md) structure.
 
 ## -parameters
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvwritespoolbuf.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvwritespoolbuf.md
@@ -43,9 +43,9 @@ api_name:
 
 The **DrvWriteSpoolBuf** function pointed to by this function pointer is obsolete.
 
- Windows 2000 and later render plug-ins should use [IPrintOemDriverUni::DrvWriteSpoolBuf](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriveruni-drvwritespoolbuf) (Unidrv plug-ins), [IPrintOemDriverPS::DrvWriteSpoolBuf](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriverps-drvwritespoolbuf) (Pscript plug-ins), or [IPrintCorePS2::DrvWriteSpoolBuf](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcoreps2-drvwritespoolbuf) (Pscript plug-ins).
+ Windows 2000 and later render plug-ins should use [IPrintOemDriverUni::DrvWriteSpoolBuf](../prcomoem/nf-prcomoem-iprintoemdriveruni-drvwritespoolbuf.md) (Unidrv plug-ins), [IPrintOemDriverPS::DrvWriteSpoolBuf](../prcomoem/nf-prcomoem-iprintoemdriverps-drvwritespoolbuf.md) (Pscript plug-ins), or [IPrintCorePS2::DrvWriteSpoolBuf](../prcomoem/nf-prcomoem-iprintcoreps2-drvwritespoolbuf.md) (Pscript plug-ins).
 
-This function pointer prototype defines the **DrvWriteSpoolBuf** member of the [DRVPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_drvprocs) structure.
+This function pointer prototype defines the **DrvWriteSpoolBuf** member of the [DRVPROCS](./ns-printoem-_drvprocs.md) structure.
 
 ## -parameters
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvxmoveto.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvxmoveto.md
@@ -43,9 +43,9 @@ api_name:
 
 The **DrvXMoveTo** function is obsolete.
 
- Windows 2000 and later Unidrv plug-ins should use [IPrintOemDriverUni::DrvXMoveTo](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriveruni-drvxmoveto).
+ Windows 2000 and later Unidrv plug-ins should use [IPrintOemDriverUni::DrvXMoveTo](../prcomoem/nf-prcomoem-iprintoemdriveruni-drvxmoveto.md).
 
-This function pointer prototype defines the type of the **DrvXMoveTo** member of the [DRVPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_drvprocs) structure.
+This function pointer prototype defines the type of the **DrvXMoveTo** member of the [DRVPROCS](./ns-printoem-_drvprocs.md) structure.
 
 ## -parameters
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvymoveto.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfn_drvymoveto.md
@@ -43,9 +43,9 @@ api_name:
 
 The **DrvYMoveTo** function is obsolete.
 
-Windows 2000 and later Unidrv plug-ins should use [IPrintOemDriverUni::DrvYMoveTo](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriveruni-drvymoveto).
+Windows 2000 and later Unidrv plug-ins should use [IPrintOemDriverUni::DrvYMoveTo](../prcomoem/nf-prcomoem-iprintoemdriveruni-drvymoveto.md).
 
-This function pointer prototype defines the type of the **DrvYMoveTo** member of the [DRVPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_drvprocs) structure.
+This function pointer prototype defines the type of the **DrvYMoveTo** member of the [DRVPROCS](./ns-printoem-_drvprocs.md) structure.
 
 ## -parameters
 

--- a/wdk-ddi-src/content/printoem/nc-printoem-pfngetinfo.md
+++ b/wdk-ddi-src/content/printoem/nc-printoem-pfngetinfo.md
@@ -47,7 +47,7 @@ The **UNIFONTOBJ_GetInfo** callback function is provided by the Unidrv driver so
 
 ### -param unnamedParam1
 
-Pointer to the [UNIFONTOBJ](/windows-hardware/drivers/ddi/printoem/ns-printoem-_unifontobj) structure received by the function that is making the callback to **UNIFONTOBJ_GetInfo**. Supplied by the caller.
+Pointer to the [UNIFONTOBJ](./ns-printoem-_unifontobj.md) structure received by the function that is making the callback to **UNIFONTOBJ_GetInfo**. Supplied by the caller.
 
 ### -param unnamedParam2
 
@@ -59,12 +59,12 @@ Pointer to a structure, as indicated in the following table. Supplied by the cal
 
 | dwInfoID Value | *pData* Structure |
 |--|--|
-| UFO_GETINFO_FONTOBJ | [GETINFO_FONTOBJ](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_fontobj) |
-| UFO_GETINFO_GLYPHBITMAP | [GETINFO_GLYPHBITMAP](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_glyphbitmap) |
-| UFO_GETINFO_GLYPHSTRING | [GETINFO_GLYPHSTRING](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_glyphstring) |
-| UFO_GETINFO_GLYPHWIDTH | [GETINFO_GLYPHWIDTH](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_glyphwidth) |
-| UFO_GETINFO_MEMORY | [GETINFO_MEMORY](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_memory) |
-| UFO_GETINFO_STDVARIABLE | [GETINFO_STDVAR](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_stdvar) |
+| UFO_GETINFO_FONTOBJ | [GETINFO_FONTOBJ](./ns-printoem-_getinfo_fontobj.md) |
+| UFO_GETINFO_GLYPHBITMAP | [GETINFO_GLYPHBITMAP](./ns-printoem-_getinfo_glyphbitmap.md) |
+| UFO_GETINFO_GLYPHSTRING | [GETINFO_GLYPHSTRING](./ns-printoem-_getinfo_glyphstring.md) |
+| UFO_GETINFO_GLYPHWIDTH | [GETINFO_GLYPHWIDTH](./ns-printoem-_getinfo_glyphwidth.md) |
+| UFO_GETINFO_MEMORY | [GETINFO_MEMORY](./ns-printoem-_getinfo_memory.md) |
+| UFO_GETINFO_STDVARIABLE | [GETINFO_STDVAR](./ns-printoem-_getinfo_stdvar.md) |
 
 For more information, see the table in the **Remarks** section.
 
@@ -84,17 +84,17 @@ Returns a **BOOL** value. If the operation succeeds, the function returns **TRUE
 
 The **UNIFONTOBJ_GetInfo** callback function allows a [rendering plug-in](/windows-hardware/drivers/print/rendering-plug-ins) to call back into Unidrv to obtain font or glyph information from GDI, needed for handling [customized font management](/windows-hardware/drivers/print/customized-font-management) operations.
 
-A rendering plug-in receives the **UNIFONTOBJ_GetInfo** function's address in the [UNIFONTOBJ](/windows-hardware/drivers/ddi/printoem/ns-printoem-_unifontobj) structure that is passed to the font customization methods.
+A rendering plug-in receives the **UNIFONTOBJ_GetInfo** function's address in the [UNIFONTOBJ](./ns-printoem-_unifontobj.md) structure that is passed to the font customization methods.
 
 The type of information returned by the function is dependent on the input arguments. The caller supplies values for *dwInfoID*, *pData*, and *dwDataSize* to indicate the type of information wanted. The following table summarizes the types of information returned. For more information, see the structure descriptions.
 
 | *pData* Structure | Returned Information |
 |--|--|
-| [GETINFO_FONTOBJ](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_fontobj) | A FONTOBJ structure describing the current font. |
-| [GETINFO_GLYPHBITMAP](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_glyphbitmap) | A single glyph bitmap. |
-| [GETINFO_GLYPHSTRING](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_glyphstring) | An array of glyph specifiers in a specified format. |
-| [GETINFO_GLYPHWIDTH](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_glyphwidth) | Total width of a set of glyphs. |
-| [GETINFO_MEMORY](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_memory) | Amount of available printer memory remaining. |
-| [GETINFO_STDVAR](/windows-hardware/drivers/ddi/printoem/ns-printoem-_getinfo_stdvar) | The current value for one or more of Unidrv's [standard variables](/windows-hardware/drivers/print/standard-variables). |
+| [GETINFO_FONTOBJ](./ns-printoem-_getinfo_fontobj.md) | A FONTOBJ structure describing the current font. |
+| [GETINFO_GLYPHBITMAP](./ns-printoem-_getinfo_glyphbitmap.md) | A single glyph bitmap. |
+| [GETINFO_GLYPHSTRING](./ns-printoem-_getinfo_glyphstring.md) | An array of glyph specifiers in a specified format. |
+| [GETINFO_GLYPHWIDTH](./ns-printoem-_getinfo_glyphwidth.md) | Total width of a set of glyphs. |
+| [GETINFO_MEMORY](./ns-printoem-_getinfo_memory.md) | Amount of available printer memory remaining. |
+| [GETINFO_STDVAR](./ns-printoem-_getinfo_stdvar.md) | The current value for one or more of Unidrv's [standard variables](/windows-hardware/drivers/print/standard-variables). |
 
 If the buffer described by *pData* and *dwDataSize* is too small to receive the structure indicated by *dwInfoID*, the function loads the required buffer size into the location pointed by *pcbNeeded* and returns **FALSE**.

--- a/wdk-ddi-src/content/printoem/ne-printoem-_eattribute_datatype.md
+++ b/wdk-ddi-src/content/printoem/ne-printoem-_eattribute_datatype.md
@@ -90,8 +90,8 @@ The attribute is of type RECT.
 
 ### -field kADT_CUSTOMSIZEPARAMS
 
-The attribute is an array containing CUSTOMPARAM_MAX (a constant defined in printoem.h) elements. Each element is a [CUSTOMSIZEPARAM](/windows-hardware/drivers/ddi/printoem/ns-printoem-_customsizeparam) structure.
+The attribute is an array containing CUSTOMPARAM_MAX (a constant defined in printoem.h) elements. Each element is a [CUSTOMSIZEPARAM](./ns-printoem-_customsizeparam.md) structure.
 
 ## -see-also
 
-[CUSTOMSIZEPARAM](/windows-hardware/drivers/ddi/printoem/ns-printoem-_customsizeparam)
+[CUSTOMSIZEPARAM](./ns-printoem-_customsizeparam.md)

--- a/wdk-ddi-src/content/printoem/nf-printoem-oemupgraderegistry.md
+++ b/wdk-ddi-src/content/printoem/nf-printoem-oemupgraderegistry.md
@@ -63,4 +63,4 @@ Returns a **BOOL** value.
 
 ## -see-also
 
-[DrvUpgradeRegistrySetting](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvupgraderegistrysetting)
+[DrvUpgradeRegistrySetting](./nc-printoem-pfn_drvupgraderegistrysetting.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_customsizeparam.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_customsizeparam.md
@@ -69,4 +69,4 @@ The custom page size parameters include Width, Height, WidthOffset, HeightOffset
 
 ## -see-also
 
-[EATTRIBUTE_DATATYPE](/windows-hardware/drivers/ddi/printoem/ne-printoem-_eattribute_datatype)
+[EATTRIBUTE_DATATYPE](./ne-printoem-_eattribute_datatype.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_devobj.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_devobj.md
@@ -57,7 +57,7 @@ Specifies the size, in bytes, of the **DEVOBJ** structure. Supplied by the Unidr
 
 ### -field pdevOEM
 
-Pointer to the rendering plug-in's private PDEV structure, as returned by [IPrintOemUni::EnablePDEV](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-enablepdev) or [IPrintOemPS::EnablePDEV](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-enablepdev). Supplied by the Unidrv or Pscript5 driver.
+Pointer to the rendering plug-in's private PDEV structure, as returned by [IPrintOemUni::EnablePDEV](../prcomoem/nf-prcomoem-iprintoemuni-enablepdev.md) or [IPrintOemPS::EnablePDEV](../prcomoem/nf-prcomoem-iprintoemps-enablepdev.md). Supplied by the Unidrv or Pscript5 driver.
 
 ### -field hEngine
 
@@ -81,11 +81,11 @@ Pointer to the rendering plug-in's private DEVMODEW structure members. Supplied 
 
 ### -field pDrvProcs
 
-      Not used. In a previous version of the interface, this was a pointer to a [DRVPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_drvprocs) structure.
+      Not used. In a previous version of the interface, this was a pointer to a [DRVPROCS](./ns-printoem-_drvprocs.md) structure.
 
 ## -remarks
 
-The **DEVOBJ** structure is accessible to graphics DDI hooking functions through the [SURFOBJ](/windows/win32/api/winddi/ns-winddi-surfobj) structure's **dhpdev** member. For more information, see [IPrintOemUni::EnablePDEV](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-enablepdev) or [IPrintOemPS::EnablePDEV](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-enablepdev).
+The **DEVOBJ** structure is accessible to graphics DDI hooking functions through the [SURFOBJ](/windows/win32/api/winddi/ns-winddi-surfobj) structure's **dhpdev** member. For more information, see [IPrintOemUni::EnablePDEV](../prcomoem/nf-prcomoem-iprintoemuni-enablepdev.md) or [IPrintOemPS::EnablePDEV](../prcomoem/nf-prcomoem-iprintoemps-enablepdev.md).
 
 ## -see-also
 
@@ -95,8 +95,8 @@ The **DEVOBJ** structure is accessible to graphics DDI hooking functions through
 
 [DrvEnablePDEV](/windows/win32/api/winddi/nf-winddi-drvenablepdev)
 
-[IPrintOemPS::EnablePDEV](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-enablepdev)
+[IPrintOemPS::EnablePDEV](../prcomoem/nf-prcomoem-iprintoemps-enablepdev.md)
 
-[IPrintOemUni::EnablePDEV](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-enablepdev)
+[IPrintOemUni::EnablePDEV](../prcomoem/nf-prcomoem-iprintoemuni-enablepdev.md)
 
 [SURFOBJ](/windows/win32/api/winddi/ns-winddi-surfobj)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_drvprocs.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_drvprocs.md
@@ -53,19 +53,19 @@ The structure contains the addresses of helper functions that are provided to re
 
 All of the functions pointed to by members of this structure are obsolete. For more information about each, see the following topics:
 
-[**DrvWriteSpoolBuf**](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvwritespoolbuf)
+[**DrvWriteSpoolBuf**](./nc-printoem-pfn_drvwritespoolbuf.md)
 
-[**DrvXMoveTo**](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvxmoveto)
+[**DrvXMoveTo**](./nc-printoem-pfn_drvxmoveto.md)
 
-[**DrvYMoveTo**](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvymoveto)
+[**DrvYMoveTo**](./nc-printoem-pfn_drvymoveto.md)
 
-[**DrvGetDriverSetting**](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvgetdriversetting)
+[**DrvGetDriverSetting**](./nc-printoem-pfn_drvgetdriversetting.md)
 
-[**DrvGetStandardVariable**](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvgetstandardvariable) (for information about BGetStandardVariable)
+[**DrvGetStandardVariable**](./nc-printoem-pfn_drvgetstandardvariable.md) (for information about BGetStandardVariable)
 
-[**DrvUnidriverTextOut**](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvunidrivertextout)
+[**DrvUnidriverTextOut**](./nc-printoem-pfn_drvunidrivertextout.md)
 
-[**DrvWriteAbortBuf**](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvwriteabortbuf)
+[**DrvWriteAbortBuf**](./nc-printoem-pfn_drvwriteabortbuf.md)
 
 ## -struct-fields
 

--- a/wdk-ddi-src/content/printoem/ns-printoem-_finvocation.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_finvocation.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **FINVOCATION** structure is used as input to the [IPrintOemUni::SendFontCmd](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-sendfontcmd) method. The structure is defined in printoem.h.
+The **FINVOCATION** structure is used as input to the [IPrintOemUni::SendFontCmd](../prcomoem/nf-prcomoem-iprintoemuni-sendfontcmd.md) method. The structure is defined in printoem.h.
 
 ## -struct-fields
 
@@ -61,4 +61,4 @@ Unidrv-supplied pointer to a string containing the printer's font selection comm
 
 ## -see-also
 
-[IPrintOemUni::SendFontCmd](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-sendfontcmd)
+[IPrintOemUni::SendFontCmd](../prcomoem/nf-prcomoem-iprintoemuni-sendfontcmd.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_fontobj.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_fontobj.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **GETINFO_FONTOBJ** structure is used as input to the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+The **GETINFO_FONTOBJ** structure is used as input to the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -struct-fields
 
@@ -57,14 +57,14 @@ Specifies the size, in bytes, of the **GETINFO_FONTOBJ** structure. Supplied by 
 
 ### -field pFontObj
 
-Pointer to an empty [FONTOBJ](/windows/win32/api/winddi/ns-winddi-fontobj) structure. The structure is filled in by Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function. The pointer is supplied by the UNIFONTOBJ_GetInfo caller.
+Pointer to an empty [FONTOBJ](/windows/win32/api/winddi/ns-winddi-fontobj) structure. The structure is filled in by Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function. The pointer is supplied by the UNIFONTOBJ_GetInfo caller.
 
 ## -remarks
 
-To obtain a font's **FONTOBJ** structure contents, a rendering plug-in can supply the address of a **GETINFO_FONTOBJ** structure when calling Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+To obtain a font's **FONTOBJ** structure contents, a rendering plug-in can supply the address of a **GETINFO_FONTOBJ** structure when calling Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -see-also
 
 [FONTOBJ](/windows/win32/api/winddi/ns-winddi-fontobj)
 
-[UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo)
+[UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_glyphbitmap.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_glyphbitmap.md
@@ -47,32 +47,32 @@ api_name:
 
 ## -description
 
-The **GETINFO_GLYPHBITMAP** structure is used as input to the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+The **GETINFO_GLYPHBITMAP** structure is used as input to the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -struct-fields
 
 ### -field dwSize
 
-Specifies the size, in bytes, of the **GETINFO_GLYPHBITMAP** structure. Supplied by [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Specifies the size, in bytes, of the **GETINFO_GLYPHBITMAP** structure. Supplied by [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field hGlyph
 
-Handle to the glyph. See the following Remarks section. Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Handle to the glyph. See the following Remarks section. Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field pGlyphData
 
-Pointer to a [GLYPHDATA](/windows/win32/api/winddi/ns-winddi-glyphdata) structure. The structure is filled in by Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function. The pointer is supplied by the *UNIFONTOBJ_GetInfo* caller.
+Pointer to a [GLYPHDATA](/windows/win32/api/winddi/ns-winddi-glyphdata) structure. The structure is filled in by Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function. The pointer is supplied by the *UNIFONTOBJ_GetInfo* caller.
 
 ## -remarks
 
-To obtain a glyph bitmap, a rendering plug-in can supply the address of a **GETINFO_GLYPHBITMAP** structure when calling Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+To obtain a glyph bitmap, a rendering plug-in can supply the address of a **GETINFO_GLYPHBITMAP** structure when calling Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
-The value that a rendering plug-in specifies for the **hGlyph** member must have been previously received as the *hGlyph* parameter to the [IPrintOemUni::DownloadCharGlyph](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-downloadcharglyph) method.
+The value that a rendering plug-in specifies for the **hGlyph** member must have been previously received as the *hGlyph* parameter to the [IPrintOemUni::DownloadCharGlyph](../prcomoem/nf-prcomoem-iprintoemuni-downloadcharglyph.md) method.
 
 ## -see-also
 
 [GLYPHDATA](/windows/win32/api/winddi/ns-winddi-glyphdata)
 
-[IPrintOemUni::DownloadCharGlyph](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-downloadcharglyph)
+[IPrintOemUni::DownloadCharGlyph](../prcomoem/nf-prcomoem-iprintoemuni-downloadcharglyph.md)
 
-[UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo)
+[UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_glyphstring.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_glyphstring.md
@@ -47,17 +47,17 @@ api_name:
 
 ## -description
 
-The **GETINFO_GLYPHSTRING** structure is used as input to the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+The **GETINFO_GLYPHSTRING** structure is used as input to the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -struct-fields
 
 ### -field dwSize
 
-Specifies the size, in bytes, of the **GETINFO_GLYPHSTRING** structure. This value is supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Specifies the size, in bytes, of the **GETINFO_GLYPHSTRING** structure. This value is supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field dwCount
 
-Specifies the number of elements in the arrays pointed to by **pGlyphIn** and **pGlyphOut**. This value is supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Specifies the number of elements in the arrays pointed to by **pGlyphIn** and **pGlyphOut**. This value is supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field dwTypeIn
 
@@ -68,11 +68,11 @@ Specifies the type of glyph specifier array pointed to by **pGlyphIn**. Valid va
 | TYPE_GLYPHHANDLE | T**pGlyphIn** array elements are of type HGLYPH, or handle to a device font glyph. For this value of **dwTypeIn**, valid values for **dwTypeOut** are either TYPE_UNICODE or TYPE_TRANSDATA. |
 | TYPE_GLYPHID | The **pGlyphIn** array elements are of type DWORD, and contain glyph identifiers for downloaded TrueType font glyphs. For this value of **dwTypeIn**, valid values for **dwTypeOut** are either TYPE_UNICODE or TYPE_GLYPHHANDLE. |
 
-Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field pGlyphIn
 
-Pointer to an array of glyph specifiers. The array element type is indicated by **dwTypeIn**. This value is supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Pointer to an array of glyph specifiers. The array element type is indicated by **dwTypeIn**. This value is supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field dwTypeOut
 
@@ -81,14 +81,14 @@ Specifies the type of glyph specifier array pointed to by **pGlyphOut**. Valid v
 | Value | Definition |
 |--|--|
 | TYPE_GLYPHHANDLE | The **pGlyphOut** array elements are of type HGLYPH, or handle to a device font glyph. This value is valid only when **dwTypeIn** has been set to TYPE_GLYPHID. |
-| TYPE_TRANSDATA | The **pGlyphOut** array elements are of type [TRANSDATA](/windows-hardware/drivers/ddi/prntfont/ns-prntfont-_transdata). This value is valid only when **dwTypeIn** has been set to TYPE_GLYPHHANDLE. |
+| TYPE_TRANSDATA | The **pGlyphOut** array elements are of type [TRANSDATA](../prntfont/ns-prntfont-_transdata.md). This value is valid only when **dwTypeIn** has been set to TYPE_GLYPHHANDLE. |
 | TYPE_UNICODE | The *pGlyph* array elements are of type WCHAR. This value is valid when **dwTypeIn** has been set to either TYPE_GLYPHHANDLE or TYPE_GLYPHID. |
 
-Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field pGlyphOut
 
-Caller-supplied pointer to an empty array of glyph specifiers. The array is filled in by Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function. The array element type is indicated by **dwTypeOut**. This pointer is supplied by the UNIFONTOBJ_GetInfo caller.
+Caller-supplied pointer to an empty array of glyph specifiers. The array is filled in by Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function. The array element type is indicated by **dwTypeOut**. This pointer is supplied by the UNIFONTOBJ_GetInfo caller.
 
 ### -field dwGlyphOutSize
 
@@ -96,20 +96,20 @@ Specifies the size, in bytes, of the buffer pointed to by **pGlyphOut**. This me
 
 ## -remarks
 
-To convert an array of glyph specifiers from one type to another, a rendering plug-in can supply the address of a GETINFO_GLYPHSTRING structure when calling Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+To convert an array of glyph specifiers from one type to another, a rendering plug-in can supply the address of a GETINFO_GLYPHSTRING structure when calling Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
-If the conversion is from TYPE_GLYPHHANDLE to TYPE_TRANSDATA, [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) must be called twice.
+If the conversion is from TYPE_GLYPHHANDLE to TYPE_TRANSDATA, [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) must be called twice.
 
-- Before the first call to [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo), the rendering plug-in fills in the **dwSize**, **dwCount**, **dwTypeIn**, and **pGlyphIn** members and sets **dwGlyphOutSize** member to zero.
+- Before the first call to [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md), the rendering plug-in fills in the **dwSize**, **dwCount**, **dwTypeIn**, and **pGlyphIn** members and sets **dwGlyphOutSize** member to zero.
 
-  After [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) returns, the **dwGlyphOutSize** member contains the size, in bytes, of the buffer needed to store the converted string.
+  After [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) returns, the **dwGlyphOutSize** member contains the size, in bytes, of the buffer needed to store the converted string.
 
-- The plug-in allocates a block of memory of the size received in the **dwGlyphOutSize** member, sets the **pGlyphOut** member to point to this memory block, and calls [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) once more. UNIDRV then converts the string from TYPE_GLYPHHANDLE to TYPE_TRANSDATA.
+- The plug-in allocates a block of memory of the size received in the **dwGlyphOutSize** member, sets the **pGlyphOut** member to point to this memory block, and calls [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) once more. UNIDRV then converts the string from TYPE_GLYPHHANDLE to TYPE_TRANSDATA.
 
-The values that a rendering plug-in specifies for the **dwTypeIn**and **pGlyphIn** members typically are those that were previously received as the **dwType**and *pGlyph* parameters to the [IPrintOemUni::OutputCharStr](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-outputcharstr) method.
+The values that a rendering plug-in specifies for the **dwTypeIn**and **pGlyphIn** members typically are those that were previously received as the **dwType**and *pGlyph* parameters to the [IPrintOemUni::OutputCharStr](../prcomoem/nf-prcomoem-iprintoemuni-outputcharstr.md) method.
 
 ## -see-also
 
-[IPrintOemUni::OutputCharStr](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-outputcharstr)
+[IPrintOemUni::OutputCharStr](../prcomoem/nf-prcomoem-iprintoemuni-outputcharstr.md)
 
-[UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo)
+[UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_glyphwidth.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_glyphwidth.md
@@ -47,13 +47,13 @@ api_name:
 
 ## -description
 
-The **GETINFO_GLYPHWIDTH** structure is used as input to the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+The **GETINFO_GLYPHWIDTH** structure is used as input to the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -struct-fields
 
 ### -field dwSize
 
-Size, in bytes, of the **GETINFO_GLYPHWIDTH** structure. Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Size, in bytes, of the **GETINFO_GLYPHWIDTH** structure. Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field dwType
 
@@ -63,24 +63,24 @@ Specifies the type of the glyph specifier array pointed to by **pGlyph**. Valid 
 
 - TYPE_GLYPHID
 
-Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field dwCount
 
-Specifies the number of elements in the array pointed to by **pGlyph**. Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Specifies the number of elements in the array pointed to by **pGlyph**. Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field pGlyph
 
-Pointer to an array of glyph specifiers. The array element type is indicated by **dwType**. Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Pointer to an array of glyph specifiers. The array element type is indicated by **dwType**. Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field plWidth
 
-Pointer to a location into which Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function places the width value. The pointer is supplied by the UNIFONTOBJ_GetInfo caller.
+Pointer to a location into which Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function places the width value. The pointer is supplied by the UNIFONTOBJ_GetInfo caller.
 
 ## -remarks
 
-To obtain the width of a set of glyphs, a rendering plug-in can supply the address of a GETINFO_GLYPHWIDTH structure when calling Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function. The callback function calculates the total width of all the glyphs described by the input array, and places the calculated value in the location pointed to by **plWidth**.
+To obtain the width of a set of glyphs, a rendering plug-in can supply the address of a GETINFO_GLYPHWIDTH structure when calling Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function. The callback function calculates the total width of all the glyphs described by the input array, and places the calculated value in the location pointed to by **plWidth**.
 
 ## -see-also
 
-[UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo)
+[UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_memory.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_memory.md
@@ -44,22 +44,22 @@ api_name:
 
 ## -description
 
-The **GETINFO_MEMORY** structure is used as input to the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+The **GETINFO_MEMORY** structure is used as input to the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -struct-fields
 
 ### -field dwSize
 
-Specifies the size, in bytes, of the **GETINFO_MEMORY** structure. Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Specifies the size, in bytes, of the **GETINFO_MEMORY** structure. Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field dwRemainingMemory
 
-Specifies the amount, in bytes, of currently available printer memory. Supplied by Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+Specifies the amount, in bytes, of currently available printer memory. Supplied by Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -remarks
 
-To obtain Unidrv's calculation of the amount of printer memory currently available, a rendering plug-in can supply the address of a **GETINFO_MEMORY** structure when calling Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+To obtain Unidrv's calculation of the amount of printer memory currently available, a rendering plug-in can supply the address of a **GETINFO_MEMORY** structure when calling Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -see-also
 
-[UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo)
+[UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_stdvar.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_getinfo_stdvar.md
@@ -47,13 +47,13 @@ api_name:
 
 ## -description
 
-The **GETINFO_STDVAR** structure is used as input to the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+The **GETINFO_STDVAR** structure is used as input to the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -struct-fields
 
 ### -field dwSize
 
-Specifies the size, in bytes, of the **GETINFO_STDVAR** structure. Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Specifies the size, in bytes, of the **GETINFO_STDVAR** structure. Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 ### -field dwNumOfVariable
 
@@ -73,7 +73,7 @@ An array specifying standard variable indexes and values. Each array element con
 
 #### dwStdVarID
 
-Specifies the [standard variables](/windows-hardware/drivers/print/standard-variables) for which a value should be returned. Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller. Valid values are contained in the following table.
+Specifies the [standard variables](/windows-hardware/drivers/print/standard-variables) for which a value should be returned. Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller. Valid values are contained in the following table.
 
 | Identifier                   | Standard Variable     |
 |------------------------------|-----------------------|
@@ -92,18 +92,18 @@ Specifies the [standard variables](/windows-hardware/drivers/print/standard-vari
 | FNT_INFO_TEXTXRES            | TextXRes            |
 | FNT_INFO_TEXTYRES            | TextYRes            |
 
-Supplied by the [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) caller.
+Supplied by the [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) caller.
 
 #### lStdVariable
 
-Specifies the current value of the specified standard variable. Supplied by Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+Specifies the current value of the specified standard variable. Supplied by Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 ## -remarks
 
-To obtain the current value for one or more of Unidrv's standard variables, a rendering plug-in can supply the address of a GETINFO_STDVAR structure when calling Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function.
+To obtain the current value for one or more of Unidrv's standard variables, a rendering plug-in can supply the address of a GETINFO_STDVAR structure when calling Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function.
 
 For more information about [standard variables](/windows-hardware/drivers/print/standard-variables), see [Microsoft Universal Printer Driver](/windows-hardware/drivers/print/microsoft-universal-printer-driver).
 
 ## -see-also
 
-[UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo)
+[UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_oem_dmextraheader.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_oem_dmextraheader.md
@@ -57,7 +57,7 @@ Total size, in bytes, of the added private **DEVMODEW** structure members, inclu
 
 ### -field dwSignature
 
-Unique signature value that the plug-in also returns when its [IPrintOemUI::GetInfo](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-getinfo) method receives the OEMGI_GETSIGNATURE flag.
+Unique signature value that the plug-in also returns when its [IPrintOemUI::GetInfo](../prcomoem/nf-prcomoem-iprintoemui-getinfo.md) method receives the OEMGI_GETSIGNATURE flag.
 
 ### -field dwVersion
 

--- a/wdk-ddi-src/content/printoem/ns-printoem-_oemcuipparam.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_oemcuipparam.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **OEMCUIPPARAM** structure is used as an input parameter to a user interface plug-in's [IPrintOemUI::CommonUIProp](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-commonuiprop) method.
+The **OEMCUIPPARAM** structure is used as an input parameter to a user interface plug-in's [IPrintOemUI::CommonUIProp](../prcomoem/nf-prcomoem-iprintoemui-commonuiprop.md) method.
 
 ## -struct-fields
 
@@ -57,7 +57,7 @@ Size of the **OEMCUIPPARAM** structure. Supplied by the Unidrv or Pscript5 drive
 
 ### -field poemuiobj
 
-Pointer to an [OEMUIOBJ](/windows-hardware/drivers/ddi/printoem/ns-printoem-_oemuiobj) structure.
+Pointer to an [OEMUIOBJ](./ns-printoem-_oemuiobj.md) structure.
 
 ### -field hPrinter
 
@@ -77,7 +77,7 @@ Handle to a heap from which space can be allocated by calling the **HeapAlloc** 
 
 ### -field pPublicDM
 
-Pointer to the printer's public **DEVMODEW** structure. Valid only if the [IPrintOemUI::CommonUIProp](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-commonuiprop) method's *dwMode* argument is OEMCUIP_DOCPROP. Supplied by the Unidrv or Pscript5 driver.
+Pointer to the printer's public **DEVMODEW** structure. Valid only if the [IPrintOemUI::CommonUIProp](../prcomoem/nf-prcomoem-iprintoemui-commonuiprop.md) method's *dwMode* argument is OEMCUIP_DOCPROP. Supplied by the Unidrv or Pscript5 driver.
 
 ### -field pOEMDM
 
@@ -87,15 +87,15 @@ Pointer to the user interface plug-in's private **DEVMODEW** members. Valid only
 
 #### For calls to IPrintOemUI::CommonUIProp with its dwMode parameter set to OEMCUIP_DOCPROP
 
-Contains the contents of the **fMode** member of the [DOCUMENTPROPERTYHEADER](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_documentpropertyheader) structure received by the printer driver's [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets) function.
+Contains the contents of the **fMode** member of the [DOCUMENTPROPERTYHEADER](../winddiui/ns-winddiui-_documentpropertyheader.md) structure received by the printer driver's [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md) function.
 
 #### For calls to IPrintOemUI::CommonUIProp with its dwMode parameter set to OEMCUIP_PRNPROP
 
-Contains the contents of the **Flags** member of the DEVICEPROPERTYHEADER structure received by the printer driver's [DrvDevicePropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdevicepropertysheets) function.
+Contains the contents of the **Flags** member of the DEVICEPROPERTYHEADER structure received by the printer driver's [DrvDevicePropertySheets](../winddiui/nf-winddiui-drvdevicepropertysheets.md) function.
 
 ### -field pDrvOptItems
 
-Pointer to the printer driver's [**OPTITEM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) array. Not valid the first time **IPrintOemUI::CommonUIProp** is called. Supplied by the Unidrv or Pscript5 driver.
+Pointer to the printer driver's [**OPTITEM**](../compstui/ns-compstui-_optitem.md) array. Not valid the first time **IPrintOemUI::CommonUIProp** is called. Supplied by the Unidrv or Pscript5 driver.
 
 ### -field cDrvOptItems
 
@@ -123,10 +123,10 @@ Used by the **IPrintOemUI::CommonUIProp** method, the second time it is called, 
 
 ### -field OEMCUIPCallback
 
-Used by the **IPrintOemUI::CommonUIProp** method, the second time it is called, to return the address of a callback function of type [OEMCUIPCALLBACK](/windows-hardware/drivers/ddi/printoem/nc-printoem-oemcuipcallback).
+Used by the **IPrintOemUI::CommonUIProp** method, the second time it is called, to return the address of a callback function of type [OEMCUIPCALLBACK](./nc-printoem-oemcuipcallback.md).
 
 ## -remarks
 
-A user interface plug-in receives this structure's address as an input argument to both its [IPrintOemUI::CommonUIProp](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-commonuiprop) method and its [OEMCUIPCALLBACK](/windows-hardware/drivers/ddi/printoem/nc-printoem-oemcuipcallback)-typed callback function.
+A user interface plug-in receives this structure's address as an input argument to both its [IPrintOemUI::CommonUIProp](../prcomoem/nf-prcomoem-iprintoemui-commonuiprop.md) method and its [OEMCUIPCALLBACK](./nc-printoem-oemcuipcallback.md)-typed callback function.
 
 For additional information about the use of this structure and associated functions, see [User Interface Plug-Ins](/windows-hardware/drivers/print/user-interface-plug-ins).

--- a/wdk-ddi-src/content/printoem/ns-printoem-_oemdmparam.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_oemdmparam.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **OEMDMPARAM** structure is used as an input parameter to the [IPrintOemUI::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-devmode), [IPrintOemUni::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-devmode), and [IPrintOemPS::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-devmode) methods.
+The **OEMDMPARAM** structure is used as an input parameter to the [IPrintOemUI::DevMode](../prcomoem/nf-prcomoem-iprintoemui-devmode.md), [IPrintOemUni::DevMode](../prcomoem/nf-prcomoem-iprintoemuni-devmode.md), and [IPrintOemPS::DevMode](../prcomoem/nf-prcomoem-iprintoemps-devmode.md) methods.
 
 ## -struct-fields
 
@@ -63,7 +63,7 @@ Not used.
 
 #### For IPrintOemUni::DevMode and IPrintOemPS::DevMode
 
-Pointer to a [**DEVOBJ**](/windows-hardware/drivers/ddi/printoem/ns-printoem-_devobj) structure.
+Pointer to a [**DEVOBJ**](./ns-printoem-_devobj.md) structure.
 
 ### -field hPrinter
 
@@ -97,4 +97,4 @@ On output, contains the method-supplied size of the current version of the priva
 
 ## -remarks
 
-For more information about the use of **OEMDMPARAM** structure members, see the description of the [IPrintOemUI::DevMode](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-devmode) method.
+For more information about the use of **OEMDMPARAM** structure members, see the description of the [IPrintOemUI::DevMode](../prcomoem/nf-prcomoem-iprintoemui-devmode.md) method.

--- a/wdk-ddi-src/content/printoem/ns-printoem-_oemuiobj.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_oemuiobj.md
@@ -57,10 +57,10 @@ Size of the **OEMUIOBJ** structure.
 
 ### -field pOemUIProcs
 
-Pointer to a an [**OEMUIPROCS**](/windows-hardware/drivers/ddi/printoem/ns-printoem-_oemuiprocs) structure, which is a private, internal structure.
+Pointer to a an [**OEMUIPROCS**](./ns-printoem-_oemuiprocs.md) structure, which is a private, internal structure.
 
 ## -remarks
 
-User interface plug-ins do not need to reference an **OEMUIOBJ** structure's members. Plug-ins receive a pointer to this structure as input to their [IPrintOemUI::DeviceCapabilities](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-devicecapabilities), [IPrintOemUI::DevQueryPrintEx](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-devqueryprintex) and [IPrintOemUI::QueryColorProfile](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-querycolorprofile) methods.
+User interface plug-ins do not need to reference an **OEMUIOBJ** structure's members. Plug-ins receive a pointer to this structure as input to their [IPrintOemUI::DeviceCapabilities](../prcomoem/nf-prcomoem-iprintoemui-devicecapabilities.md), [IPrintOemUI::DevQueryPrintEx](../prcomoem/nf-prcomoem-iprintoemui-devqueryprintex.md) and [IPrintOemUI::QueryColorProfile](../prcomoem/nf-prcomoem-iprintoemui-querycolorprofile.md) methods.
 
-Additionally, the **OEMCUIPPARAM** structure contains an **OEMUIOBJ** structure pointer. Plug-ins must supply the received pointer when calling [IPrintOemDriverUI::DrvGetDriverSetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriverui-drvgetdriversetting) or [IPrintOemDriverUI::DrvUpdateUISetting](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemdriverui-drvupdateuisetting).
+Additionally, the **OEMCUIPPARAM** structure contains an **OEMUIOBJ** structure pointer. Plug-ins must supply the received pointer when calling [IPrintOemDriverUI::DrvGetDriverSetting](../prcomoem/nf-prcomoem-iprintoemdriverui-drvgetdriversetting.md) or [IPrintOemDriverUI::DrvUpdateUISetting](../prcomoem/nf-prcomoem-iprintoemdriverui-drvupdateuisetting.md).

--- a/wdk-ddi-src/content/printoem/ns-printoem-_oemuiprocs.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_oemuiprocs.md
@@ -49,13 +49,13 @@ api_name:
 
 The **OEMUIPROCS** structure is obsolete.
 
-The **OEMUIPROCS** structure contains the address of the [DrvGetDriverSetting](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvgetdriversetting) and [DrvUpdateUISetting](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvupdateuisetting) functions that are exported by Microsoft printer drivers.
+The **OEMUIPROCS** structure contains the address of the [DrvGetDriverSetting](./nc-printoem-pfn_drvgetdriversetting.md) and [DrvUpdateUISetting](./nc-printoem-pfn_drvupdateuisetting.md) functions that are exported by Microsoft printer drivers.
 
 ## -struct-fields
 
 ### -field DrvGetDriverSetting
 
-Pointer to the printer driver's **DrvGetDriverSetting** function. (To obtain this function's address in kernel mode, see [DRVPROCS](/windows-hardware/drivers/ddi/printoem/ns-printoem-_drvprocs).
+Pointer to the printer driver's **DrvGetDriverSetting** function. (To obtain this function's address in kernel mode, see [DRVPROCS](./ns-printoem-_drvprocs.md).
 
 ### -field DrvUpdateUISetting
 
@@ -63,6 +63,6 @@ Pointer to the printer driver's **DrvUpdateUISetting** function.
 
 ## -remarks
 
-[DrvGetDriverSetting](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvgetdriversetting) and [DrvUpdateUISetting](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfn_drvupdateuisetting) have been superseded by COM-based interfaces.
+[DrvGetDriverSetting](./nc-printoem-pfn_drvgetdriversetting.md) and [DrvUpdateUISetting](./nc-printoem-pfn_drvupdateuisetting.md) have been superseded by COM-based interfaces.
 
-The **OEMUIPROCS** structure's address is contained in an [OEMUIOBJ](/windows-hardware/drivers/ddi/printoem/ns-printoem-_oemuiobj) structure.
+The **OEMUIPROCS** structure's address is contained in an [OEMUIOBJ](./ns-printoem-_oemuiobj.md) structure.

--- a/wdk-ddi-src/content/printoem/ns-printoem-_oemuipsparam.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_oemuipsparam.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **OEMUIPSPARAM** structure is passed to a user interface plug-in's [IPrintOemUI::DevicePropertySheets](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-devicepropertysheets) and [IPrintOemUI::DocumentPropertySheets](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-documentpropertysheets) methods.
+The **OEMUIPSPARAM** structure is passed to a user interface plug-in's [IPrintOemUI::DevicePropertySheets](../prcomoem/nf-prcomoem-iprintoemui-devicepropertysheets.md) and [IPrintOemUI::DocumentPropertySheets](../prcomoem/nf-prcomoem-iprintoemui-documentpropertysheets.md) methods.
 
 ## -struct-fields
 
@@ -95,15 +95,15 @@ Not used.
 
 ### -field pOEMUserData
 
-Pointer, supplied by user interface plug-in, to a location containing private information. This pointer is returned to the plug-in's [_CPSUICALLBACK](/windows-hardware/drivers/ddi/compstui/nc-compstui-_cpsuicallback)-typed callback function when a property sheet item has changed.
+Pointer, supplied by user interface plug-in, to a location containing private information. This pointer is returned to the plug-in's [_CPSUICALLBACK](../compstui/nc-compstui-_cpsuicallback.md)-typed callback function when a property sheet item has changed.
 
 ### -field dwFlags
 
 **For calls to IPrintOemUI::DocumentPropertySheets**  
-Contains the contents of the **fMode** member of the **DOCUMENTPROPERTYHEADER** structure received by the printer driver's [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets) function.
+Contains the contents of the **fMode** member of the **DOCUMENTPROPERTYHEADER** structure received by the printer driver's [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md) function.
 
 **For calls to IPrintOemUI::DevicePropertySheets**  
-Contains the contents of the **Flags** member of the **DEVICEPROPERTYHEADER** structure received by the printer driver's [DrvDevicePropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdevicepropertysheets) function.
+Contains the contents of the **Flags** member of the **DEVICEPROPERTYHEADER** structure received by the printer driver's [DrvDevicePropertySheets](../winddiui/nf-winddiui-drvdevicepropertysheets.md) function.
 
 ### -field pOemEntry
 
@@ -111,12 +111,12 @@ Reserved for system use.
 
 ## -see-also
 
-[DrvDevicePropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdevicepropertysheets)
+[DrvDevicePropertySheets](../winddiui/nf-winddiui-drvdevicepropertysheets.md)
 
-[DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets)
+[DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md)
 
-[IPrintOemUI::DevicePropertySheets](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-devicepropertysheets)
+[IPrintOemUI::DevicePropertySheets](../prcomoem/nf-prcomoem-iprintoemui-devicepropertysheets.md)
 
-[IPrintOemUI::DocumentPropertySheets](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-documentpropertysheets)
+[IPrintOemUI::DocumentPropertySheets](../prcomoem/nf-prcomoem-iprintoemui-documentpropertysheets.md)
 
-[_CPSUICALLBACK](/windows-hardware/drivers/ddi/compstui/nc-compstui-_cpsuicallback)
+[_CPSUICALLBACK](../compstui/nc-compstui-_cpsuicallback.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_pdev_adjust_paper_margin.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_pdev_adjust_paper_margin.md
@@ -56,10 +56,10 @@ Is a [RECTL](/windows/win32/api/windef/ns-windef-rectl) structure that specifies
 
 This structure is available in Windows XP and later.
 
-The *pBuf* parameter of the [IPrintOemPS2::GetPDEVAdjustment](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment) method can point to a structure of this type.
+The *pBuf* parameter of the [IPrintOemPS2::GetPDEVAdjustment](../prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment.md) method can point to a structure of this type.
 
 ## -see-also
 
-[IPrintOemPS2::GetPDEVAdjustment](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment)
+[IPrintOemPS2::GetPDEVAdjustment](../prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment.md)
 
 [RECTL](/windows/win32/api/windef/ns-windef-rectl)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_pdev_hostfont_enabled.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_pdev_hostfont_enabled.md
@@ -56,7 +56,7 @@ Specifies whether the Hostfont feature is enabled. If set to **TRUE**, the Hostf
 
 This structure is available in Windows XP and later.
 
-The *pBuf* parameter of the [IPrintOemPS2::GetPDEVAdjustment](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment) method can point to a structure of this type.
+The *pBuf* parameter of the [IPrintOemPS2::GetPDEVAdjustment](../prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment.md) method can point to a structure of this type.
 
 Hostfont support is designed to improve the performance of a PostScript interpreter running on a host computer system, rather than on a physical printer. When the Hostfont feature is enabled, the Pscript5 driver stops converting and downloading host font data when there is already an identical font resident on the host on which the interpreter is running. This applies only to the following fonts:
 
@@ -68,4 +68,4 @@ Hostfont support is designed to improve the performance of a PostScript interpre
 
 ## -see-also
 
-[IPrintOemPS2::GetPDEVAdjustment](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment)
+[IPrintOemPS2::GetPDEVAdjustment](../prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_pdev_use_true_color.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_pdev_use_true_color.md
@@ -56,10 +56,10 @@ Specifies whether the PostScript output should be in color mode or in monochrome
 
 This structure is available in Windows XP and later.
 
-The *pBuf* parameter of the [IPrintOemPS2::GetPDEVAdjustment](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment) method can point to a structure of this type.
+The *pBuf* parameter of the [IPrintOemPS2::GetPDEVAdjustment](../prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment.md) method can point to a structure of this type.
 
 A plug-in can use this flag to turn color output on or off for Pscript5 printer output data. If the plug-in chooses to not change the current setting, it can simply return **S_FALSE**.
 
 ## -see-also
 
-[IPrintOemPS2::GetPDEVAdjustment](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment)
+[IPrintOemPS2::GetPDEVAdjustment](../prcomoem/nf-prcomoem-iprintoemps2-getpdevadjustment.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_publisherinfo.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_publisherinfo.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **PUBLISHERINFO** structure is used as an input parameter to the [IPrintOemPS::GetInfo](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-getinfo) method.
+The **PUBLISHERINFO** structure is used as an input parameter to the [IPrintOemPS::GetInfo](../prcomoem/nf-prcomoem-iprintoemps-getinfo.md) method.
 
 ## -struct-fields
 
@@ -65,4 +65,4 @@ Specifies the maximum font size, in pixels, for which the Pscript5 driver will d
 
 ## -see-also
 
-[IPrintOemPS::GetInfo](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemps-getinfo)
+[IPrintOemPS::GetInfo](../prcomoem/nf-prcomoem-iprintoemps-getinfo.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_simulate_caps_1.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_simulate_caps_1.md
@@ -83,4 +83,4 @@ The **IPrintCoreUI2::QuerySimulationSupport** method uses this structure to repo
 
 ## -see-also
 
-[IPrintCoreUI2::QuerySimulationSupport](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintcoreui2-querysimulationsupport)
+[IPrintCoreUI2::QuerySimulationSupport](../prcomoem/nf-prcomoem-iprintcoreui2-querysimulationsupport.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_unifontobj.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_unifontobj.md
@@ -75,10 +75,10 @@ Pointer to an [IFIMETRICS](/windows/win32/api/winddi/ns-winddi-ifimetrics) struc
 
 ### -field pfnGetInfo
 
-Pointer to Unidrv's [UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo) callback function. Supplied by Unidrv.
+Pointer to Unidrv's [UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md) callback function. Supplied by Unidrv.
 
 ## -see-also
 
 [IFIMETRICS](/windows/win32/api/winddi/ns-winddi-ifimetrics)
 
-[UNIFONTOBJ_GetInfo](/windows-hardware/drivers/ddi/printoem/nc-printoem-pfngetinfo)
+[UNIFONTOBJ_GetInfo](./nc-printoem-pfngetinfo.md)

--- a/wdk-ddi-src/content/printoem/ns-printoem-_userdata.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-_userdata.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **USERDATA** structure is used by [Unidrv](/windows-hardware/drivers/) and [Pscript](/windows-hardware/drivers/) to specify additional information about printer features. A **USERDATA** structure pointer is supplied as the **UserData** member for each [**OPTITEM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure.
+The **USERDATA** structure is used by [Unidrv](/windows-hardware/drivers/) and [Pscript](/windows-hardware/drivers/) to specify additional information about printer features. A **USERDATA** structure pointer is supplied as the **UserData** member for each [**OPTITEM**](../compstui/ns-compstui-_optitem.md) structure.
 
 ## -struct-fields
 

--- a/wdk-ddi-src/content/printoem/ns-printoem-ipparams.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-ipparams.md
@@ -70,6 +70,6 @@ Specifies whether a blank band was drawn in the source bitmap supplied to **IPri
 
 ## -see-also
 
-[IPrintOemUn::ImageProcessing](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-imageprocessing)
+[IPrintOemUn::ImageProcessing](../prcomoem/nf-prcomoem-iprintoemuni-imageprocessing.md)
 
 [POINT](/windows/win32/api/windef/ns-windef-point)

--- a/wdk-ddi-src/content/printoem/ns-printoem-oemmemoryusage.md
+++ b/wdk-ddi-src/content/printoem/ns-printoem-oemmemoryusage.md
@@ -44,7 +44,7 @@ api_name:
 
 ## -description
 
-The **OEMMEMORYUSAGE** structure is used as an input parameter to a rendering plug-in's [IPrintOemUni::MemoryUsage](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-memoryusage) method.
+The **OEMMEMORYUSAGE** structure is used as an input parameter to a rendering plug-in's [IPrintOemUni::MemoryUsage](../prcomoem/nf-prcomoem-iprintoemuni-memoryusage.md) method.
 
 ## -struct-fields
 
@@ -54,7 +54,7 @@ Specifies the amount, in bytes, of fixed-sized memory required by the **IPrintOe
 
 ### -field dwPercentMemoryUsage
 
-Specifies the amount of variably-sized memory required by the **IPrintOemUni::MemoryUsage** method, expressed as a percentage of the size of the source bitmap received by [IPrintOemUni::ImageProcessing](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-imageprocessing). Supplied by the rendering plug-in.
+Specifies the amount of variably-sized memory required by the **IPrintOemUni::MemoryUsage** method, expressed as a percentage of the size of the source bitmap received by [IPrintOemUni::ImageProcessing](../prcomoem/nf-prcomoem-iprintoemuni-imageprocessing.md). Supplied by the rendering plug-in.
 
 ### -field dwMaxBandSize
 
@@ -62,10 +62,10 @@ Specifies the maximum size, in bytes, that can be used for source bitmaps. This 
 
 ## -remarks
 
-The Unidrv driver uses the values in the **dwFixedMemoryUsage** and **dwPercentMemoryUsage** members of this structure to determine the optimum size for a GDI drawing surface, taking into account any memory requirements of a rendering plug-in's **IPrintOemUni::ImageProcessing** method. For more information about how these members are used, see the Remarks section in [IPrintOemUni::MemoryUsage](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-memoryusage).
+The Unidrv driver uses the values in the **dwFixedMemoryUsage** and **dwPercentMemoryUsage** members of this structure to determine the optimum size for a GDI drawing surface, taking into account any memory requirements of a rendering plug-in's **IPrintOemUni::ImageProcessing** method. For more information about how these members are used, see the Remarks section in [IPrintOemUni::MemoryUsage](../prcomoem/nf-prcomoem-iprintoemuni-memoryusage.md).
 
 ## -see-also
 
-[IPrintOemUni::ImageProcessing](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-imageprocessing)
+[IPrintOemUni::ImageProcessing](../prcomoem/nf-prcomoem-iprintoemuni-imageprocessing.md)
 
-[IPrintOemUni::MemoryUsage](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemuni-memoryusage)
+[IPrintOemUni::MemoryUsage](../prcomoem/nf-prcomoem-iprintoemuni-memoryusage.md)

--- a/wdk-ddi-src/content/wdfdevice/ne-wdfdevice-_wdf_device_hwaccess_target_type.md
+++ b/wdk-ddi-src/content/wdfdevice/ne-wdfdevice-_wdf_device_hwaccess_target_type.md
@@ -72,4 +72,4 @@ The **WDF_DEVICE_HWACCESS_TARGET_SIZE** enumeration is used internally by the fr
 
 ## -see-also
 
-- [UMDF Structures and Enumeration Types](/windows-hardware/drivers/ddi/wudfddi/)
+- [UMDF Structures and Enumeration Types](../wudfddi/index.md)

--- a/wdk-ddi-src/content/wdfinterrupt/nc-wdfinterrupt-pfn_wdfinterruptacquirelock.md
+++ b/wdk-ddi-src/content/wdfinterrupt/nc-wdfinterrupt-pfn_wdfinterruptacquirelock.md
@@ -97,7 +97,7 @@ For more information about the **WdfInterruptAcquireLock** method, see [Synchron
 
 For more information about handling interrupts in framework-based drivers, see [Handling Hardware Interrupts](/windows-hardware/drivers/wdf/handling-hardware-interrupts).
 
-For passive-level interrupt objects, drivers must call [WdfInterruptTryToAcquireLock](../wdfinterrupt/nf-wdfinterrupt-wdfinterrupttrytoacquirelock.md) instead of **WdfInterruptAcquireLock**, when running in an arbitrary thread, such as a [queue object callback function](/windows-hardware/drivers/ddi/wdfio/). For example, the driver might call **WdfInterruptTryToAcquireLock** from [EvtIoRead](../wdfio/nc-wdfio-evt_wdf_io_queue_io_read.md).
+For passive-level interrupt objects, drivers must call [WdfInterruptTryToAcquireLock](../wdfinterrupt/nf-wdfinterrupt-wdfinterrupttrytoacquirelock.md) instead of **WdfInterruptAcquireLock**, when running in an arbitrary thread, such as a [queue object callback function](../wdfio/index.md). For example, the driver might call **WdfInterruptTryToAcquireLock** from [EvtIoRead](../wdfio/nc-wdfio-evt_wdf_io_queue_io_read.md).
 
 Doing so avoids the possibility of deadlock, as described in the following scenario.
 

--- a/wdk-ddi-src/content/winsplp/nf-winsplp-addportui.md
+++ b/wdk-ddi-src/content/winsplp/nf-winsplp-addportui.md
@@ -67,7 +67,7 @@ If the operation succeeds, the function should return **TRUE**. Otherwise SetLas
 
 ## -remarks
 
-Port monitor UI DLLs are required to define an **AddPortUI** function and include the function's address in a [MONITORUI](/windows-hardware/drivers/ddi/winsplp/ns-winsplp-_monitorui) structure.
+Port monitor UI DLLs are required to define an **AddPortUI** function and include the function's address in a [MONITORUI](./ns-winsplp-_monitorui.md) structure.
 
 The spooler calls **AddPortUI** from within its AddPort function. The first three arguments received by **AddPortUI** are the arguments received by AddPort. (The AddPort function is described in the Microsoft Windows SDK documentation.)
 
@@ -81,7 +81,7 @@ The function should perform the following operations:
 
     The call to OpenPrinter requires a PRINTER_DEFAULTS structure, which is described in the Windows SDK documentation. The structure's **DesiredAccess** member must be set to SERVER_ACCESS_ADMINISTER. Its **pDatatype** and **pDevMode** members can be **NULL**.
 
-    This call causes the print monitor server DLL's [XcvOpenPort](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-xcvopenport) function to be called.
+    This call causes the print monitor server DLL's [XcvOpenPort](./nf-winsplp-xcvopenport.md) function to be called.
 
 1. Obtain a port name from the user by displaying a dialog box.
 
@@ -93,7 +93,7 @@ The function should perform the following operations:
 
     - A customized data name string, such as "PortExists"
 
-    This call causes the server DLL's [XcvDataPort](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-xcvdataport) function to be called. The **XcvDataPort** function should return a value that indicates whether the specified port name has already been used. If it has, the UI DLL should request another name from the user and call [XcvData](/previous-versions/ff564255(v=vs.85)) again.
+    This call causes the server DLL's [XcvDataPort](./nf-winsplp-xcvdataport.md) function to be called. The **XcvDataPort** function should return a value that indicates whether the specified port name has already been used. If it has, the UI DLL should request another name from the user and call [XcvData](/previous-versions/ff564255(v=vs.85)) again.
 
 1. After a valid new port name has been received, call [XcvData](/previous-versions/ff564255(v=vs.85)) again, this time specifying the following input arguments
 
@@ -103,22 +103,22 @@ The function should perform the following operations:
 
     - A data name string of "AddPort"
 
-    This call causes the server DLL's [XcvDataPort](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-xcvdataport) function to be called again.
+    This call causes the server DLL's [XcvDataPort](./nf-winsplp-xcvdataport.md) function to be called again.
 
 1. Obtain port configuration parameters from the user by displaying a dialog box.
 
-1. Call [XcvData](/previous-versions/ff564255(v=vs.85)) one or more times, specifying customized data name strings, to send each configuration parameter to the server DLL. Each **XcvData** call causes the server's [XcvDataPort](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-xcvdataport) function to be called.
+1. Call [XcvData](/previous-versions/ff564255(v=vs.85)) one or more times, specifying customized data name strings, to send each configuration parameter to the server DLL. Each **XcvData** call causes the server's [XcvDataPort](./nf-winsplp-xcvdataport.md) function to be called.
 
-1. Call ClosePrinter, specifying the handle received from OpenPrinter. This causes the server DLL's [XcvClosePort](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-xcvcloseport) function to be called.
+1. Call ClosePrinter, specifying the handle received from OpenPrinter. This causes the server DLL's [XcvClosePort](./nf-winsplp-xcvcloseport.md) function to be called.
 
 ## -see-also
 
-[MONITORUI](/windows-hardware/drivers/ddi/winsplp/ns-winsplp-_monitorui)
+[MONITORUI](./ns-winsplp-_monitorui.md)
 
-[XcvClosePort](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-xcvcloseport)
+[XcvClosePort](./nf-winsplp-xcvcloseport.md)
 
 [XcvData](/previous-versions/ff564255(v=vs.85))
 
-[XcvDataPort](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-xcvdataport)
+[XcvDataPort](./nf-winsplp-xcvdataport.md)
 
-[XcvOpenPort](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-xcvopenport)
+[XcvOpenPort](./nf-winsplp-xcvopenport.md)

--- a/wdk-ddi-src/content/winsplp/nf-winsplp-appendprinternotifyinfodata.md
+++ b/wdk-ddi-src/content/winsplp/nf-winsplp-appendprinternotifyinfodata.md
@@ -66,7 +66,7 @@ If the operation succeeds, the function returns **TRUE**. Otherwise, the functio
 
 ## -remarks
 
-A print provider's [RefreshPrinterChangeNotification](/previous-versions/ff561930(v=vs.85)) function should call **AppendPrinterNotifyInfoData** as often as necessary to populate a **PRINTER_NOTIFY_INFO_DATA** structure array, after first calling [RouterAllocPrinterNotifyInfo](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-routerallocprinternotifyinfo) to allocate storage for the array and its associated PRINTER_NOTIFY_INFO structure.
+A print provider's [RefreshPrinterChangeNotification](/previous-versions/ff561930(v=vs.85)) function should call **AppendPrinterNotifyInfoData** as often as necessary to populate a **PRINTER_NOTIFY_INFO_DATA** structure array, after first calling [RouterAllocPrinterNotifyInfo](./nf-winsplp-routerallocprinternotifyinfo.md) to allocate storage for the array and its associated PRINTER_NOTIFY_INFO structure.
 
 Based on whether the PRINTER_NOTIFY_INFO_DATA_COMPACT flag is set, the function either appends the specified **PRINTER_NOTIFY_INFO_DATA** structure to the end of the structure array or overwrites an existing array element. If the structure is appended, the function increments the **PRINTER_NOTIFY_INFO** structure's **Count** member.
 
@@ -82,4 +82,4 @@ For additional information, see [Supporting Printer Change Notifications](/windo
 
 [RefreshPrinterChangeNotification](/previous-versions/ff561930(v=vs.85))
 
-[RouterAllocPrinterNotifyInfo](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-routerallocprinternotifyinfo)
+[RouterAllocPrinterNotifyInfo](./nf-winsplp-routerallocprinternotifyinfo.md)

--- a/wdk-ddi-src/content/winsplp/nf-winsplp-partialreplyprinterchangenotification.md
+++ b/wdk-ddi-src/content/winsplp/nf-winsplp-partialreplyprinterchangenotification.md
@@ -47,7 +47,7 @@ The print spooler's **PartialReplyPrinterChangeNotification** function allows a 
 
 ### -param hPrinter
 
-Caller-supplied handle. This handle must have been previously received as the *hNotify* input to the print provider's [FindFirstPrinterChangeNotification](/windows-hardware/drivers/ddi/winspool/nf-winspool-findfirstprinterchangenotification) function.
+Caller-supplied handle. This handle must have been previously received as the *hNotify* input to the print provider's [FindFirstPrinterChangeNotification](../winspool/nf-winspool-findfirstprinterchangenotification.md) function.
 
 ### -param pDataSrc
 
@@ -61,7 +61,7 @@ If the operation succeeds, the function returns **TRUE**. Otherwise the function
 
 For the specified notification handle, the spooler's **PartialReplyPrinterChangeNotification** function adds the contents of the specified PRINTER_NOTIFY_INFO_DATA structure to the array within the spooler's stored PRINTER_NOTIFY_INFO structure. (These structures are described in the Windows SDK documentation.)
 
-Calling **PartialReplyPrinterChangeNotification** does not cause the spooler to notify the application that changes have occurred. If the print provider's [FindFirstPrinterChangeNotification](/windows-hardware/drivers/ddi/winspool/nf-winspool-findfirstprinterchangenotification) function did not set the PRINTER_NOTIFY_STATUS_POLL flag, the provider must call [ReplyPrinterChangeNotification](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-replyprinterchangenotification) to cause the application to be notified.
+Calling **PartialReplyPrinterChangeNotification** does not cause the spooler to notify the application that changes have occurred. If the print provider's [FindFirstPrinterChangeNotification](../winspool/nf-winspool-findfirstprinterchangenotification.md) function did not set the PRINTER_NOTIFY_STATUS_POLL flag, the provider must call [ReplyPrinterChangeNotification](./nf-winsplp-replyprinterchangenotification.md) to cause the application to be notified.
 
 If *pInfoDataSrc* is **NULL**, all stored information associated with the specified handle is deleted from the spooler. The function accomplishes this deletion by freeing all buffers associated with *pBuf* members of PRINTER_NOTIFY_INFO_DATA structures belonging to the specified handle. The function then sets the PRINTER_NOTIFY_INFO_DISCARDED flag in the stored PRINTER_NOTIFY_INFO structure.
 
@@ -69,6 +69,6 @@ For additional information, see [Supporting Printer Change Notifications](/windo
 
 ## -see-also
 
-[FindFirstPrinterChangeNotification](/windows-hardware/drivers/ddi/winspool/nf-winspool-findfirstprinterchangenotification)
+[FindFirstPrinterChangeNotification](../winspool/nf-winspool-findfirstprinterchangenotification.md)
 
-[ReplyPrinterChangeNotification](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-replyprinterchangenotification)
+[ReplyPrinterChangeNotification](./nf-winsplp-replyprinterchangenotification.md)

--- a/wdk-ddi-src/content/winsplp/nf-winsplp-replyprinterchangenotification.md
+++ b/wdk-ddi-src/content/winsplp/nf-winsplp-replyprinterchangenotification.md
@@ -47,7 +47,7 @@ The print spooler's **ReplyPrinterChangeNotification** function allows a print p
 
 ### -param hPrinter
 
-Caller-supplied handle. This handle must have been previously received as the *hNotify* input to the print provider's [FindFirstPrinterChangeNotification](/windows-hardware/drivers/ddi/winspool/nf-winspool-findfirstprinterchangenotification) function.
+Caller-supplied handle. This handle must have been previously received as the *hNotify* input to the print provider's [FindFirstPrinterChangeNotification](../winspool/nf-winspool-findfirstprinterchangenotification.md) function.
 
 ### -param fdwChangeFlags
 
@@ -67,16 +67,16 @@ If the operation succeeds, the function returns **TRUE**. Otherwise the function
 
 ## -remarks
 
-Print providers that do not support polling (see [FindFirstPrinterChangeNotification](/windows-hardware/drivers/ddi/winspool/nf-winspool-findfirstprinterchangenotification)) must notify the spooler of the occurrence of any events represented by the PRINTER_CHANGE_-prefixed flags received by the provider's **FindFirstPrinterChangeNotification** function. When an event occurs, the print provider can call **ReplyPrinterChangeNotification** to inform the spooler of the event and to supply information associated with the event. The spooler keeps track of this event information, for each notification handle, and delivers the information to an application when the application calls **FindNextPrinterChangeNotification** (described in the Windows SDK documentation).
+Print providers that do not support polling (see [FindFirstPrinterChangeNotification](../winspool/nf-winspool-findfirstprinterchangenotification.md)) must notify the spooler of the occurrence of any events represented by the PRINTER_CHANGE_-prefixed flags received by the provider's **FindFirstPrinterChangeNotification** function. When an event occurs, the print provider can call **ReplyPrinterChangeNotification** to inform the spooler of the event and to supply information associated with the event. The spooler keeps track of this event information, for each notification handle, and delivers the information to an application when the application calls **FindNextPrinterChangeNotification** (described in the Windows SDK documentation).
 
 When a print provider calls **ReplyPrinterChangeNotification**, it must identify the event that has occurred by setting a PRINTER_CHANGE_-prefixed flag in *fwdFlags* or by using *pPrinterNotifyInfo* to return a PRINTER_NOTIFY_INFO structure. (Use the flags listed in the Windows SDK documentation's description of **FindNextPrinterChangeNotification**--not the flags listed in the Windows SDK documentation's description of **FindFirstPrinterChangeNotification**.)
 
-Calling **ReplyPrinterChangeNotification** causes the spooler to signal the client application that a print queue event has occurred. This happens even if the provider supplies **NULL** for *pPrinterNotifyInfo*. To update the spooler's record of print queue changes without causing the client to be notified, use [PartialReplyPrinterChangeNotification](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-partialreplyprinterchangenotification). It is common to call **PartialReplyPrinterChangeNotification** several times to update the spooler's database, then to call **ReplyPrinterChangeNotification** to notify the client that changes have occurred.
+Calling **ReplyPrinterChangeNotification** causes the spooler to signal the client application that a print queue event has occurred. This happens even if the provider supplies **NULL** for *pPrinterNotifyInfo*. To update the spooler's record of print queue changes without causing the client to be notified, use [PartialReplyPrinterChangeNotification](./nf-winsplp-partialreplyprinterchangenotification.md). It is common to call **PartialReplyPrinterChangeNotification** several times to update the spooler's database, then to call **ReplyPrinterChangeNotification** to notify the client that changes have occurred.
 
 For additional information, see [Supporting Printer Change Notifications](/windows-hardware/drivers/print/supporting-printer-change-notifications).
 
 ## -see-also
 
-[FindFirstPrinterChangeNotification](/windows-hardware/drivers/ddi/winspool/nf-winspool-findfirstprinterchangenotification)
+[FindFirstPrinterChangeNotification](../winspool/nf-winspool-findfirstprinterchangenotification.md)
 
-[PartialReplyPrinterChangeNotification](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-partialreplyprinterchangenotification)
+[PartialReplyPrinterChangeNotification](./nf-winsplp-partialreplyprinterchangenotification.md)

--- a/wdk-ddi-src/content/winsplp/nf-winsplp-routerallocbidiresponsecontainer.md
+++ b/wdk-ddi-src/content/winsplp/nf-winsplp-routerallocbidiresponsecontainer.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-**RouterAllocBidiResponseContainer** allocates a [BIDI_RESPONSE_CONTAINER](/windows-hardware/drivers/ddi/winspool/ns-winspool-_bidi_response_container) structure containing a list of bidi responses. The bidi response list is an array of [BIDI_RESPONSE_DATA](/windows-hardware/drivers/ddi/winspool/ns-winspool-_bidi_response_data) structures.
+**RouterAllocBidiResponseContainer** allocates a [BIDI_RESPONSE_CONTAINER](../winspool/ns-winspool-_bidi_response_container.md) structure containing a list of bidi responses. The bidi response list is an array of [BIDI_RESPONSE_DATA](../winspool/ns-winspool-_bidi_response_data.md) structures.
 
 ## -parameters
 
@@ -55,14 +55,14 @@ Specifies the number of BIDI_RESPONSE_DATA structures to be allocated.
 
 ## -remarks
 
-When the memory allocated by this function is no longer needed, use [RouterFreeBidiResponseContainer](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-routerfreebidiresponsecontainer).
+When the memory allocated by this function is no longer needed, use [RouterFreeBidiResponseContainer](./nf-winsplp-routerfreebidiresponsecontainer.md).
 
 ## -see-also
 
-[BIDI_RESPONSE_CONTAINER](/windows-hardware/drivers/ddi/winspool/ns-winspool-_bidi_response_container)
+[BIDI_RESPONSE_CONTAINER](../winspool/ns-winspool-_bidi_response_container.md)
 
-[BIDI_RESPONSE_DATA](/windows-hardware/drivers/ddi/winspool/ns-winspool-_bidi_response_data)
+[BIDI_RESPONSE_DATA](../winspool/ns-winspool-_bidi_response_data.md)
 
-[RouterFreeBidiResponseContainer](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-routerfreebidiresponsecontainer)
+[RouterFreeBidiResponseContainer](./nf-winsplp-routerfreebidiresponsecontainer.md)
 
 [SendRecvBidiDataFromPort](/previous-versions/ff562071(v=vs.85))

--- a/wdk-ddi-src/content/winsplp/nf-winsplp-splissessionzero.md
+++ b/wdk-ddi-src/content/winsplp/nf-winsplp-splissessionzero.md
@@ -63,10 +63,10 @@ On success, the **SplIsSessionZero** function returns ERROR_SUCCESS; otherwise t
 
 ## -remarks
 
-A driver that displays custom user interface elements can use the **SplIsSessionZero** function to determine whether the current job was issued in session 0. Such a driver can use this information to enable it to present user interface elements in the user's session, rather than in session zero. A related function, [SplPromptUIInUsersSession](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-splpromptuiinuserssession), displays a standard Windows message box in the user's session.
+A driver that displays custom user interface elements can use the **SplIsSessionZero** function to determine whether the current job was issued in session 0. Such a driver can use this information to enable it to present user interface elements in the user's session, rather than in session zero. A related function, [SplPromptUIInUsersSession](./nf-winsplp-splpromptuiinuserssession.md), displays a standard Windows message box in the user's session.
 
 If you plan to use this function in a driver intended to run under Windows 2000, you must load spoolss.dll by a call to the **LoadLibrary** function, and then find the address of this function within that DLL by a call to the **GetProcAddress** function. If the call to **GetProcAddress** fails, you must use an alternative mechanism to display user interface elements.
 
 ## -see-also
 
-[SplPromptUIInUsersSession](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-splpromptuiinuserssession)
+[SplPromptUIInUsersSession](./nf-winsplp-splpromptuiinuserssession.md)

--- a/wdk-ddi-src/content/wudfddi/nf-wudfddi-ipnpcallbackhardwareinterrupt-ond0entrypostinterruptsenabled.md
+++ b/wdk-ddi-src/content/wudfddi/nf-wudfddi-ipnpcallbackhardwareinterrupt-ond0entrypostinterruptsenabled.md
@@ -53,11 +53,11 @@ A driver's **OnD0EntryPostInterruptsEnabled** event callback function performs d
 
 ### -param pDevice
 
-A pointer to [IWDFDevice3](/windows-hardware/drivers/ddi/wudfddi/nn-wudfddi-iwdfdevice3) interface.
+A pointer to [IWDFDevice3](./nn-wudfddi-iwdfdevice3.md) interface.
 
 ### -param PreviousState [in]
 
-A [WDF_POWER_DEVICE_STATE](/windows-hardware/drivers/ddi/wdfdevice/ne-wdfdevice-_wdf_power_device_state) enumerator value that identifies the previous device power state.
+A [WDF_POWER_DEVICE_STATE](../wdfdevice/ne-wdfdevice-_wdf_power_device_state.md) enumerator value that identifies the previous device power state.
 
 ## -returns
 
@@ -65,6 +65,6 @@ If successful, **OnD0EntryPostInterruptsEnabled** returns S_OK. Otherwise, it re
 
 ## -see-also
 
-- [IPnpCallbackHardwareInterrupt](/windows-hardware/drivers/ddi/wudfddi/nn-wudfddi-ipnpcallbackhardwareinterrupt)
-- [OnD0ExitPreInterruptsDisabled](/windows-hardware/drivers/ddi/wudfddi/nf-wudfddi-ipnpcallbackhardwareinterrupt-ond0exitpreinterruptsdisabled)
+- [IPnpCallbackHardwareInterrupt](./nn-wudfddi-ipnpcallbackhardwareinterrupt.md)
+- [OnD0ExitPreInterruptsDisabled](./nf-wudfddi-ipnpcallbackhardwareinterrupt-ond0exitpreinterruptsdisabled.md)
 - [Enabling and Disabling Interrupts](/windows-hardware/drivers/wdf/enabling-and-disabling-interrupts)

--- a/wdk-ddi-src/content/wudfddi/nf-wudfddi-ipnpcallbackhardwareinterrupt-ond0exitpreinterruptsdisabled.md
+++ b/wdk-ddi-src/content/wudfddi/nf-wudfddi-ipnpcallbackhardwareinterrupt-ond0exitpreinterruptsdisabled.md
@@ -53,11 +53,11 @@ A driver's **OnD0ExitPreInterruptsDisabled** event callback function performs de
 
 ### -param pDevice
 
-A pointer to an [IWDFDevice3](/windows-hardware/drivers/ddi/wudfddi/nn-wudfddi-iwdfdevice3) interface.
+A pointer to an [IWDFDevice3](./nn-wudfddi-iwdfdevice3.md) interface.
 
 ### -param TargetState [in]
 
-A [WDF_POWER_DEVICE_STATE](/windows-hardware/drivers/ddi/wdfdevice/ne-wdfdevice-_wdf_power_device_state) enumerator value that identifies the target device power state that the device is about to enter.
+A [WDF_POWER_DEVICE_STATE](../wdfdevice/ne-wdfdevice-_wdf_power_device_state.md) enumerator value that identifies the target device power state that the device is about to enter.
 
 ## -returns
 
@@ -66,5 +66,5 @@ If successful, **OnD0ExitPreInterruptsDisabled**, returns S_OK. Otherwise, it re
 ## -see-also
 
 - [Enabling and Disabling Interrupts](/windows-hardware/drivers/wdf/enabling-and-disabling-interrupts)
-- [IPnpCallbackHardwareInterrupt](/windows-hardware/drivers/ddi/wudfddi/nn-wudfddi-ipnpcallbackhardwareinterrupt)
-- [OnD0EntryPostInterruptsEnabled](/windows-hardware/drivers/ddi/wudfddi/nf-wudfddi-ipnpcallbackhardwareinterrupt-ond0entrypostinterruptsenabled)
+- [IPnpCallbackHardwareInterrupt](./nn-wudfddi-ipnpcallbackhardwareinterrupt.md)
+- [OnD0EntryPostInterruptsEnabled](./nf-wudfddi-ipnpcallbackhardwareinterrupt-ond0entrypostinterruptsenabled.md)

--- a/wdk-ddi-src/content/wudfddi_types/ne-wudfddi_types-_wdf_device_hwaccess_target_type.md
+++ b/wdk-ddi-src/content/wudfddi_types/ne-wudfddi_types-_wdf_device_hwaccess_target_type.md
@@ -72,4 +72,4 @@ The **WDF_DEVICE_HWACCESS_TARGET_SIZE** enumeration is used internally by the fr
 
 ## -see-also
 
-[UMDF Structures and Enumeration Types](/windows-hardware/drivers/ddi/wudfddi/)
+[UMDF Structures and Enumeration Types](../wudfddi/index.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 