### PR TITLE
US 1974660: Previous versions cleanup - part 23

### DIFF
--- a/wdk-ddi-src/content/vpci/nc-vpci-vpci_read_block.md
+++ b/wdk-ddi-src/content/vpci/nc-vpci-vpci_read_block.md
@@ -1,0 +1,94 @@
+---
+UID: NC:vpci.VPCI_READ_BLOCK
+tech.root: pci
+title: VPCI_READ_BLOCK
+ms.date: 09/29/2022
+targetos: Windows
+description: Learn more about the VPCI_READ_BLOCK routine
+prerelease: false
+req.assembly: 
+req.construct-type: function
+req.ddi-compliance: 
+req.dll: 
+req.header: vpci.h
+req.idl: 
+req.include-header: 
+req.irql: APC_LEVEL
+req.kmdf-ver: 
+req.lib: 
+req.max-support: 
+req.namespace: 
+req.redist: 
+req.target-min-winverclnt: 
+req.target-min-winversvr: Windows Server 2012
+req.target-type: 
+req.type-library: 
+req.umdf-ver: 
+req.unicode-ansi: 
+topic_type:
+ - apiref
+api_type:
+ - UserDefined
+api_location:
+ - vpci.h
+api_name:
+ - VPCI_READ_BLOCK
+f1_keywords:
+ - VPCI_READ_BLOCK
+ - vpci/VPCI_READ_BLOCK
+dev_langs:
+ - c++
+helpviewer_keywords:
+ - VPCI_READ_BLOCK
+---
+
+## -description
+
+The *ReadVfConfigBlock* routine reads a block of configuration data for a PCI Express (PCIe) virtual function (VF). This routine is called by the driver of a PCIe VF on a device that supports the single root I/O virtualization (SR-IOV) interface.
+
+## -parameters
+
+### -param Context
+
+A pointer to interface-specific context information. The caller passes the value that is passed as the **Context** member of the [**VPCI\_INTERFACE\_STANDARD**](/windows-hardware/drivers/ddi/vpci/ns-vpci-vpci_interface_standard) structure for the interface.
+
+### -param BlockId
+
+The identifier of the VF configuration block to be read. This identifier is proprietary to the independent hardware vendor (IHV) and is used only by the drivers for the PCIe physical function (PF) and VF on the device.
+
+### -param Buffer
+
+A pointer to a caller-allocated buffer that will contain the configuration data to be read. For more information, see Remarks.
+
+### -param Length
+
+The number of bytes to be read from the VF configuration block.
+
+> [!NOTE]
+> The value of this parameter must not exceed **VPCI\_MAX\_READ\_WRITE\_BLOCK\_SIZE**.
+
+## -returns
+
+The *ReadVfConfigBlock* routine returns **STATUS\_SUCCESS** if the operation succeeds. Otherwise, the routine returns an appropriate NTSTATUS value.
+
+## -remarks
+
+When the *ReadVfConfigBlock* routine is called, the driver of the PF is notified to return data from a specified VF configuration block.
+
+A VF configuration block is used for backchannel communication between the drivers of the PF and a VF on a device that supports the SR-IOV interface. The IHV can define one or more VF configuration blocks for the device. Each VF configuration block has an IHV-defined format, length, and block ID.
+
+VF configuration data can be exchanged between the following drivers in a protected manner:
+
+- The VF driver, which runs in the guest operating system. This operating system runs within a Hyper-V child partition.
+- The PF driver, which runs in the management operating system. This operating system runs within the Hyper-V parent partition.
+
+Data from each VF configuration block is used only by the drivers of the PF and VF.
+
+> [!NOTE]
+> The [**IOCTL\_VPCI\_READ\_BLOCK**](/windows-hardware/drivers/ddi/vpci/ni-vpci-ioctl_vpci_read_block) IOCTL offers an asynchronous alternative to the *ReadVfConfigBlock* routine.
+
+## -see-also
+
+[**IOCTL\_VPCI\_READ\_BLOCK**](/windows-hardware/drivers/ddi/vpci/ni-vpci-ioctl_vpci_read_block)
+
+[**VPCI\_INTERFACE\_STANDARD**](/windows-hardware/drivers/ddi/vpci/ns-vpci-vpci_interface_standard)

--- a/wdk-ddi-src/content/vpci/nc-vpci-vpci_read_block.md
+++ b/wdk-ddi-src/content/vpci/nc-vpci-vpci_read_block.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: vpci.h
 req.idl: 
 req.include-header: 
