### PR TITLE
LinkFix: windows-driver-docs-ddi (2022-10)

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatesection.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatesection.md
@@ -104,7 +104,7 @@ Once the handle pointed to by **SectionHandle** is no longer in use, the driver 
 
 If the caller is not running in a system thread context, it must ensure that any handles it creates are private handles. Otherwise, the handle can be accessed by the process in whose context the driver is running. For more information, see [Object Handles](/windows-hardware/drivers/kernel/object-handles).
 
-For more information about setting up mapped sections and views of memory, see [Sections and Views](/windows-hardware/drivers/ddi/_kernel/#sections-and-views).
+For more information about setting up mapped sections and views of memory, see [Sections and Views](../_kernel/index.md#sections-and-views).
 
 > [!NOTE]
 > If the call to this function occurs in user mode, you should use the name "**NtCreateSection**" instead of "**ZwCreateSection**".

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatesectionex.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatesectionex.md
@@ -111,7 +111,7 @@ Once the handle pointed to by **SectionHandle** is no longer in use, the driver 
 
 If the caller is not running in a system thread context, it must ensure that any handles it creates are private handles. Otherwise, the handle can be accessed by the process in whose context the driver is running. For more information, see [Object Handles](/windows-hardware/drivers/kernel/object-handles).
 
-For more information about setting up mapped sections and views of memory, see [Sections and Views](/windows-hardware/drivers/ddi/_kernel/#sections-and-views).
+For more information about setting up mapped sections and views of memory, see [Sections and Views](../_kernel/index.md#sections-and-views).
 
 > [!NOTE]
 > If the call to this function occurs in user mode, you should use the name "**NtCreateSectionEx**" instead of "**ZwCreateSectionEx**".


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 