### PR TITLE
fix FILE_OPEN_BY_FILE_ID description of ZwCreateFile/NtCreateFile

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatefile.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatefile.md
@@ -260,7 +260,14 @@ Step 3 makes this practical only for Filter oplocks. The handle opened in step 3
 
 NTFS is the only Microsoft file system that implements FILE_RESERVE_OPFILTER.
 
-For the *CreateOptions* FILE_OPEN_BY_FILE_ID flag, an example device name will have the format: ```\??\C:\FileID\device\HardDiskVolume1\ObjectID```, where FileID is 8 bytes and ObjectID is 16 bytes:
+For the *CreateOptions* FILE_OPEN_BY_FILE_ID flag, an example device name will have the format: 
+
+```
+\??\C:\<FileID>
+\device\HardDiskVolume1\<ObjectID>
+```
+
+where *FileID* is 8 bytes and *ObjectID* is 16 bytes:
 
 * On NTFS, this can be a 8-byte or 16-byte reference number or object ID. A 16-byte reference number is the same as an 8-byte number padded with zeros.
 * On ReFS, this can be an 8-byte or 16-byte reference number. A 16-byte number is not related to an 8-byte number. Object IDs are not supported.

--- a/wdk-ddi-src/content/wdm/nf-wdm-zwcreatefile.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-zwcreatefile.md
@@ -570,9 +570,10 @@ FILE_OPEN_BY_FILE_ID
 <td>
 The file name that is specified by the <i>ObjectAttributes</i> parameter includes a binary 8-byte or 16-byte file reference number or object ID for the file, depending on the file system as shown below. Optionally, a device name followed by a backslash character may proceed these binary values. For example, a device name will have the following format.
 
-<pre class="syntax">\??\C:\FileID\device\HardDiskVolume1\ObjectID</pre>
+ <pre class="syntax">\??\C:\<i>FileID</i>
+\device\HardDiskVolume1\<i>ObjectID</i></pre>
 
-where FileID is 8 bytes and ObjectID is 16 bytes
+ where <i>FileID</i> is 8 bytes and <i>ObjectID</i> is 16 bytes
 
 <ul>
 <li>

--- a/wdk-ddi-src/content/wdm/nf-wdm-zwcreatefile.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-zwcreatefile.md
@@ -570,10 +570,10 @@ FILE_OPEN_BY_FILE_ID
 <td>
 The file name that is specified by the <i>ObjectAttributes</i> parameter includes a binary 8-byte or 16-byte file reference number or object ID for the file, depending on the file system as shown below. Optionally, a device name followed by a backslash character may proceed these binary values. For example, a device name will have the following format.
 
- <pre class="syntax">\??\C:\<i>FileID</i>
+<pre class="syntax">\??\C:\<i>FileID</i>
 \device\HardDiskVolume1\<i>ObjectID</i></pre>
 
- where <i>FileID</i> is 8 bytes and <i>ObjectID</i> is 16 bytes
+where <i>FileID</i> is 8 bytes and <i>ObjectID</i> is 16 bytes
 
 <ul>
 <li>


### PR DESCRIPTION
The file name example in FILE_OPEN_BY_FILE_ID of ZwCreateFile/NtCreateFile was corrupted in a fix of #882 .
Example have two forms and should be present in separated lines, not in single line. 

This appear in older version of these documents like [https://github.com/MicrosoftDocs/windows-driver-docs-ddi/blob/bc38ed6027d95903b53ed8a934b19d5f5f9f73a8/wdk-ddi-src/content/wdm/nf-wdm-zwcreatefile.md#:~:text=%5C%3F%3F%5CC%3A%5C%3C8%20bytes%20of%20binary%20FileID%3E%0A%5Cdevice%5CHardDiskVolume1%5C%3C16%20bytes%20of%20binary%20ObjectID%3E](url)