-req.irql: APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 
@@ -50,19 +50,19 @@ The *ReadVfConfigBlock* routine reads a block of configuration data for a PCI Ex
 
 ### -param Context
 
-A pointer to interface-specific context information. The caller passes the value that is passed as the **Context** member of the [**VPCI\_INTERFACE\_STANDARD**](/windows-hardware/drivers/ddi/vpci/ns-vpci-vpci_interface_standard) structure for the interface.
+[in] A pointer to interface-specific context information. The caller passes the value that is passed as the **Context** member of the [**VPCI\_INTERFACE\_STANDARD**](ns-vpci-vpci_interface_standard.md) structure for the interface.
 
 ### -param BlockId
 
-The identifier of the VF configuration block to be read. This identifier is proprietary to the independent hardware vendor (IHV) and is used only by the drivers for the PCIe physical function (PF) and VF on the device.
+[in] The identifier of the VF configuration block to be read. This identifier is proprietary to the independent hardware vendor (IHV) and is used only by the drivers for the PCIe physical function (PF) and VF on the device.
 
 ### -param Buffer
 
-A pointer to a caller-allocated buffer that will contain the configuration data to be read. For more information, see Remarks.
+[out] A pointer to a caller-allocated buffer that will contain the configuration data to be read. For more information, see Remarks.
 
 ### -param Length
 
-The number of bytes to be read from the VF configuration block.
+[in] The number of bytes to be read from the VF configuration block.
 
 > [!NOTE]
 > The value of this parameter must not exceed **VPCI\_MAX\_READ\_WRITE\_BLOCK\_SIZE**.
@@ -85,10 +85,10 @@ VF configuration data can be exchanged between the following drivers in a protec
 Data from each VF configuration block is used only by the drivers of the PF and VF.
 
 > [!NOTE]
-> The [**IOCTL\_VPCI\_READ\_BLOCK**](/windows-hardware/drivers/ddi/vpci/ni-vpci-ioctl_vpci_read_block) IOCTL offers an asynchronous alternative to the *ReadVfConfigBlock* routine.
+> The [**IOCTL\_VPCI\_READ\_BLOCK**](ni-vpci-ioctl_vpci_read_block.md) IOCTL offers an asynchronous alternative to the *ReadVfConfigBlock* routine.
 
 ## -see-also
 
-[**IOCTL\_VPCI\_READ\_BLOCK**](/windows-hardware/drivers/ddi/vpci/ni-vpci-ioctl_vpci_read_block)
+[**IOCTL\_VPCI\_READ\_BLOCK**](ni-vpci-ioctl_vpci_read_block.md)
 
-[**VPCI\_INTERFACE\_STANDARD**](/windows-hardware/drivers/ddi/vpci/ns-vpci-vpci_interface_standard)
+[**VPCI\_INTERFACE\_STANDARD**](ns-vpci-vpci_interface_standard.md)

