### PR TITLE
LinkFix: windows-driver-docs-ddi (2022-09) - 2

### DIFF
--- a/wdk-ddi-src/content/irb/nf-irb-ataportsetbusdata.md
+++ b/wdk-ddi-src/content/irb/nf-irb-ataportsetbusdata.md
@@ -84,4 +84,4 @@ ConfigDataOffest[i] =
 
 ## -see-also
 
-[**AtaPortGetBusData**](/windows-hardware/drivers/ddi/irb/nf-irb-ataportgetbusdata)
+[**AtaPortGetBusData**](./nf-irb-ataportgetbusdata.md)

--- a/wdk-ddi-src/content/minitape/ns-minitape-block_device_range_descriptor.md
+++ b/wdk-ddi-src/content/minitape/ns-minitape-block_device_range_descriptor.md
@@ -68,6 +68,6 @@ All multibyte values are in big endian format. Prior to setting, these values mu
 
 ## -see-also
 
-[**POPULATE_TOKEN_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-populate_token_header)
+[**POPULATE_TOKEN_HEADER**](../storport/ns-storport-populate_token_header.md)
 
-[**WRITE_USING_TOKEN_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-write_using_token_header)
+[**WRITE_USING_TOKEN_HEADER**](./ns-minitape-write_using_token_header.md)

--- a/wdk-ddi-src/content/minitape/ns-minitape-block_device_token_descriptor.md
+++ b/wdk-ddi-src/content/minitape/ns-minitape-block_device_token_descriptor.md
@@ -44,7 +44,7 @@ api_name:
 
 ## -description
 
-**BLOCK_DEVICE_TOKEN_DESCRIPTOR** contains the token returned from a the POPULATE TOKEN command for an offload read data operation. The token information is included as part of the [**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-receive_token_information_response_header) structure.
+**BLOCK_DEVICE_TOKEN_DESCRIPTOR** contains the token returned from a the POPULATE TOKEN command for an offload read data operation. The token information is included as part of the [**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](./ns-minitape-receive_token_information_response_header.md) structure.
 
 ## -struct-fields
 
@@ -58,4 +58,4 @@ A data value defining a token as a point-in-time representation of data (ROD) fo
 
 ## -see-also
 
-[**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-receive_token_information_response_header)
+[**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](./ns-minitape-receive_token_information_response_header.md)

--- a/wdk-ddi-src/content/minitape/ns-minitape-populate_token_header.md
+++ b/wdk-ddi-src/content/minitape/ns-minitape-populate_token_header.md
@@ -74,18 +74,18 @@ Reserved.
 
 ### -field BlockDeviceRangeDescriptorListLength
 
-The length, in bytes, for all  of the [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures in the **BlockDeviceRangeDescriptor** array.
+The length, in bytes, for all  of the [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](../scsi/ns-scsi-block_device_range_descriptor.md) structures in the **BlockDeviceRangeDescriptor** array.
 
 ### -field BlockDeviceRangeDescriptor
 
-An array of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures which describe the logical blocks representing the file being read from the LUN.
+An array of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](../scsi/ns-scsi-block_device_range_descriptor.md) structures which describe the logical blocks representing the file being read from the LUN.
 
 ## -remarks
 
-The **POPULATE_TOKEN_HEADER** structure contains a series of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures which describe the token ROD.
+The **POPULATE_TOKEN_HEADER** structure contains a series of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](../scsi/ns-scsi-block_device_range_descriptor.md) structures which describe the token ROD.
 
 All multibyte values are in big endian format. Prior to setting, these values must be converted from the endian format of the current platform.
 
 ## -see-also
 
-[**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor)
+[**BLOCK_DEVICE_RANGE_DESCRIPTOR**](../scsi/ns-scsi-block_device_range_descriptor.md)

--- a/wdk-ddi-src/content/minitape/ns-minitape-pri_registration_list.md
+++ b/wdk-ddi-src/content/minitape/ns-minitape-pri_registration_list.md
@@ -62,8 +62,8 @@ The reservation key list contains the 8-byte reservation keys for all initiators
 
 ## -remarks
 
-The [IOCTL_STORAGE_PERSISTENT_RESERVE_IN](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in) request is used to obtain information about persistent reservations and reservation keys that are active within a device server.
+The [IOCTL_STORAGE_PERSISTENT_RESERVE_IN](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in.md) request is used to obtain information about persistent reservations and reservation keys that are active within a device server.
 
 ## -see-also
 
-[IOCTL_STORAGE_PERSISTENT_RESERVE_IN](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in)
+[IOCTL_STORAGE_PERSISTENT_RESERVE_IN](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in.md)

--- a/wdk-ddi-src/content/minitape/ns-minitape-pro_parameter_list.md
+++ b/wdk-ddi-src/content/minitape/ns-minitape-pro_parameter_list.md
@@ -102,8 +102,8 @@ Reserved. Must be zero.
 
 ## -remarks
 
