### PR TITLE
Limit the obsolescence text to what was intended

### DIFF
--- a/wdk-ddi-src/content/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_read_q_channel.md
+++ b/wdk-ddi-src/content/ntddcdrm/ni-ntddcdrm-ioctl_cdrom_read_q_channel.md
@@ -1,7 +1,7 @@
 ---
 UID: NI:ntddcdrm.IOCTL_CDROM_READ_Q_CHANNEL
 title: IOCTL_CDROM_READ_Q_CHANNEL (ntddcdrm.h)
-description: Returns the current position, media catalog, or ISRC track data. Obsolete, beginning with Windows Vista.
+description: Returns the current position, media catalog, or ISRC track data. Reading the current position is obsolete, beginning with Windows Vista.
 old-location: storage\ioctl_cdrom_read_q_channel.htm
 tech.root: storage
 ms.date: 03/29/2018
@@ -45,7 +45,7 @@ api_name:
 
 ## -description
 
-Returns the current position, media catalog, or ISRC track data. Obsolete, beginning with Windows Vista.
+Returns the current position, media catalog, or ISRC track data. Reading the current position is obsolete, beginning with Windows Vista.
 
 ## -ioctlparameters
 
@@ -86,7 +86,7 @@ The <b>Information</b> field is set to the number of bytes returned. The <b>Stat
 
 ## -remarks
 
-Beginning with Windows Vista, CDROM class drivers do not use this IOCTL. Prior to Windows Vista, this IOCTL was used for audio playback on older CD-ROM drives that supported direct audio output in hardware.
+Beginning with Windows Vista, CDROM class drivers do not use this IOCTL with the format member set to IOCTL_CDROM_CURRENT_POSITION. Prior to Windows Vista, this IOCTL was used for audio playback on older CD-ROM drives that supported direct audio output in hardware.
 
 Client applications should use the <i>Media Control Interface (MCI) API</i> rather than issuing this IOCTL.
 


### PR DESCRIPTION
Only the CD playback api was deprecated, not the other uses for this IOCTL.