--- a/wdk-ddi-src/content/vpci/nc-vpci-vpci_write_block.md
+++ b/wdk-ddi-src/content/vpci/nc-vpci-vpci_write_block.md
@@ -1,0 +1,94 @@
+---
+UID: NC:vpci.VPCI_WRITE_BLOCK
+tech.root: pci
+title: VPCI_WRITE_BLOCK
+ms.date: 09/29/2022
+targetos: Windows
+description: Learn more about the VPCI_WRITE_BLOCK routine
+prerelease: false
+req.assembly: 
+req.construct-type: function
+req.ddi-compliance: 
+req.dll: 
+req.header: vpci.h
+req.idl: 
+req.include-header: 
+req.irql: DISPATCH_LEVEL
+req.kmdf-ver: 
+req.lib: 
+req.max-support: 
+req.namespace: 
+req.redist: 
+req.target-min-winverclnt: 
+req.target-min-winversvr: Windows Server 2012
+req.target-type: 
+req.type-library: 
+req.umdf-ver: 
+req.unicode-ansi: 
+topic_type:
+ - apiref
+api_type:
+ - UserDefined
+api_location:
+ - vpci.h
+api_name:
+ - VPCI_WRITE_BLOCK
+f1_keywords:
+ - VPCI_WRITE_BLOCK
+ - vpci/VPCI_WRITE_BLOCK
+dev_langs:
+ - c++
+helpviewer_keywords:
+ - VPCI_WRITE_BLOCK
+---
+
+## -description
+
+The *WriteVfConfigBlock* routine writes a block of configuration data for a PCI Express virtual function (VF). This routine is called by the driver of a PCIe VF on a device that supports the single root I/O virtualization (SR-IOV) interface.
+
+## -parameters
+
+### -param Context \[in\]
+
+A pointer to interface-specific context information. The caller passes the value that is passed as the **Context** member of the [**VPCI\_INTERFACE\_STANDARD**](/windows-hardware/drivers/ddi/vpci/ns-vpci-vpci_interface_standard) structure for the interface.
+
+### -param BlockId \[in\]
+
+The identifier of the VF configuration block to be written. This identifier is proprietary to the independent hardware vendor (IHV) and is used only by the drivers for the PCIe physical function (PF) and VF on the device.
+
+### -param Buffer \[in\]
+
+A pointer to a caller-allocated buffer that contains the configuration data to be written. For more information, see Remarks.
+
+### -param Length \[in\]
+
+The number of bytes to be written to the VF configuration block.
+
+> [!NOTE]
+> The value of this parameter must not exceed **VPCI\_MAX\_READ\_WRITE\_BLOCK\_SIZE**.
+
+## -returns
+
+The *ReadVfConfigBlock* routine returns **STATUS\_SUCCESS** if the operation succeeds. Otherwise, the routine returns an appropriate NTSTATUS value.
+
+## -remarks
+
+When the *WriteVfConfigBlock* routine is called, the driver of the PF is notified to update a specified VF configuration block with the specified data.
+
+A VF configuration block is used for backchannel communication between the drivers of the PCIe PF and a VF on a device that supports the SR-IOV interface. The IHV can define one or more VF configuration blocks for the device. Each VF configuration block has an IHV-defined format, length, and block ID.
+
+VF configuration data can be exchanged between the following drivers in a protected manner:
+
+- The VF driver, which runs in the guest operating system. This operating system runs within a Hyper-V child partition.
+- The PF driver, which runs in the management operating system. This operating system runs within the Hyper-V parent partition.
+
+Data from each VF configuration block is used only by the drivers of the PF and VF.
+
+> [!NOTE]
+> The [**IOCTL\_VPCI\_WRITE\_BLOCK**](/windows-hardware/drivers/ddi/vpci/ni-vpci-ioctl_vpci_write_block) IOCTL offers an asynchronous alternative to the *WriteVfConfigBlock* routine.
+
+## -see-also
+
+[**IOCTL\_VPCI\_WRITE\_BLOCK**](/windows-hardware/drivers/ddi/vpci/ni-vpci-ioctl_vpci_write_block)
+
+[**VPCI\_INTERFACE\_STANDARD**](/windows-hardware/drivers/ddi/vpci/ns-vpci-vpci_interface_standard)

--- a/wdk-ddi-src/content/vpci/nc-vpci-vpci_write_block.md
+++ b/wdk-ddi-src/content/vpci/nc-vpci-vpci_write_block.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: vpci.h
 req.idl: 
 req.include-header: 
-req.irql: DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 
@@ -48,21 +48,21 @@ The *WriteVfConfigBlock* routine writes a block of configuration data for a PCI 
 
 ## -parameters
 
-### -param Context \[in\]
+### -param Context
 
-A pointer to interface-specific context information. The caller passes the value that is passed as the **Context** member of the [**VPCI\_INTERFACE\_STANDARD**](/windows-hardware/drivers/ddi/vpci/ns-vpci-vpci_interface_standard) structure for the interface.
+[in] A pointer to interface-specific context information. The caller passes the value that is passed as the **Context** member of the [**VPCI\_INTERFACE\_STANDARD**](ns-vpci-vpci_interface_standard.md) structure for the interface.
 
-### -param BlockId \[in\]
+### -param BlockId
 
-The identifier of the VF configuration block to be written. This identifier is proprietary to the independent hardware vendor (IHV) and is used only by the drivers for the PCIe physical function (PF) and VF on the device.
+[in] The identifier of the VF configuration block to be written. This identifier is proprietary to the independent hardware vendor (IHV) and is used only by the drivers for the PCIe physical function (PF) and VF on the device.
 
-### -param Buffer \[in\]
+### -param Buffer
 
-A pointer to a caller-allocated buffer that contains the configuration data to be written. For more information, see Remarks.
+[in] A pointer to a caller-allocated buffer that contains the configuration data to be written. For more information, see Remarks.
 
-### -param Length \[in\]
+### -param Length
 