-The [IOCTL_STORAGE_PERSISTENT_RESERVE_OUT](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_out) request is used to control information about persistent reservations and reservation keys that are active within a device server.
+The [IOCTL_STORAGE_PERSISTENT_RESERVE_OUT](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_out.md) request is used to control information about persistent reservations and reservation keys that are active within a device server.
 
 ## -see-also
 
-[IOCTL_STORAGE_PERSISTENT_RESERVE_OUT](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_out)
+[IOCTL_STORAGE_PERSISTENT_RESERVE_OUT](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_out.md)

--- a/wdk-ddi-src/content/minitape/ns-minitape-receive_token_information_header.md
+++ b/wdk-ddi-src/content/minitape/ns-minitape-receive_token_information_header.md
@@ -136,10 +136,10 @@ Sense data returned for the copy operation.
 
 ## -remarks
 
-If **RECEIVE_TOKEN_INFORMATION_HEADER** is for a POPULATE TOKEN command operation, and the command completed successfully, a [**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-receive_token_information_response_header) structure will also be present after **SenseData** at an offset of **SenseDataFieldLength** from the beginning of the **SenseData** array. The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure will contain the token created as a representation of data (ROD) for the range parameters sent with the command.
+If **RECEIVE_TOKEN_INFORMATION_HEADER** is for a POPULATE TOKEN command operation, and the command completed successfully, a [**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](./ns-minitape-receive_token_information_response_header.md) structure will also be present after **SenseData** at an offset of **SenseDataFieldLength** from the beginning of the **SenseData** array. The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure will contain the token created as a representation of data (ROD) for the range parameters sent with the command.
 
 All multibyte values are in big endian format. Prior to evaluation, these values must be converted to match the endian format of the current platform.
 
 ## -see-also
 
-[**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-receive_token_information_response_header)
+[**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](./ns-minitape-receive_token_information_response_header.md)

--- a/wdk-ddi-src/content/minitape/ns-minitape-receive_token_information_response_header.md
+++ b/wdk-ddi-src/content/minitape/ns-minitape-receive_token_information_response_header.md
@@ -58,12 +58,12 @@ The data containing a token created as the offload read ROD.
 
 ## -remarks
 
-The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure is included with a [**RECEIVE_TOKEN_INFORMATION_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-receive_token_information_header)structure  as a response to a POPULATE TOKEN command. The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure follows the **SenseData** member of **RECEIVE_TOKEN_INFORMATION_HEADER**.
+The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure is included with a [**RECEIVE_TOKEN_INFORMATION_HEADER**](../storport/ns-storport-receive_token_information_header.md)structure  as a response to a POPULATE TOKEN command. The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure follows the **SenseData** member of **RECEIVE_TOKEN_INFORMATION_HEADER**.
 
 All multibyte values are in big endian format. Prior to evaluation, these values must be converted to match the endian format of the current platform.
 
 ## -see-also
 
-[**POPULATE_TOKEN_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-populate_token_header)
+[**POPULATE_TOKEN_HEADER**](../storport/ns-storport-populate_token_header.md)
 
-[**RECEIVE_TOKEN_INFORMATION_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-receive_token_information_header)
+[**RECEIVE_TOKEN_INFORMATION_HEADER**](../storport/ns-storport-receive_token_information_header.md)

--- a/wdk-ddi-src/content/minitape/ns-minitape-write_using_token_header.md
+++ b/wdk-ddi-src/content/minitape/ns-minitape-write_using_token_header.md
@@ -78,11 +78,11 @@ Reserved.
 
 ### -field BlockDeviceRangeDescriptorListLength
 
-The length, in bytes, for all  of the [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures in the **BlockDeviceRangeDescriptor** array.
+The length, in bytes, for all  of the [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](../scsi/ns-scsi-block_device_range_descriptor.md) structures in the **BlockDeviceRangeDescriptor** array.
 
 ### -field BlockDeviceRangeDescriptor
 
-An array of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures which describe the destination data blocks for the offload write data transfer.
+An array of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](../scsi/ns-scsi-block_device_range_descriptor.md) structures which describe the destination data blocks for the offload write data transfer.
 
 ## -remarks
 
@@ -90,6 +90,6 @@ All multibyte values are in big endian format. Prior to setting, these values mu
 
 ## -see-also
 
-[**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor)
+[**BLOCK_DEVICE_RANGE_DESCRIPTOR**](../scsi/ns-scsi-block_device_range_descriptor.md)
 
-[**POPULATE_TOKEN_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-populate_token_header)
+[**POPULATE_TOKEN_HEADER**](../storport/ns-storport-populate_token_header.md)

--- a/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemprintticketprovider-querydevicedefaultnamespace.md
+++ b/wdk-ddi-src/content/prcomoem/nf-prcomoem-iprintoemprintticketprovider-querydevicedefaultnamespace.md
@@ -67,6 +67,6 @@ The plug-in should specify the name of the private namespace URI that the core d
 
 ## -see-also
 