-The number of bytes to be written to the VF configuration block.
+[in] The number of bytes to be written to the VF configuration block.
 
 > [!NOTE]
 > The value of this parameter must not exceed **VPCI\_MAX\_READ\_WRITE\_BLOCK\_SIZE**.
@@ -85,10 +85,10 @@ VF configuration data can be exchanged between the following drivers in a protec
 Data from each VF configuration block is used only by the drivers of the PF and VF.
 
 > [!NOTE]
-> The [**IOCTL\_VPCI\_WRITE\_BLOCK**](/windows-hardware/drivers/ddi/vpci/ni-vpci-ioctl_vpci_write_block) IOCTL offers an asynchronous alternative to the *WriteVfConfigBlock* routine.
+> The [**IOCTL\_VPCI\_WRITE\_BLOCK**](ni-vpci-ioctl_vpci_write_block.md) IOCTL offers an asynchronous alternative to the *WriteVfConfigBlock* routine.
 
 ## -see-also
 
-[**IOCTL\_VPCI\_WRITE\_BLOCK**](/windows-hardware/drivers/ddi/vpci/ni-vpci-ioctl_vpci_write_block)
+[**IOCTL\_VPCI\_WRITE\_BLOCK**](ni-vpci-ioctl_vpci_write_block.md)
 
-[**VPCI\_INTERFACE\_STANDARD**](/windows-hardware/drivers/ddi/vpci/ns-vpci-vpci_interface_standard)
+[**VPCI\_INTERFACE\_STANDARD**](ns-vpci-vpci_interface_standard.md)

--- a/wdk-ddi-src/content/vpci/ns-vpci-vpci_interface_standard.md
+++ b/wdk-ddi-src/content/vpci/ns-vpci-vpci_interface_standard.md
@@ -2,7 +2,7 @@
 UID: NS:vpci._VPCI_INTERFACE_STANDARD
 tech.root: pci
 title: VPCI_INTERFACE_STANDARD
-ms.date: 09/27/2022
+ms.date: 09/29/2022
 targetos: Windows
 description: Learn more about the VPCI_INTERFACE_STANDARD structure
 prerelease: false
@@ -69,19 +69,19 @@ A pointer to interface-specific context information.
 
 ### -field InterfaceReference
 
-A pointer to an [*InterfaceReference*](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface) routine that increments the interface's reference count.
+A pointer to an [*InterfaceReference*](../wdm/ns-wdm-_interface.md) routine that increments the interface's reference count.
 
 ### -field InterfaceDereference
 
-A pointer to an [*InterfaceDereference*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pinterface_dereference) routine that decrements the interface's reference count.
+A pointer to an [*InterfaceDereference*](../wdm/nc-wdm-pinterface_dereference.md) routine that decrements the interface's reference count.
 
 ### -field WriteVfConfigBlock
 
-A pointer to a [*WriteVfConfigBlock*](/windows-hardware/drivers/ddi/vpci/nc-vpci-vpci_write_block) routine that writes a block of configuration data for a PCIe VF.
+A pointer to a [*WriteVfConfigBlock*](nc-vpci-vpci_write_block.md) routine that writes a block of configuration data for a PCIe VF.
 
 ### -field ReadVfConfigBlock
 
-A pointer to a [*ReadVfConfigBlock*](/windows-hardware/drivers/ddi/vpci/nc-vpci-vpci_read_block) routine that reads a block of configuration data for a PCIe VF.
+A pointer to a [*ReadVfConfigBlock*](nc-vpci-vpci_read_block.md) routine that reads a block of configuration data for a PCIe VF.
 
 ### -field SerialNumber
 
@@ -95,12 +95,12 @@ A driver obtains a pointer to the **VPCI\_INTERFACE\_STANDARD** structure by sen
 
 ## -see-also
 
-[*InterfaceDereference*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pinterface_dereference)
+[*InterfaceDereference*](../wdm/nc-wdm-pinterface_dereference.md)
 
-[*InterfaceReference*](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface)
+[*InterfaceReference*](../wdm/ns-wdm-_interface.md)
 
 [**IRP\_MN\_QUERY\_INTERFACE**](/windows-hardware/drivers/kernel/irp-mn-query-interface)
 
-[*ReadVfConfigBlock*](/windows-hardware/drivers/ddi/vpci/nc-vpci-vpci_read_block)
+[*ReadVfConfigBlock*](nc-vpci-vpci_read_block.md)
 
-[*WriteVfConfigBlock*](/windows-hardware/drivers/ddi/vpci/nc-vpci-vpci_write_block)
+[*WriteVfConfigBlock*](nc-vpci-vpci_write_block.md)

--- a/wdk-ddi-src/content/vpci/ns-vpci-vpci_interface_standard.md
+++ b/wdk-ddi-src/content/vpci/ns-vpci-vpci_interface_standard.md
@@ -1,0 +1,106 @@
+---
+UID: NS:vpci._VPCI_INTERFACE_STANDARD
+tech.root: pci
+title: VPCI_INTERFACE_STANDARD
+ms.date: 09/27/2022
+targetos: Windows
+description: Learn more about the VPCI_INTERFACE_STANDARD structure
+prerelease: false
+req.construct-type: structure
+req.ddi-compliance: 
+req.dll: 
+req.header: vpci.h
+req.include-header: 
+req.kmdf-ver: 
+req.lib: 
+req.max-support: 
+req.redist: 
+req.target-min-winverclnt: 
+req.target-min-winversvr: Windows Server 2012
+req.target-type: 
+req.typenames: VPCI_INTERFACE_STANDARD, *PVPCI_INTERFACE_STANDARD
+req.umdf-ver: 
+req.unicode-ansi: 
+topic_type:
+ - apiref
+api_type:
+ - HeaderDef
+api_location:
+ - vpci.h
+api_name:
+ - _VPCI_INTERFACE_STANDARD
+ - PVPCI_INTERFACE_STANDARD
+ - VPCI_INTERFACE_STANDARD
+f1_keywords:
+ - _VPCI_INTERFACE_STANDARD
+ - vpci/_VPCI_INTERFACE_STANDARD
+ - PVPCI_INTERFACE_STANDARD
+ - vpci/PVPCI_INTERFACE_STANDARD
+ - VPCI_INTERFACE_STANDARD
+ - vpci/VPCI_INTERFACE_STANDARD
+dev_langs:
+ - c++
+helpviewer_keywords:
+ - _VPCI_INTERFACE_STANDARD
+---
+
+## -description
+
+The **VPCI\_INTERFACE\_STANDARD** interface structure enables device drivers to access blocks of configuration data that is specific to a PCI Express (PCIe) virtual function (VF) of devices that support the single root I/O virtualization (SR-IOV) interface.
+
+This structure describes the **GUID\_VPCI\_INTERFACE\_STANDARD** interface.
+
+> [!NOTE]
+> The location of the VF configuration block and the format of the configuration data are defined by the independent hardware vendor (IHV) of the device. They are used only by the drivers of the PCIe physical function (PF) and the VF.
+
+## -struct-fields
+
+### -field Size
+
+The size, in bytes, of this structure.
+
+### -field Version
+
+The driver-defined interface version.
+
+### -field Context
+
+A pointer to interface-specific context information.
+
+### -field InterfaceReference
+
+A pointer to an [*InterfaceReference*](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface) routine that increments the interface's reference count.
+
+### -field InterfaceDereference
+
+A pointer to an [*InterfaceDereference*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pinterface_dereference) routine that decrements the interface's reference count.
+
+### -field WriteVfConfigBlock
+
+A pointer to a [*WriteVfConfigBlock*](/windows-hardware/drivers/ddi/vpci/nc-vpci-vpci_write_block) routine that writes a block of configuration data for a PCIe VF.
+
+### -field ReadVfConfigBlock
+
+A pointer to a [*ReadVfConfigBlock*](/windows-hardware/drivers/ddi/vpci/nc-vpci-vpci_read_block) routine that reads a block of configuration data for a PCIe VF.
+
+### -field SerialNumber
+
+A UINT32 value that contains the serial number for the PCIe VF on the device. The virtualization stack generates a unique serial number for each VF that is exposed on the device.
+
+## -remarks
+
+The **GUID\_VPCI\_INTERFACE\_STANDARD** interface is provided by the virtual PCI (VPCI) bus driver that creates the physical device objects (PDOs) that are layered below the loaded drivers for the VFs. These drivers are loaded in the guest operating system that runs in a Hyper-V child partition.
+
+A driver obtains a pointer to the **VPCI\_INTERFACE\_STANDARD** structure by sending an [**IRP\_MN\_QUERY\_INTERFACE**](/windows-hardware/drivers/kernel/irp-mn-query-interface) IRP to its bus driver with **InterfaceType** set to GUID\_VPCI\_INTERFACE\_STANDARD.
+
+## -see-also
+
+[*InterfaceDereference*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pinterface_dereference)
+
+[*InterfaceReference*](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface)
+
+[**IRP\_MN\_QUERY\_INTERFACE**](/windows-hardware/drivers/kernel/irp-mn-query-interface)
+
+[*ReadVfConfigBlock*](/windows-hardware/drivers/ddi/vpci/nc-vpci-vpci_read_block)
+
+[*WriteVfConfigBlock*](/windows-hardware/drivers/ddi/vpci/nc-vpci-vpci_write_block)