-[IPrintOemPrintTicketProvider](/windows-hardware/drivers/ddi/prcomoem/nn-prcomoem-iprintoemprintticketprovider)
+[IPrintOemPrintTicketProvider](./nn-prcomoem-iprintoemprintticketprovider.md)
 
 [IPrintOemPrintTicketProvider::BindPrinter](./nf-prcomoem-iprintoemprintticketprovider-bindprinter.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-_inquirydata.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-_inquirydata.md
@@ -46,7 +46,7 @@ api_name:
 ---
 ## -description
 
-The **INQUIRYDATA** structure is used in conjunction with the [TapeMiniExtensionInit](/windows-hardware/drivers/ddi/minitape/nc-minitape-tape_extension_init_routine) and [TapeMiniVerifyInquiry](/windows-hardware/drivers/ddi/minitape/nc-minitape-tape_verify_inquiry_routine) routines to report SCSI inquiry data associated with a tape device.
+The **INQUIRYDATA** structure is used in conjunction with the [TapeMiniExtensionInit](../minitape/nc-minitape-tape_extension_init_routine.md) and [TapeMiniVerifyInquiry](../minitape/nc-minitape-tape_verify_inquiry_routine.md) routines to report SCSI inquiry data associated with a tape device.
 
 ## -struct-fields
 
@@ -222,6 +222,6 @@ Indicates, when set to one, that the target supports the SCSI CONTINUE TASK and 
 
 ## -see-also
 
-[TapeMiniExtensionInit](/windows-hardware/drivers/ddi/minitape/nc-minitape-tape_extension_init_routine)
+[TapeMiniExtensionInit](../minitape/nc-minitape-tape_extension_init_routine.md)
 
-[TapeMiniVerifyInquiry](/windows-hardware/drivers/ddi/minitape/nc-minitape-tape_verify_inquiry_routine)
+[TapeMiniVerifyInquiry](../minitape/nc-minitape-tape_verify_inquiry_routine.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-block_device_range_descriptor.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-block_device_range_descriptor.md
@@ -68,6 +68,6 @@ All multibyte values are in big endian format. Prior to setting, these values mu
 
 ## -see-also
 
-[**POPULATE_TOKEN_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-populate_token_header)
+[**POPULATE_TOKEN_HEADER**](../storport/ns-storport-populate_token_header.md)
 
-[**WRITE_USING_TOKEN_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-write_using_token_header)
+[**WRITE_USING_TOKEN_HEADER**](../minitape/ns-minitape-write_using_token_header.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-block_device_token_descriptor.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-block_device_token_descriptor.md
@@ -44,7 +44,7 @@ api_name:
 
 ## -description
 
-**BLOCK_DEVICE_TOKEN_DESCRIPTOR** contains the token returned from a the POPULATE TOKEN command for an offload read data operation. The token information is included as part of the [**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-receive_token_information_response_header) structure.
+**BLOCK_DEVICE_TOKEN_DESCRIPTOR** contains the token returned from a the POPULATE TOKEN command for an offload read data operation. The token information is included as part of the [**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](../minitape/ns-minitape-receive_token_information_response_header.md) structure.
 
 ## -struct-fields
 
@@ -58,4 +58,4 @@ A data value defining a token as a point-in-time representation of data (ROD) fo
 
 ## -see-also
 
-[**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-receive_token_information_response_header)
+[**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](../minitape/ns-minitape-receive_token_information_response_header.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-populate_token_header.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-populate_token_header.md
@@ -74,18 +74,18 @@ Reserved.
 
 ### -field BlockDeviceRangeDescriptorListLength
 
-The length, in bytes, for all  of the [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures in the **BlockDeviceRangeDescriptor** array.
+The length, in bytes, for all  of the [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](./ns-scsi-block_device_range_descriptor.md) structures in the **BlockDeviceRangeDescriptor** array.
 
 ### -field BlockDeviceRangeDescriptor
 
-An array of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures which describe the logical blocks representing the file being read from the LUN.
+An array of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](./ns-scsi-block_device_range_descriptor.md) structures which describe the logical blocks representing the file being read from the LUN.
 
 ## -remarks
 
-The **POPULATE_TOKEN_HEADER** structure contains a series of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures which describe the token ROD.
+The **POPULATE_TOKEN_HEADER** structure contains a series of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](./ns-scsi-block_device_range_descriptor.md) structures which describe the token ROD.
 
 All multibyte values are in big endian format. Prior to setting, these values must be converted from the endian format of the current platform.
 
 ## -see-also
 
-[**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor)
+[**BLOCK_DEVICE_RANGE_DESCRIPTOR**](./ns-scsi-block_device_range_descriptor.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-pri_registration_list.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-pri_registration_list.md
@@ -62,8 +62,8 @@ The reservation key list contains the 8-byte reservation keys for all initiators
 
 ## -remarks
 
-The [**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in) request is used to obtain information about persistent reservations and reservation keys that are active within a device server.
+The [**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in.md) request is used to obtain information about persistent reservations and reservation keys that are active within a device server.
 
 ## -see-also
 
-[**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in)
+[**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-pri_reservation_descriptor.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-pri_reservation_descriptor.md
@@ -44,7 +44,7 @@ api_name:
 
 ## -description
 
-The **PRI_RESERVATION_DESCRIPTOR** structure is used to construct the [**PRI_RESERVATION_LIST**](/windows-hardware/drivers/ddi/minitape/ns-minitape-pri_reservation_list) structure that is returned in response to a Persistent Reserve In command with ServiceAction = RESERVATION_ACTION_READ_RESERVATIONS.
+The **PRI_RESERVATION_DESCRIPTOR** structure is used to construct the [**PRI_RESERVATION_LIST**](../minitape/ns-minitape-pri_reservation_list.md) structure that is returned in response to a Persistent Reserve In command with ServiceAction = RESERVATION_ACTION_READ_RESERVATIONS.
 
 ## -struct-fields
 
@@ -74,10 +74,10 @@ Reserved. Must be zero.
 
 ## -remarks
 
-The [**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in) request is used to obtain information about persistent reservations and reservation keys that are active within a device server.
+The [**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in.md) request is used to obtain information about persistent reservations and reservation keys that are active within a device server.
 
 ## -see-also
 
-[**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in)
+[**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in.md)
 
-[**PRI_RESERVATION_LIST**](/windows-hardware/drivers/ddi/minitape/ns-minitape-pri_reservation_list)
+[**PRI_RESERVATION_LIST**](../minitape/ns-minitape-pri_reservation_list.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-pri_reservation_list.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-pri_reservation_list.md
@@ -62,8 +62,8 @@ An array of reservation descriptors.
 
 ## -remarks
 
-The [**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in) request is used to obtain information about persistent reservations and reservation keys that are active within a device server.
+The [**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in.md) request is used to obtain information about persistent reservations and reservation keys that are active within a device server.
 
 ## -see-also
 
-[**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in)
+[**IOCTL_STORAGE_PERSISTENT_RESERVE_IN**](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_in.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-pro_parameter_list.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-pro_parameter_list.md
@@ -102,8 +102,8 @@ Reserved. Must be zero.
 
 ## -remarks
 
-The [**IOCTL_STORAGE_PERSISTENT_RESERVE_OUT**](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_out) request is used to control information about persistent reservations and reservation keys that are active within a device server.
+The [**IOCTL_STORAGE_PERSISTENT_RESERVE_OUT**](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_out.md) request is used to control information about persistent reservations and reservation keys that are active within a device server.
 
 ## -see-also
 
-[**IOCTL_STORAGE_PERSISTENT_RESERVE_OUT**](/windows-hardware/drivers/ddi/ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_out)
+[**IOCTL_STORAGE_PERSISTENT_RESERVE_OUT**](../ntddstor/ni-ntddstor-ioctl_storage_persistent_reserve_out.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-receive_token_information_header.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-receive_token_information_header.md
@@ -136,10 +136,10 @@ Sense data returned for the copy operation.
 
 ## -remarks
 
-If **RECEIVE_TOKEN_INFORMATION_HEADER** is for a POPULATE TOKEN command operation, and the command completed successfully, a [**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-receive_token_information_response_header) structure will also be present after **SenseData** at an offset of **SenseDataFieldLength** from the beginning of the **SenseData** array. The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure will contain the token created as a representation of data (ROD) for the range parameters sent with the command.
+If **RECEIVE_TOKEN_INFORMATION_HEADER** is for a POPULATE TOKEN command operation, and the command completed successfully, a [**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](../minitape/ns-minitape-receive_token_information_response_header.md) structure will also be present after **SenseData** at an offset of **SenseDataFieldLength** from the beginning of the **SenseData** array. The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure will contain the token created as a representation of data (ROD) for the range parameters sent with the command.
 
 All multibyte values are in big endian format. Prior to evaluation, these values must be converted to match the endian format of the current platform.
 
 ## -see-also
 
-[**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](/windows-hardware/drivers/ddi/minitape/ns-minitape-receive_token_information_response_header)
+[**RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER**](../minitape/ns-minitape-receive_token_information_response_header.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-receive_token_information_response_header.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-receive_token_information_response_header.md
@@ -58,12 +58,12 @@ The data containing a token created as the offload read ROD.
 
 ## -remarks
 
-The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure is included with a [**RECEIVE_TOKEN_INFORMATION_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-receive_token_information_header)structure  as a response to a POPULATE TOKEN command. The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure follows the **SenseData** member of **RECEIVE_TOKEN_INFORMATION_HEADER**.
+The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure is included with a [**RECEIVE_TOKEN_INFORMATION_HEADER**](../storport/ns-storport-receive_token_information_header.md)structure  as a response to a POPULATE TOKEN command. The **RECEIVE_TOKEN_INFORMATION_RESPONSE_HEADER** structure follows the **SenseData** member of **RECEIVE_TOKEN_INFORMATION_HEADER**.
 
 All multibyte values are in big endian format. Prior to evaluation, these values must be converted to match the endian format of the current platform.
 
 ## -see-also
 
-[**POPULATE_TOKEN_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-populate_token_header)
+[**POPULATE_TOKEN_HEADER**](../storport/ns-storport-populate_token_header.md)
 
-[**RECEIVE_TOKEN_INFORMATION_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-receive_token_information_header)
+[**RECEIVE_TOKEN_INFORMATION_HEADER**](../storport/ns-storport-receive_token_information_header.md)

--- a/wdk-ddi-src/content/scsi/ns-scsi-write_using_token_header.md
+++ b/wdk-ddi-src/content/scsi/ns-scsi-write_using_token_header.md
@@ -78,11 +78,11 @@ Reserved.
 
 ### -field BlockDeviceRangeDescriptorListLength
 
-The length, in bytes, for all  of the [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures in the **BlockDeviceRangeDescriptor** array.
+The length, in bytes, for all  of the [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](./ns-scsi-block_device_range_descriptor.md) structures in the **BlockDeviceRangeDescriptor** array.
 
 ### -field BlockDeviceRangeDescriptor
 
-An array of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor) structures which describe the destination data blocks for the offload write data transfer.
+An array of [**BLOCK_DEVICE_RANGE_DESCRIPTOR**](./ns-scsi-block_device_range_descriptor.md) structures which describe the destination data blocks for the offload write data transfer.
 
 ## -remarks
 
@@ -90,6 +90,6 @@ All multibyte values are in big endian format. Prior to setting, these values mu
 
 ## -see-also
 
-[**BLOCK_DEVICE_RANGE_DESCRIPTOR**](/windows-hardware/drivers/ddi/scsi/ns-scsi-block_device_range_descriptor)
+[**BLOCK_DEVICE_RANGE_DESCRIPTOR**](./ns-scsi-block_device_range_descriptor.md)
 
-[**POPULATE_TOKEN_HEADER**](/windows-hardware/drivers/ddi/storport/ns-storport-populate_token_header)
+[**POPULATE_TOKEN_HEADER**](../storport/ns-storport-populate_token_header.md)

--- a/wdk-ddi-src/content/wdm/nf-wdm-exinitializelookasidelistex.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exinitializelookasidelistex.md
@@ -51,15 +51,15 @@ A pointer to the [LOOKASIDE_LIST_EX](/windows-hardware/drivers/kernel/eprocess) 
 
 ### -param Allocate [in, optional]
 
-A pointer to a caller-supplied [LookasideListAllocateEx](/windows-hardware/drivers/ddi/wdm/nc-wdm-allocate_function_ex) routine that allocates a new lookaside-list entry. The [ExAllocateFromLookasideListEx](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatefromlookasidelistex) routine calls this *LookasideListAllocateEx* routine if the lookaside list is empty (contains no entries). This parameter is optional and can be specified as **NULL** if a custom allocation routine is not required. If this parameter is **NULL**, calls to **ExAllocateFromPagedLookasideList** automatically allocate the paged or nonpaged storage (as determined by the *PoolType* parameter) for the new entries.
+A pointer to a caller-supplied [LookasideListAllocateEx](./nc-wdm-allocate_function_ex.md) routine that allocates a new lookaside-list entry. The [ExAllocateFromLookasideListEx](./nf-wdm-exallocatefromlookasidelistex.md) routine calls this *LookasideListAllocateEx* routine if the lookaside list is empty (contains no entries). This parameter is optional and can be specified as **NULL** if a custom allocation routine is not required. If this parameter is **NULL**, calls to **ExAllocateFromPagedLookasideList** automatically allocate the paged or nonpaged storage (as determined by the *PoolType* parameter) for the new entries.
 
 ### -param Free [in, optional]
 
-A pointer to a caller-supplied [LookasideListFreeEx](/windows-hardware/drivers/ddi/wdm/nc-wdm-free_function_ex) routine that frees a previously allocated lookaside-list entry. The [ExFreeToPagedLookasideList](/windows-hardware/drivers/ddi/wdm/nf-wdm-exfreetopagedlookasidelist) routine calls this *LookasideListFreeEx* routine if the lookaside list is full (that is, the list already contains the maximum number of entries, as determined by the operating system). This parameter is optional and can be specified as **NULL** if a custom deallocation routine is not required. If this parameter is **NULL**, calls to **ExFreeToPagedLookasideList** automatically free the storage for the specified entries.
+A pointer to a caller-supplied [LookasideListFreeEx](./nc-wdm-free_function_ex.md) routine that frees a previously allocated lookaside-list entry. The [ExFreeToPagedLookasideList](./nf-wdm-exfreetopagedlookasidelist.md) routine calls this *LookasideListFreeEx* routine if the lookaside list is full (that is, the list already contains the maximum number of entries, as determined by the operating system). This parameter is optional and can be specified as **NULL** if a custom deallocation routine is not required. If this parameter is **NULL**, calls to **ExFreeToPagedLookasideList** automatically free the storage for the specified entries.
 
 ### -param PoolType [in]
 
-Specifies the pool type of the entries in the lookaside list. Set this parameter to a valid [POOL_TYPE](/windows-hardware/drivers/ddi/wdm/ne-wdm-_pool_type) enumeration value.
+Specifies the pool type of the entries in the lookaside list. Set this parameter to a valid [POOL_TYPE](./ne-wdm-_pool_type.md) enumeration value.
 
 ### -param Flags [in]
 
@@ -68,15 +68,15 @@ Specifies an optional flag value to modify the default behavior of the *Lookasid
 | Flag bit | Description |
 |--|--|
 | EX_LOOKASIDE_LIST_EX_FLAGS_RAISE_ON_FAIL | If the allocation fails, raise an exception. |
-| EX_LOOKASIDE_LIST_EX_FLAGS_FAIL_NO_RAISE | If the allocation fails, return **NULL** instead of raising an exception. This flag is intended for use with an allocation routine, such as [ExAllocatePoolWithQuotaTag](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepoolwithquotatag), that charges quotas for pool usage. |
+| EX_LOOKASIDE_LIST_EX_FLAGS_FAIL_NO_RAISE | If the allocation fails, return **NULL** instead of raising an exception. This flag is intended for use with an allocation routine, such as [ExAllocatePoolWithQuotaTag](./nf-wdm-exallocatepoolwithquotatag.md), that charges quotas for pool usage. |
 
 These two flag bits are mutually exclusive.
 
 If *Allocate* is **NULL**, set *Flags* to either zero or EX_LOOKASIDE_LIST_EX_FLAGS_RAISE_ON_FAIL, but not to EX_LOOKASIDE_LIST_EX_FLAGS_FAIL_NO_RAISE. Otherwise, the behavior of the default allocation routine is undefined.
 
-If *Flags* = EX_LOOKASIDE_LIST_EX_FLAGS_RAISE_ON_FAIL, the *PoolType* parameter value is bitwise ORed with the POOL_RAISE_IF_ALLOCATION_FAILURE flag bit to form the *PoolType* parameter value that is passed to the *LookasideListAllocateEx* routine. The *LookasideListAllocateEx* routine can pass this *PoolType* value, without modification, to the **ExAllocatePoolWithTag** routine. For more information about the POOL_RAISE_IF_ALLOCATION_FAILURE flag, see [ExAllocatePoolWithTag](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepoolwithtag).
+If *Flags* = EX_LOOKASIDE_LIST_EX_FLAGS_RAISE_ON_FAIL, the *PoolType* parameter value is bitwise ORed with the POOL_RAISE_IF_ALLOCATION_FAILURE flag bit to form the *PoolType* parameter value that is passed to the *LookasideListAllocateEx* routine. The *LookasideListAllocateEx* routine can pass this *PoolType* value, without modification, to the **ExAllocatePoolWithTag** routine. For more information about the POOL_RAISE_IF_ALLOCATION_FAILURE flag, see [ExAllocatePoolWithTag](./nf-wdm-exallocatepoolwithtag.md).
 
-If *Flags* = EX_LOOKASIDE_LIST_EX_FLAGS_FAIL_NO_RAISE, the *PoolType* parameter value is bitwise ORed with the POOL_QUOTA_FAIL_INSTEAD_OF_RAISE flag bit to form the *PoolType* parameter value that is passed to the *LookasideListAllocateEx* routine. The *LookasideListAllocateEx* routine can pass this *PoolType* value, without modification, to the **ExAllocatePoolWithQuotaTag** routine. For more information about the POOL_QUOTA_FAIL_INSTEAD_OF_RAISE flag, see [ExAllocatePoolWithQuotaTag](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepoolwithquotatag).
+If *Flags* = EX_LOOKASIDE_LIST_EX_FLAGS_FAIL_NO_RAISE, the *PoolType* parameter value is bitwise ORed with the POOL_QUOTA_FAIL_INSTEAD_OF_RAISE flag bit to form the *PoolType* parameter value that is passed to the *LookasideListAllocateEx* routine. The *LookasideListAllocateEx* routine can pass this *PoolType* value, without modification, to the **ExAllocatePoolWithQuotaTag** routine. For more information about the POOL_QUOTA_FAIL_INSTEAD_OF_RAISE flag, see [ExAllocatePoolWithQuotaTag](./nf-wdm-exallocatepoolwithquotatag.md).
 
 ### -param Size [in]
 
@@ -103,13 +103,13 @@ Reserved. Always set this parameter to zero.
 
 A driver must call this routine to initialize a lookaside list before the driver can begin to use the list. A lookaside list is a pool of fixed-size buffers that the driver can manage locally to reduce the number of calls to system allocation routines and, thereby, to improve performance. The buffers are stored as entries in the lookaside list. All entries in the list are of the same, uniform size, which is specified by the *Size* parameter.
 
-After **ExInitializeLookasideListEx** returns, the lookaside list is initialized but contains no entries. When a client calls the [ExAllocateFromLookasideListEx](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatefromlookasidelistex) routine to request an entry, this routine determines that the lookaside list is empty and calls the driver-supplied [LookasideListAllocateEx](/windows-hardware/drivers/ddi/wdm/nc-wdm-allocate_function_ex) routine to dynamically allocate storage for a new entry. Additional entries might be allocated in response to similar requests from clients. Later, when clients call the [ExFreeToLookasideListEx](/windows-hardware/drivers/ddi/wdm/nf-wdm-exfreetolookasidelistex) to release these entries, this routine inserts the entries into the lookaside list. If the number of entries in the list reaches a limit that is determined by the operating system, **ExFreeToLookasideListEx** ceases to add further entries to the list and instead passes these entries to the driver-supplied [LookasideListFreeEx](/windows-hardware/drivers/ddi/wdm/nc-wdm-free_function_ex) routine to be freed.
+After **ExInitializeLookasideListEx** returns, the lookaside list is initialized but contains no entries. When a client calls the [ExAllocateFromLookasideListEx](./nf-wdm-exallocatefromlookasidelistex.md) routine to request an entry, this routine determines that the lookaside list is empty and calls the driver-supplied [LookasideListAllocateEx](./nc-wdm-allocate_function_ex.md) routine to dynamically allocate storage for a new entry. Additional entries might be allocated in response to similar requests from clients. Later, when clients call the [ExFreeToLookasideListEx](./nf-wdm-exfreetolookasidelistex.md) to release these entries, this routine inserts the entries into the lookaside list. If the number of entries in the list reaches a limit that is determined by the operating system, **ExFreeToLookasideListEx** ceases to add further entries to the list and instead passes these entries to the driver-supplied [LookasideListFreeEx](./nc-wdm-free_function_ex.md) routine to be freed.
 
 If the driver does not supply *LookasideListAllocateEx* and *LookasideListFreeEx* routines, the **ExAllocateFromLookasideListEx** and **ExFreeToLookasideListEx** routines use default allocation and deallocation routines instead.
 
-There is no benefit to providing *LookasideListAllocateEx* and *LookasideListFreeEx* routines that do nothing but call [ExAllocatePoolWithTag](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepoolwithtag) and [ExFreePool](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-exfreepool). The same effect can be achieved with better performance by simply setting the *Allocate* and *Free* parameters to **NULL**.
+There is no benefit to providing *LookasideListAllocateEx* and *LookasideListFreeEx* routines that do nothing but call [ExAllocatePoolWithTag](./nf-wdm-exallocatepoolwithtag.md) and [ExFreePool](../ntddk/nf-ntddk-exfreepool.md). The same effect can be achieved with better performance by simply setting the *Allocate* and *Free* parameters to **NULL**.
 
-Before a driver unloads, it must explicitly free any lookaside lists it created. Failure to do so is a serious programming error. Call the [ExDeleteLookasideListEx](/windows-hardware/drivers/ddi/wdm/nf-wdm-exdeletelookasidelistex) routine to free a lookaside list. This routine frees the storage for any remaining entries in the specified lookaside list and then removes the list from the system-wide set of active lookaside lists.
+Before a driver unloads, it must explicitly free any lookaside lists it created. Failure to do so is a serious programming error. Call the [ExDeleteLookasideListEx](./nf-wdm-exdeletelookasidelistex.md) routine to free a lookaside list. This routine frees the storage for any remaining entries in the specified lookaside list and then removes the list from the system-wide set of active lookaside lists.
 
 The operating system keeps track of all lookaside lists that are currently in use. As both the amount of available nonpaged memory and the demand for lookaside list entries vary over time, the operating system dynamically adjusts its limits for the maximum number of entries in each nonpaged lookaside list.
 
@@ -192,9 +192,9 @@ The [**CONTAINING_RECORD**](/windows/win32/api/ntdef/nf-ntdef-containing_record)
 
 After the **MyLookasideListAllocateEx** routine in this example returns, **ExAllocateFromLookasideListEx** inserts the buffer pointed to by the **NewEntry** variable into the lookaside list. To make this insertion operation thread-safe, **ExAllocateFromLookasideListEx** synchronizes its access of the lookaside list with other list insertion and removal operations that might be performed by other threads. Similarly, when **ExFreeFromLookasideListEx** removes a buffer from the lookaside list, it synchronizes its access to the list.
 
-**ExAllocateFromLookasideListEx** and **ExFreeFromLookasideListEx** do not synchronize their calls to driver-supplied [LookasideListAllocateEx](/windows-hardware/drivers/ddi/wdm/nc-wdm-allocate_function_ex) and [LookasideListFreeEx](/windows-hardware/drivers/ddi/wdm/nc-wdm-free_function_ex) routines. Thus, if the **MyLookasideListAllocateEx** and **MyLookasideListFreeEx** routines in the preceding code examples must be thread-safe, the driver must provide the necessary synchronization.
+**ExAllocateFromLookasideListEx** and **ExFreeFromLookasideListEx** do not synchronize their calls to driver-supplied [LookasideListAllocateEx](./nc-wdm-allocate_function_ex.md) and [LookasideListFreeEx](./nc-wdm-free_function_ex.md) routines. Thus, if the **MyLookasideListAllocateEx** and **MyLookasideListFreeEx** routines in the preceding code examples must be thread-safe, the driver must provide the necessary synchronization.
 
-The example routine, **MyLookasideListAllocateEx**, synchronizes its access of the **MyContext->NumberOfAllocations** variable with other threads that might increment and decrement this variable. To provide this synchronization, **MyLookasideListAllocateEx** calls the [InterlockedIncrement](/windows-hardware/drivers/ddi/wdm/nf-wdm-interlockedincrement) routine to atomically increment this variable. Similarly, the **MyLookasideListFreeEx** routine (not shown) can call the [InterlockedDecrement](/windows-hardware/drivers/ddi/wdm/nf-wdm-interlockeddecrement) routine to atomically decrement this variable.
+The example routine, **MyLookasideListAllocateEx**, synchronizes its access of the **MyContext->NumberOfAllocations** variable with other threads that might increment and decrement this variable. To provide this synchronization, **MyLookasideListAllocateEx** calls the [InterlockedIncrement](./nf-wdm-interlockedincrement.md) routine to atomically increment this variable. Similarly, the **MyLookasideListFreeEx** routine (not shown) can call the [InterlockedDecrement](./nf-wdm-interlockeddecrement.md) routine to atomically decrement this variable.
 
 However, if the sole purpose of the **MyContext->NumberOfAllocations** variable in the preceding code example is simply to gather statistics on lookaside list allocations, atomic increments and decrements are hardly necessary. In this case, the remote possibility of a missed increment or decrement should not be a concern.
 
@@ -202,30 +202,30 @@ For more information about thread safety for lookaside lists, see [Using Lookasi
 
 ## -see-also
 
-[ExAllocateFromLookasideListEx](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatefromlookasidelistex)
+[ExAllocateFromLookasideListEx](./nf-wdm-exallocatefromlookasidelistex.md)
 
-[ExAllocatePoolWithQuotaTag](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepoolwithquotatag)
+[ExAllocatePoolWithQuotaTag](./nf-wdm-exallocatepoolwithquotatag.md)
 
-[ExAllocatePoolWithTag](/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepoolwithtag)
+[ExAllocatePoolWithTag](./nf-wdm-exallocatepoolwithtag.md)
 
-[ExDeleteLookasideListEx](/windows-hardware/drivers/ddi/wdm/nf-wdm-exdeletelookasidelistex)
+[ExDeleteLookasideListEx](./nf-wdm-exdeletelookasidelistex.md)
 
-[ExFreePool](/windows-hardware/drivers/ddi/ntddk/nf-ntddk-exfreepool)
+[ExFreePool](../ntddk/nf-ntddk-exfreepool.md)
 
-[ExFreeToLookasideListEx](/windows-hardware/drivers/ddi/wdm/nf-wdm-exfreetolookasidelistex)
+[ExFreeToLookasideListEx](./nf-wdm-exfreetolookasidelistex.md)
 
-[InterlockedDecrement](/windows-hardware/drivers/ddi/wdm/nf-wdm-interlockeddecrement)
+[InterlockedDecrement](./nf-wdm-interlockeddecrement.md)
 
-[InterlockedIncrement](/windows-hardware/drivers/ddi/wdm/nf-wdm-interlockedincrement)
+[InterlockedIncrement](./nf-wdm-interlockedincrement.md)
 
 [LOOKASIDE_LIST_EX](/windows-hardware/drivers/kernel/eprocess)
 
-[LookasideListAllocateEx](/windows-hardware/drivers/ddi/wdm/nc-wdm-allocate_function_ex)
+[LookasideListAllocateEx](./nc-wdm-allocate_function_ex.md)
 
-[LookasideListFreeEx](/windows-hardware/drivers/ddi/wdm/nc-wdm-free_function_ex)
+[LookasideListFreeEx](./nc-wdm-free_function_ex.md)
 
 [NPAGED_LOOKASIDE_LIST](/windows-hardware/drivers/kernel/eprocess)
 
 [PAGED_LOOKASIDE_LIST](/windows-hardware/drivers/kernel/eprocess)
 
-[POOL_TYPE](/windows-hardware/drivers/ddi/wdm/ne-wdm-_pool_type)
+[POOL_TYPE](./ne-wdm-_pool_type.md)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 