--- a/wdk-ddi-src/content/wdm/ns-wdm-pci_virtualization_interface.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-pci_virtualization_interface.md
@@ -2,7 +2,7 @@
 UID: NS:wdm._PCI_VIRTUALIZATION_INTERFACE
 tech.root: pci
 title: PCI_VIRTUALIZATION_INTERFACE
-ms.date: 09/27/2022
+ms.date: 09/29/2022
 targetos: Windows
 description: Learn more about the PCI_VIRTUALIZATION_INTERFACE structure
 prerelease: false
@@ -66,53 +66,53 @@ A pointer to interface-specific context information.
 
 ### -field InterfaceReference
 
-A pointer to an [*InterfaceReference*](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface) routine that increments the interface's reference count.
+A pointer to an [*InterfaceReference*](ns-wdm-_interface.md) routine that increments the interface's reference count.
 
 ### -field InterfaceDereference
 
-A pointer to an [*InterfaceDereference*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pinterface_dereference) routine that decrements the interface's reference count.
+A pointer to an [*InterfaceDereference*](nc-wdm-pinterface_dereference.md) routine that decrements the interface's reference count.
 
 ### -field SetVirtualFunctionData
 
-A pointer to a [*SetVirtualFunctionData*](/windows-hardware/drivers/ddi/wdm/nc-wdm-set_virtual_device_data) routine that writes data to the PCIe configuration space of an SR-IOV device's VF.
+A pointer to a [*SetVirtualFunctionData*](nc-wdm-set_virtual_device_data.md) routine that writes data to the PCIe configuration space of an SR-IOV device's VF.
 
 ### -field GetVirtualFunctionData
 
-A pointer to a [*GetVirtualFunctionData*](/windows-hardware/drivers/ddi/wdm/nc-wdm-get_virtual_device_data) routine that reads data from the PCIe configuration space of an SR-IOV device's VF.
+A pointer to a [*GetVirtualFunctionData*](nc-wdm-get_virtual_device_data.md) routine that reads data from the PCIe configuration space of an SR-IOV device's VF.
 
 ### -field GetLocation
 
-A pointer to a [*GetLocation*](/windows-hardware/drivers/ddi/wdm/nc-wdm-get_virtual_device_location) routine that provides information about the current device location of a VF in the PCIe hierarchy. This information is necessary for a virtualization system that is using an I/O memory management unit (IOMMU) to route traffic to or from the device.
+A pointer to a [*GetLocation*](nc-wdm-get_virtual_device_location.md) routine that provides information about the current device location of a VF in the PCIe hierarchy. This information is necessary for a virtualization system that is using an I/O memory management unit (IOMMU) to route traffic to or from the device.
 
 ### -field GetResources
 
-A pointer to a [*GetResources*](/windows-hardware/drivers/ddi/wdm/nc-wdm-get_virtual_device_resources) routine that provides information about the resources that are available for virtualization on an SR-IOV device.
+A pointer to a [*GetResources*](nc-wdm-get_virtual_device_resources.md) routine that provides information about the resources that are available for virtualization on an SR-IOV device.
 
 ### -field EnableVirtualization
 
-A pointer to an [*EnableVirtualization*](/windows-hardware/drivers/ddi/wdm/nc-wdm-enable_virtualization) routine that enables or disables virtualization on an SR-IOV device.
+A pointer to an [*EnableVirtualization*](nc-wdm-enable_virtualization.md) routine that enables or disables virtualization on an SR-IOV device.
 
 ### -field GetVirtualFunctionProbedBars
 
-A pointer to a [*GetVirtualFunctionProbedBars*](/windows-hardware/drivers/ddi/wdm/nc-wdm-get_virtual_function_probed_bars) routine that allows a non-privileged Hyper-V virtual machine (VM) to determine what would be read from the PCIe Base Address Registers (BARs) of a VF after a query by the PCI bus driver. The PCI driver performs this query to determine the memory or I/O address space that the device requires.
+A pointer to a [*GetVirtualFunctionProbedBars*](nc-wdm-get_virtual_function_probed_bars.md) routine that allows a non-privileged Hyper-V virtual machine (VM) to determine what would be read from the PCIe Base Address Registers (BARs) of a VF after a query by the PCI bus driver. The PCI driver performs this query to determine the memory or I/O address space that the device requires.
 
 ## -remarks
 
 For devices that support the SR-IOV interface, drivers occasionally have to access and manage the PCIe configuration space of the device's VFs. Drivers call routines from the GUID\_PCI\_VIRTUALIZATION\_INTERFACE interface to access the PCIe configuration space of the VFs on the device.
 
 > [!NOTE]
-> Since a device's VFs do not appear as complete PCIe devices on the PCI bus, the [GUID\_BUS\_INTERFACE\_STANDARD](/windows-hardware/drivers/ddi/wdm/ns-wdm-_bus_interface_standard) interface cannot be used for the management of a VF.
+> Since a device's VFs do not appear as complete PCIe devices on the PCI bus, the [GUID\_BUS\_INTERFACE\_STANDARD](ns-wdm-_bus_interface_standard.md) interface cannot be used for the management of a VF.
 
-The **PCI\_VIRTUALIZATION\_INTERFACE** structure is an extension of the [**INTERFACE**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface) structure.
+The **PCI\_VIRTUALIZATION\_INTERFACE** structure is an extension of the [**INTERFACE**](ns-wdm-_interface.md) structure.
 
 A driver obtains a pointer to the **PCI\_VIRTUALIZATION\_INTERFACE** structure by sending an [**IRP\_MN\_QUERY\_INTERFACE**](/windows-hardware/drivers/kernel/irp-mn-query-interface) I/O request packet (IRP) to its bus driver with *InterfaceType* set to GUID\_PCI\_VIRTUALIZATION\_INTERFACE.
 
 ## -see-also
 
-[GUID\_BUS\_INTERFACE\_STANDARD](/windows-hardware/drivers/ddi/wdm/ns-wdm-_bus_interface_standard)
+[GUID\_BUS\_INTERFACE\_STANDARD](ns-wdm-_bus_interface_standard.md)
 
-[*InterfaceDereference*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pinterface_dereference)
+[*InterfaceDereference*](nc-wdm-pinterface_dereference.md)
 
-[*InterfaceReference*](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface)
+[*InterfaceReference*](ns-wdm-_interface.md)
 
 [**IRP\_MN\_QUERY\_INTERFACE**](/windows-hardware/drivers/kernel/irp-mn-query-interface)

--- a/wdk-ddi-src/content/wdm/ns-wdm-pci_virtualization_interface.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-pci_virtualization_interface.md
@@ -1,0 +1,118 @@
+---
+UID: NS:wdm._PCI_VIRTUALIZATION_INTERFACE
+tech.root: pci
+title: PCI_VIRTUALIZATION_INTERFACE
+ms.date: 09/27/2022
+targetos: Windows
+description: Learn more about the PCI_VIRTUALIZATION_INTERFACE structure
+prerelease: false
+req.construct-type: structure
+req.ddi-compliance: 
+req.dll: 
+req.header: wdm.h
+req.include-header: 
+req.kmdf-ver: 
+req.lib: 
+req.max-support: 
+req.redist: 
+req.target-min-winverclnt: 
+req.target-min-winversvr: Windows Server 2012
+req.target-type: 
+req.typenames: PCI_VIRTUALIZATION_INTERFACE, *PPCI_VIRTUALIZATION_INTERFACE
+req.umdf-ver: 
+req.unicode-ansi: 
+topic_type:
+ - apiref
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _PCI_VIRTUALIZATION_INTERFACE
+ - PPCI_VIRTUALIZATION_INTERFACE
+ - PCI_VIRTUALIZATION_INTERFACE
+f1_keywords:
+ - _PCI_VIRTUALIZATION_INTERFACE
+ - wdm/_PCI_VIRTUALIZATION_INTERFACE
+ - PPCI_VIRTUALIZATION_INTERFACE
+ - wdm/PPCI_VIRTUALIZATION_INTERFACE
+ - PCI_VIRTUALIZATION_INTERFACE
+ - wdm/PCI_VIRTUALIZATION_INTERFACE
+dev_langs:
+ - c++
+helpviewer_keywords:
+ - _PCI_VIRTUALIZATION_INTERFACE
+---
+
+## -description
+
+The **PCI\_VIRTUALIZATION\_INTERFACE** structure enables drivers to manage and configure the PCI Express (PCIe) configuration space for a virtual function (VF). VFs are exposed on the PCI bus by devices that support the single root I/O virtualization (SR-IOV) interface.
+
+This structure describes the **GUID\_PCI\_VIRTUALIZATION\_INTERFACE** interface.
+
+## -struct-fields
+
+### -field Size
+
+The size, in bytes, of this structure.
+
+### -field Version
+
+The driver-defined interface version.
+
+### -field Context
+
+A pointer to interface-specific context information.
+
+### -field InterfaceReference
+
+A pointer to an [*InterfaceReference*](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface) routine that increments the interface's reference count.
+
+### -field InterfaceDereference
+
+A pointer to an [*InterfaceDereference*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pinterface_dereference) routine that decrements the interface's reference count.
+
+### -field SetVirtualFunctionData
+
+A pointer to a [*SetVirtualFunctionData*](/windows-hardware/drivers/ddi/wdm/nc-wdm-set_virtual_device_data) routine that writes data to the PCIe configuration space of an SR-IOV device's VF.
+
+### -field GetVirtualFunctionData
+
+A pointer to a [*GetVirtualFunctionData*](/windows-hardware/drivers/ddi/wdm/nc-wdm-get_virtual_device_data) routine that reads data from the PCIe configuration space of an SR-IOV device's VF.
+
+### -field GetLocation
+
+A pointer to a [*GetLocation*](/windows-hardware/drivers/ddi/wdm/nc-wdm-get_virtual_device_location) routine that provides information about the current device location of a VF in the PCIe hierarchy. This information is necessary for a virtualization system that is using an I/O memory management unit (IOMMU) to route traffic to or from the device.
+
+### -field GetResources
+
+A pointer to a [*GetResources*](/windows-hardware/drivers/ddi/wdm/nc-wdm-get_virtual_device_resources) routine that provides information about the resources that are available for virtualization on an SR-IOV device.
+
+### -field EnableVirtualization
+
+A pointer to an [*EnableVirtualization*](/windows-hardware/drivers/ddi/wdm/nc-wdm-enable_virtualization) routine that enables or disables virtualization on an SR-IOV device.
+
+### -field GetVirtualFunctionProbedBars
+
+A pointer to a [*GetVirtualFunctionProbedBars*](/windows-hardware/drivers/ddi/wdm/nc-wdm-get_virtual_function_probed_bars) routine that allows a non-privileged Hyper-V virtual machine (VM) to determine what would be read from the PCIe Base Address Registers (BARs) of a VF after a query by the PCI bus driver. The PCI driver performs this query to determine the memory or I/O address space that the device requires.
+
+## -remarks
+
+For devices that support the SR-IOV interface, drivers occasionally have to access and manage the PCIe configuration space of the device's VFs. Drivers call routines from the GUID\_PCI\_VIRTUALIZATION\_INTERFACE interface to access the PCIe configuration space of the VFs on the device.
+
+> [!NOTE]
+> Since a device's VFs do not appear as complete PCIe devices on the PCI bus, the [GUID\_BUS\_INTERFACE\_STANDARD](/windows-hardware/drivers/ddi/wdm/ns-wdm-_bus_interface_standard) interface cannot be used for the management of a VF.
+
+The **PCI\_VIRTUALIZATION\_INTERFACE** structure is an extension of the [**INTERFACE**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface) structure.
+
+A driver obtains a pointer to the **PCI\_VIRTUALIZATION\_INTERFACE** structure by sending an [**IRP\_MN\_QUERY\_INTERFACE**](/windows-hardware/drivers/kernel/irp-mn-query-interface) I/O request packet (IRP) to its bus driver with *InterfaceType* set to GUID\_PCI\_VIRTUALIZATION\_INTERFACE.
+
+## -see-also
+
+[GUID\_BUS\_INTERFACE\_STANDARD](/windows-hardware/drivers/ddi/wdm/ns-wdm-_bus_interface_standard)
+
+[*InterfaceDereference*](/windows-hardware/drivers/ddi/wdm/nc-wdm-pinterface_dereference)
+
+[*InterfaceReference*](/windows-hardware/drivers/ddi/wdm/ns-wdm-_interface)
+
+[**IRP\_MN\_QUERY\_INTERFACE**](/windows-hardware/drivers/kernel/irp-mn-query-interface)


### PR DESCRIPTION
Project to clean up the previous versions for "Driver Reference" articles. First set of files being moved to wdk-ddi, for pci technology.