### PR TITLE
LinkFix: windows-driver-docs-ddi (2022-11)

### DIFF
--- a/wdk-ddi-src/content/compstui/nc-compstui-pfncompropsheet.md
+++ b/wdk-ddi-src/content/compstui/nc-compstui-pfncompropsheet.md
@@ -66,21 +66,21 @@ Caller-supplied value that depends on the *ComPropSheet* function code supplied 
 
 ## -returns
 
-The return value depends on the [ComPropSheet function code](/windows-hardware/drivers/ddi/_print/index) supplied for *Function*.
+The return value depends on the [ComPropSheet function code](../_print/index.md) supplied for *Function*.
 
 ## -remarks
 
-When CPSUI calls one of an application's [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed functions, it passes a pointer to the *ComPropSheet* function in a [PROPSHEETUI_INFO](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_info) structure. A **PFNPROPSHEETUI**-typed function can call the *ComPropSheet* function to describe property sheet pages to CPSUI.
+When CPSUI calls one of an application's [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed functions, it passes a pointer to the *ComPropSheet* function in a [PROPSHEETUI_INFO](./ns-compstui-_propsheetui_info.md) structure. A **PFNPROPSHEETUI**-typed function can call the *ComPropSheet* function to describe property sheet pages to CPSUI.
 
-A [printer interface DLL](/windows-hardware/drivers/print/printer-interface-dll) can call *ComPropSheet* from within its [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets) function or its [DrvDevicePropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdevicepropertysheets) function.
+A [printer interface DLL](/windows-hardware/drivers/print/printer-interface-dll) can call *ComPropSheet* from within its [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md) function or its [DrvDevicePropertySheets](../winddiui/nf-winddiui-drvdevicepropertysheets.md) function.
 
-[User interface plug-ins](/windows-hardware/drivers/print/user-interface-plug-ins) for Microsoft's [Unidrv](/windows-hardware/drivers/) and [Pscript](/windows-hardware/drivers/) drivers can call *ComPropSheet* from within their [IPrintOemUI::DocumentPropertySheets](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-documentpropertysheets) and [IPrintOemUI::DevicePropertySheets](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-devicepropertysheets) methods.
+[User interface plug-ins](/windows-hardware/drivers/print/user-interface-plug-ins) for Microsoft's [Unidrv](/windows-hardware/drivers/) and [Pscript](/windows-hardware/drivers/) drivers can call *ComPropSheet* from within their [IPrintOemUI::DocumentPropertySheets](../prcomoem/nf-prcomoem-iprintoemui-documentpropertysheets.md) and [IPrintOemUI::DevicePropertySheets](../prcomoem/nf-prcomoem-iprintoemui-devicepropertysheets.md) methods.
 
 The [group parent](/windows-hardware/drivers/print/group-parent) handle specified for the *hComPropSheet* parameter can be either of the following:
 
-- The handle received in the *hComPropSheet* member of a [PROPSHEETUI_INFO](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_info) structure.
+- The handle received in the *hComPropSheet* member of a [PROPSHEETUI_INFO](./ns-compstui-_propsheetui_info.md) structure.
 
-- The handle received as a result of previously calling *ComPropSheet* with a [CPSFUNC_INSERT_PSUIPAGE](/previous-versions/ff546414(v=vs.85)) function code, and specifying PSUIPAGEINSERT_GROUP_PARENT as the **Type** member for an [INSERTPSUIPAGE_INFO](/windows-hardware/drivers/ddi/compstui/ns-compstui-_insertpsuipage_info) structure.
+- The handle received as a result of previously calling *ComPropSheet* with a [CPSFUNC_INSERT_PSUIPAGE](/previous-versions/ff546414(v=vs.85)) function code, and specifying PSUIPAGEINSERT_GROUP_PARENT as the **Type** member for an [INSERTPSUIPAGE_INFO](./ns-compstui-_insertpsuipage_info.md) structure.
 
 ### ComPropSheet function codes
 

--- a/wdk-ddi-src/content/compstui/nc-compstui-pfnpropsheetui.md
+++ b/wdk-ddi-src/content/compstui/nc-compstui-pfnpropsheetui.md
@@ -47,15 +47,15 @@ The PFNPROPSHEETUI function type is used by CPSUI applications (including printe
 
 ### -param pPSUIInfo
 
-CPSUI-supplied pointer to a [**PROPSHEETUI_INFO**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_info) structure.
+CPSUI-supplied pointer to a [**PROPSHEETUI_INFO**](./ns-compstui-_propsheetui_info.md) structure.
 
 ### -param lParam
 
-CPSUI-supplied integer value that is dependent on the contents of the **Reason** member of the [**PROPSHEETUI_INFO**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_info) structure. Valid values are as follows:
+CPSUI-supplied integer value that is dependent on the contents of the **Reason** member of the [**PROPSHEETUI_INFO**](./ns-compstui-_propsheetui_info.md) structure. Valid values are as follows:
 
 #### PROPSHEETUI_REASON_BEFORE_INIT
 
-This value is new to Windows 8 and it is provided only to the original PFNPROPSHEETUI parameter passed to [CommonPropertySheetUI](/windows-hardware/drivers/ddi/compstui/nf-compstui-commonpropertysheetuia).
+This value is new to Windows 8 and it is provided only to the original PFNPROPSHEETUI parameter passed to [CommonPropertySheetUI](./nf-compstui-commonpropertysheetuia.md).
 
 #### PROPSHEETUI_REASON_DESTROY
 
@@ -63,25 +63,25 @@ The *lParam* value is nonzero if the user has selected the property sheet's **OK
 
 #### PROPSHEETUI_REASON_GET_ICON
 
-The *lParam* value is a pointer to a [**PROPSHEETUI_GETICON_INFO**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_geticon_info) structure.
+The *lParam* value is a pointer to a [**PROPSHEETUI_GETICON_INFO**](./ns-compstui-_propsheetui_geticon_info.md) structure.
 
 #### PROPSHEETUI_REASON_GET_INFO_HEADER
 
-The *lParam* value is a pointer to a [**PROPSHEETUI_INFO_HEADER**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_info_header) structure.
+The *lParam* value is a pointer to a [**PROPSHEETUI_INFO_HEADER**](./ns-compstui-_propsheetui_info_header.md) structure.
 
 #### PROPSHEETUI_REASON_INIT
 
-If the callback function is specified by the *pfnPropSheetUI* parameter to [CommonPropertySheetUI](/windows-hardware/drivers/ddi/compstui/nf-compstui-commonpropertysheetuia), *lParam* is the *lParam* value passed to **CommonPropertySheetUI**.
+If the callback function is specified by the *pfnPropSheetUI* parameter to [CommonPropertySheetUI](./nf-compstui-commonpropertysheetuia.md), *lParam* is the *lParam* value passed to **CommonPropertySheetUI**.
 
-If the callback function is specified using the CPSFUNC_ADD_PFNPROPSHEETUI function code with CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function, *lParam* is the *lParam2* value passed to **ComPropSheet**.
+If the callback function is specified using the CPSFUNC_ADD_PFNPROPSHEETUI function code with CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function, *lParam* is the *lParam2* value passed to **ComPropSheet**.
 
-CPSUI copies the *lParam* value into the **lParamInit** member of the function's [**PROPSHEETUI_INFO**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_info) structure.
+CPSUI copies the *lParam* value into the **lParamInit** member of the function's [**PROPSHEETUI_INFO**](./ns-compstui-_propsheetui_info.md) structure.
 
 The *lParam* value must not reside on the application's stack.
 
 #### PROPSHEETUI_REASON_SET_RESULT
 
-The *lParam* value is a pointer to a [SETRESULT_INFO](/windows-hardware/drivers/ddi/compstui/ns-compstui-_setresult_info) structure.
+The *lParam* value is a pointer to a [SETRESULT_INFO](./ns-compstui-_setresult_info.md) structure.
 
 ## -returns
 
@@ -94,8 +94,8 @@ If the operation succeeds, the function should return a value of one (or greater
 
 ## -remarks
 
-Callback functions specified using the PFNPROPSHEETUI function type are supplied by applications that use [CPSUI](/windows-hardware/drivers/print/common-property-sheet-user-interface) to manage customized property sheet pages. One such callback function must be specified when an application calls the [CommonPropertySheetUI](/windows-hardware/drivers/ddi/compstui/nf-compstui-commonpropertysheetuia) function. For example, when the NT-based operating system print spooler calls CPSUI's **CommonPropertySheetUI** function to support its [DocumentProperties](/windows/win32/printdocs/documentproperties) or [PrinterProperties](/windows/win32/printdocs/printerproperties) functions, the spooler specifies an internal PFNPROPSHEETUI-typed callback function.
+Callback functions specified using the PFNPROPSHEETUI function type are supplied by applications that use [CPSUI](/windows-hardware/drivers/print/common-property-sheet-user-interface) to manage customized property sheet pages. One such callback function must be specified when an application calls the [CommonPropertySheetUI](./nf-compstui-commonpropertysheetuia.md) function. For example, when the NT-based operating system print spooler calls CPSUI's **CommonPropertySheetUI** function to support its [DocumentProperties](/windows/win32/printdocs/documentproperties) or [PrinterProperties](/windows/win32/printdocs/printerproperties) functions, the spooler specifies an internal PFNPROPSHEETUI-typed callback function.
 
-Applications can specify additional PFNPROPSHEETUI-typed callback functions by calling CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function with a function code of [CPSFUNC_ADD_PFNPROPSHEETUI](/previous-versions/ff546391(v=vs.85)). For example, the NT-based operating system print spooler does this to notify CPSUI of the existence of a printer interface DLL's [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets) and [DrvDevicePropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdevicepropertysheets) functions. Likewise, Microsoft's [Unidrv](/windows-hardware/drivers/) and [Pscript](/windows-hardware/drivers/) drivers use this technique to notify CPSUI of the existence of [IPrintOemUI::DocumentPropertySheets](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-documentpropertysheets) and [IPrintOemUI::DevicePropertySheets](/windows-hardware/drivers/ddi/prcomoem/nf-prcomoem-iprintoemui-devicepropertysheets) methods in [user interface plug-ins](/windows-hardware/drivers/print/user-interface-plug-ins).
+Applications can specify additional PFNPROPSHEETUI-typed callback functions by calling CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function with a function code of [CPSFUNC_ADD_PFNPROPSHEETUI](/previous-versions/ff546391(v=vs.85)). For example, the NT-based operating system print spooler does this to notify CPSUI of the existence of a printer interface DLL's [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md) and [DrvDevicePropertySheets](../winddiui/nf-winddiui-drvdevicepropertysheets.md) functions. Likewise, Microsoft's [Unidrv](/windows-hardware/drivers/) and [Pscript](/windows-hardware/drivers/) drivers use this technique to notify CPSUI of the existence of [IPrintOemUI::DocumentPropertySheets](../prcomoem/nf-prcomoem-iprintoemui-documentpropertysheets.md) and [IPrintOemUI::DevicePropertySheets](../prcomoem/nf-prcomoem-iprintoemui-devicepropertysheets.md) methods in [user interface plug-ins](/windows-hardware/drivers/print/user-interface-plug-ins).
 
-Each PFNPROPSHEETUI-typed callback function is called by CPSUI several times. The **Reason** member of the [**PROPSHEETUI_INFO**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_info) structure stipulates the operation that the function should perform, as follows:
+Each PFNPROPSHEETUI-typed callback function is called by CPSUI several times. The **Reason** member of the [**PROPSHEETUI_INFO**](./ns-compstui-_propsheetui_info.md) structure stipulates the operation that the function should perform, as follows:

--- a/wdk-ddi-src/content/compstui/nf-compstui-commonpropertysheetuia.md
+++ b/wdk-ddi-src/content/compstui/nf-compstui-commonpropertysheetuia.md
@@ -54,7 +54,7 @@ Caller-supplied window handle identifying the window into which new property she
 
 ### -param pfnPropSheetUI
 
-Caller-supplied pointer to a [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed callback function.
+Caller-supplied pointer to a [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed callback function.
 
 ### -param lParam
 
@@ -82,11 +82,11 @@ The CommonPropertySheetUI function is CPSUI's entry point for applications. A CP
 
 The NT-based operating system print spooler calls the CommonPropertySheetUI function when a Win32 application calls the spooler's [DocumentProperties](/windows/win32/printdocs/documentproperties) or [PrinterProperties](/windows/win32/printdocs/printerproperties) functions.
 
-The callback function specified by the *pfnPropSheetUI* parameter is responsible for describing the property sheet pages to be added. For more information, see the description of the [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui) function type.
+The callback function specified by the *pfnPropSheetUI* parameter is responsible for describing the property sheet pages to be added. For more information, see the description of the [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md) function type.
 
 The sequence of operation is as follows:
 
-1. The CommonPropertySheetUI function calls the *pfnPropSheetUI* callback so the callback can describe the pages to be added by calling CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function.
+1. The CommonPropertySheetUI function calls the *pfnPropSheetUI* callback so the callback can describe the pages to be added by calling CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function.
 
 1. If the *pfnPropSheetUI* callback succeeds, the CommonPropertySheetUI function displays the new property sheet pages and allows the user to modify page values.
 
@@ -96,4 +96,4 @@ The sequence of operation is as follows:
 
 For more information about the sequence of operation, see [Using CPSUI with Printer Drivers](/windows-hardware/drivers/print/using-cpsui-with-printer-drivers), in the section entitled [CPSUI](/windows-hardware/drivers/print/common-property-sheet-user-interface).
 
-The CommonPropertySheetUI function actually calls the *pfnPropSheetUI* callback several times, specifying different **Reason** member values in the callback's [PROPSHEETUI_INFO](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_info) structure. Each time the callback returns, it places a result status in the PROPSHEETUI_INFO structure's **Result** member. When the CommonPropertySheetUI function returns, it copies the final contents of **Result** into the location pointed to by *pResult*.
+The CommonPropertySheetUI function actually calls the *pfnPropSheetUI* callback several times, specifying different **Reason** member values in the callback's [PROPSHEETUI_INFO](./ns-compstui-_propsheetui_info.md) structure. Each time the callback returns, it places a result status in the PROPSHEETUI_INFO structure's **Result** member. When the CommonPropertySheetUI function returns, it copies the final contents of **Result** into the location pointed to by *pResult*.

--- a/wdk-ddi-src/content/compstui/nf-compstui-commonpropertysheetuiw.md
+++ b/wdk-ddi-src/content/compstui/nf-compstui-commonpropertysheetuiw.md
@@ -54,7 +54,7 @@ Caller-supplied window handle identifying the window into which new property she
 
 ### -param pfnPropSheetUI
 
-Caller-supplied pointer to a [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed callback function.
+Caller-supplied pointer to a [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed callback function.
 
 ### -param lParam
 
@@ -82,11 +82,11 @@ The **CommonPropertySheetUI** function is CPSUI's entry point for applications. 
 
 The NT-based operating system print spooler calls the **CommonPropertySheetUI** function when a Win32 application calls the spooler's [DocumentProperties](/windows/win32/printdocs/documentproperties) or [PrinterProperties](/windows/win32/printdocs/printerproperties) functions.
 
-The callback function specified by the *pfnPropSheetUI* parameter is responsible for describing the property sheet pages to be added. For more information, see the description of the [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui) function type.
+The callback function specified by the *pfnPropSheetUI* parameter is responsible for describing the property sheet pages to be added. For more information, see the description of the [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md) function type.
 
 The sequence of operation is as follows:
 
-1. The **CommonPropertySheetUI** function calls the *pfnPropSheetUI* callback so the callback can describe the pages to be added by calling CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function.
+1. The **CommonPropertySheetUI** function calls the *pfnPropSheetUI* callback so the callback can describe the pages to be added by calling CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function.
 
 1. If the *pfnPropSheetUI* callback succeeds, the **CommonPropertySheetUI** function displays the new property sheet pages and allows the user to modify page values.
 
@@ -96,4 +96,4 @@ The sequence of operation is as follows:
 
 For more information about the sequence of operation, see [Using CPSUI with Printer Drivers](/windows-hardware/drivers/print/using-cpsui-with-printer-drivers), in the section entitled [CPSUI](/windows-hardware/drivers/print/common-property-sheet-user-interface).
 
-The **CommonPropertySheetUI** function actually calls the *pfnPropSheetUI* callback several times, specifying different **Reason** member values in the callback's [PROPSHEETUI_INFO](/windows-hardware/drivers/ddi/compstui/ns-compstui-_propsheetui_info) structure. Each time the callback returns, it places a result status in the PROPSHEETUI_INFO structure's **Result** member. When the **CommonPropertySheetUI** function returns, it copies the final contents of **Result** into the location pointed to by *pResult*.
+The **CommonPropertySheetUI** function actually calls the *pfnPropSheetUI* callback several times, specifying different **Reason** member values in the callback's [PROPSHEETUI_INFO](./ns-compstui-_propsheetui_info.md) structure. Each time the callback returns, it places a result status in the PROPSHEETUI_INFO structure's **Result** member. When the **CommonPropertySheetUI** function returns, it copies the final contents of **Result** into the location pointed to by *pResult*.

--- a/wdk-ddi-src/content/compstui/nf-compstui-getcpsuiuserdata.md
+++ b/wdk-ddi-src/content/compstui/nf-compstui-getcpsuiuserdata.md
@@ -41,7 +41,7 @@ api_name:
 
 ## -description
 
-CPSUI's **GetCPSUIUserData** function retrieves data that was previously stored using the [SetCPSUIUserData](/windows-hardware/drivers/ddi/compstui/nf-compstui-setcpsuiuserdata) function.
+CPSUI's **GetCPSUIUserData** function retrieves data that was previously stored using the [SetCPSUIUserData](./nf-compstui-setcpsuiuserdata.md) function.
 
 ## -parameters
 
@@ -51,10 +51,10 @@ Caller-supplied handle to a property sheet dialog box. For more information, see
 
 ## -returns
 
-If the operation succeeds, the function returns the value that was previously supplied to [SetCPSUIUserData](/windows-hardware/drivers/ddi/compstui/nf-compstui-setcpsuiuserdata); otherwise the function returns zero.
+If the operation succeeds, the function returns the value that was previously supplied to [SetCPSUIUserData](./nf-compstui-setcpsuiuserdata.md); otherwise the function returns zero.
 
 ## -remarks
 
-The **GetCPSUIUserData** function should only be called from within a dialog box procedure that has been associated with a dialog box by using a [DLGPAGE](/windows-hardware/drivers/ddi/compstui/ns-compstui-_dlgpage) or an [EXTPUSH](/windows-hardware/drivers/ddi/compstui/ns-compstui-_extpush) structure.
+The **GetCPSUIUserData** function should only be called from within a dialog box procedure that has been associated with a dialog box by using a [DLGPAGE](./ns-compstui-_dlgpage.md) or an [EXTPUSH](./ns-compstui-_extpush.md) structure.
 
 The handle specified for *hDlg* must be the handle received as input to the dialog box procedure. For more information, see [Dialog box programming considerations](/windows/win32/dlgbox/dlgbox-programming-considerations).

--- a/wdk-ddi-src/content/compstui/nf-compstui-setcpsuiuserdata.md
+++ b/wdk-ddi-src/content/compstui/nf-compstui-setcpsuiuserdata.md
@@ -59,8 +59,8 @@ The  function returns **TRUE** if it is successful in associating the non-displa
 
 ## -remarks
 
-The **SetCPSUIUserData** function should be called only from within a dialog box procedure that has been associated with a dialog box by using a [**DLGPAGE**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_dlgpage) or an [**EXTPUSH**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_extpush) structure.
+The **SetCPSUIUserData** function should be called only from within a dialog box procedure that has been associated with a dialog box by using a [**DLGPAGE**](./ns-compstui-_dlgpage.md) or an [**EXTPUSH**](./ns-compstui-_extpush.md) structure.
 
-A value that is stored by calling SetCPSUIUserData can be later retrieved by calling [GetCPSUIUserData](/windows-hardware/drivers/ddi/compstui/nf-compstui-getcpsuiuserdata).
+A value that is stored by calling SetCPSUIUserData can be later retrieved by calling [GetCPSUIUserData](./nf-compstui-getcpsuiuserdata.md).
 
 The handle specified for *hDlg* must be the handle received as input to the [dialog box procedure](/windows-hardware/drivers/print/dialog-box-procedures-and-cpsui).

--- a/wdk-ddi-src/content/compstui/ns-compstui-_compropsheetui.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_compropsheetui.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **COMPROPSHEETUI** structure is used as an input parameter to CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function, if the function code is [CPSFUNC_ADD_PCOMPROPSHEETUI](/previous-versions/ff546388(v=vs.85)). All structure members must be supplied by the caller of *ComPropSheet*.
+The **COMPROPSHEETUI** structure is used as an input parameter to CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function, if the function code is [CPSFUNC_ADD_PCOMPROPSHEETUI](/previous-versions/ff546388(v=vs.85)). All structure members must be supplied by the caller of *ComPropSheet*.
 
 ## -struct-fields
 
@@ -83,27 +83,27 @@ Caller-supplied pointer to a NULL-terminated text string representing the applic
 
 ### -field UserData
 
-Optional caller-supplied value, which CPSUI places in a [CPSUICBPARAM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_cpsuicbparam) structure's **UserData** member when calling the function pointed to by **pfnCallBack**.
+Optional caller-supplied value, which CPSUI places in a [CPSUICBPARAM](./ns-compstui-_cpsuicbparam.md) structure's **UserData** member when calling the function pointed to by **pfnCallBack**.
 
 ### -field pHelpFile
 
 Caller-supplied pointer to a NULL-terminated text string representing a path to a help file. For printer interface DLLs, this is typically the help file path obtained by calling [GetPrinterDriver](/windows/win32/printdocs/getprinterdriver).
 
-The help file is indexed by values contained in the **HelpIndex** member of [OPTITEM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structures.
+The help file is indexed by values contained in the **HelpIndex** member of [OPTITEM](./ns-compstui-_optitem.md) structures.
 
 ### -field pfnCallBack
 
-Caller-supplied pointer to a [_CPSUICALLBACK](/windows-hardware/drivers/ddi/compstui/nc-compstui-_cpsuicallback)-typed callback function, which CPSUI calls when a user modifies the page's option values.
+Caller-supplied pointer to a [_CPSUICALLBACK](./nc-compstui-_cpsuicallback.md)-typed callback function, which CPSUI calls when a user modifies the page's option values.
 
-Can be used only if **pDlgPage** identifies a CPSUI-supplied [DLGPAGE](/windows-hardware/drivers/ddi/compstui/ns-compstui-_dlgpage) structure, or if the **DlgProc** member of an application-supplied DLGPAGE structure is **NULL**.
+Can be used only if **pDlgPage** identifies a CPSUI-supplied [DLGPAGE](./ns-compstui-_dlgpage.md) structure, or if the **DlgProc** member of an application-supplied DLGPAGE structure is **NULL**.
 
 ### -field pOptItem
 
-Caller-supplied pointer to an array of [OPTITEM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structures describing the page's options.
+Caller-supplied pointer to an array of [OPTITEM](./ns-compstui-_optitem.md) structures describing the page's options.
 
 ### -field pDlgPage
 
-This member specifies [DLGPAGE](/windows-hardware/drivers/ddi/compstui/ns-compstui-_dlgpage) structures that describe pages to be added to the property sheet. It can be either of the following:
+This member specifies [DLGPAGE](./ns-compstui-_dlgpage.md) structures that describe pages to be added to the property sheet. It can be either of the following:
 
 - A pointer to an array of DLGPAGE structures.
 
@@ -111,15 +111,15 @@ This member specifies [DLGPAGE](/windows-hardware/drivers/ddi/compstui/ns-compst
 
   - CPSUI_PDLGPAGE_ADVDOCPROP
 
-    Defines one treeview page whose tab reads **Advanced**. For use only by a [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets) function.
+    Defines one treeview page whose tab reads **Advanced**. For use only by a [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md) function.
 
   - CPSUI_PDLGPAGE_DOCPROP  
   
-    Defines three pages, whose tabs are **Layout**, **Paper/Quality**, and **Advanced**. The **Advanced** page is a treeview. For use only by a [DrvDocumentPropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdocumentpropertysheets) function.
+    Defines three pages, whose tabs are **Layout**, **Paper/Quality**, and **Advanced**. The **Advanced** page is a treeview. For use only by a [DrvDocumentPropertySheets](../winddiui/nf-winddiui-drvdocumentpropertysheets.md) function.
 
   - CPSUI_PDLGPAGE_PRINTERPROP  
   
-    Defines one treeview page whose tab reads **Device Settings**. For use only by a [DrvDevicePropertySheets](/windows-hardware/drivers/ddi/winddiui/nf-winddiui-drvdevicepropertysheets) function.
+    Defines one treeview page whose tab reads **Device Settings**. For use only by a [DrvDevicePropertySheets](../winddiui/nf-winddiui-drvdevicepropertysheets.md) function.
 
   - CPSUI_PDLGPAGE_TREEVIEWONLY
 
@@ -127,11 +127,11 @@ This member specifies [DLGPAGE](/windows-hardware/drivers/ddi/compstui/ns-compst
 
 ### -field cOptItem
 
-Caller-supplied number of [OPTITEM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structures pointed to by **pOptItem**.
+Caller-supplied number of [OPTITEM](./ns-compstui-_optitem.md) structures pointed to by **pOptItem**.
 
 ### -field cDlgPage
 
-Caller-supplied number of [DLGPAGE](/windows-hardware/drivers/ddi/compstui/ns-compstui-_dlgpage) structures pointed to by **pDlgPage**. Not used if **pDlgPage** specifies a predefined CPSUI_PDLGPAGE-prefixed structure.
+Caller-supplied number of [DLGPAGE](./ns-compstui-_dlgpage.md) structures pointed to by **pDlgPage**. Not used if **pDlgPage** specifies a predefined CPSUI_PDLGPAGE-prefixed structure.
 
 ### -field IconID
 

--- a/wdk-ddi-src/content/compstui/ns-compstui-_cpsuicbparam.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_cpsuicbparam.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The CPSUICBPARAM structure is used as the input parameter to [_CPSUICALLBACK](/windows-hardware/drivers/ddi/compstui/nc-compstui-_cpsuicallback)-typed callback functions.
+The CPSUICBPARAM structure is used as the input parameter to [_CPSUICALLBACK](./nc-compstui-_cpsuicallback.md)-typed callback functions.
 
 ## -struct-fields
 
@@ -61,7 +61,7 @@ CPSUI-supplied value indicating the reason it is calling the callback function. 
 
 #### CPSUICB_REASON_ABOUT
 
-The user has clicked on the page's **About** button, and the application previously set the CPSUIF_ABOUT_CALLBACK flag in a [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure. CPSUI sets *pCurItem* to the value contained in **pOptItem**, and sets **pOldSel** to point to the **COMPROPSHEETUI** structure.
+The user has clicked on the page's **About** button, and the application previously set the CPSUIF_ABOUT_CALLBACK flag in a [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure. CPSUI sets *pCurItem* to the value contained in **pOptItem**, and sets **pOldSel** to point to the **COMPROPSHEETUI** structure.
 
 #### CPSUICB_REASON_APPLYNOW
 
@@ -87,7 +87,7 @@ The user clicked on the page's **Undo** button, and CPSUI has reverted all selec
 
 #### CPSUICB_REASON_KILLACTIVE
 
-The property sheet page is about to lose activation, and CPSUI has received a [PSN_KILLACTIVE](/windows/win32/controls/psn-killactive) notification message. CPSUI sets **pCurItem** to the value contained in **pOptItem**, and sets **pOldSel** to point to the [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure.
+The property sheet page is about to lose activation, and CPSUI has received a [PSN_KILLACTIVE](/windows/win32/controls/psn-killactive) notification message. CPSUI sets **pCurItem** to the value contained in **pOptItem**, and sets **pOldSel** to point to the [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure.
 
 #### CPSUICB_REASON_OPTITEM_SETFOCUS
 
@@ -97,7 +97,7 @@ The option identified by **pCurItem** has received input focus.
 
 The option identified by **pCurItem** is a push button ([TVOT_PUSHBUTTON](/windows-hardware/drivers/print/tvot-pushbutton) option type), and the user has clicked on the button.
 
-The push button item's [**OPTPARAM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optparam) **Style**  field is set to PUSHBUTTON_TYPE_CALLBACK.
+The push button item's [**OPTPARAM**](./ns-compstui-_optparam.md) **Style**  field is set to PUSHBUTTON_TYPE_CALLBACK.
 
 #### CPSUICB_REASON_SEL_CHANGED
 
@@ -105,7 +105,7 @@ The user has changed the selected value for the option pointed to by **pCurItem*
 
 #### CPSUICB_REASON_SETACTIVE
 
-The property sheet page is about to become active, and CPSUI has received a [PSN_SETACTIVE](/windows/win32/controls/psn-setactive) notification message. CPSUI sets **pCurItem** to the value contained in **pOptItem**, and sets **pOldSel** to point to the [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure.
+The property sheet page is about to become active, and CPSUI has received a [PSN_SETACTIVE](/windows/win32/controls/psn-setactive) notification message. CPSUI sets **pCurItem** to the value contained in **pOptItem**, and sets **pOldSel** to point to the [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure.
 
 ### -field hDlg
 
@@ -113,15 +113,15 @@ CPSUI-supplied handle to the currently active dialog box.
 
 ### -field pOptItem
 
-CPSUI-supplied pointer to an array of [**OPTITEM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structures. This is the same pointer that the application previously supplied in a [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure.
+CPSUI-supplied pointer to an array of [**OPTITEM**](./ns-compstui-_optitem.md) structures. This is the same pointer that the application previously supplied in a [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure.
 
 ### -field cOptItem
 
-CPSUI-supplied number of OPTITEM structures in the array pointed to by **pOptItem**. This is the same number that the application previously supplied in a [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure.
+CPSUI-supplied number of OPTITEM structures in the array pointed to by **pOptItem**. This is the same number that the application previously supplied in a [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure.
 
 ### -field Flags
 
-CPSUI-supplied flags. This is the same set of flags that the application previously supplied in a [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure.
+CPSUI-supplied flags. This is the same set of flags that the application previously supplied in a [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure.
 
 ### -field pCurItem
 
@@ -133,22 +133,22 @@ Defines the **DUMMYUNIONNAME** union.
 
 ### -field DUMMYUNIONNAME.OldSel
 
-If the **Reason** member contains CPSUICB_REASON_SEL_CHANGED, CPSUI sets this union to the previous contents of the **OldSel**/**pOldSel** member of the [**OPTITEM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure pointed to by **pCurItem**.
+If the **Reason** member contains CPSUICB_REASON_SEL_CHANGED, CPSUI sets this union to the previous contents of the **OldSel**/**pOldSel** member of the [**OPTITEM**](./ns-compstui-_optitem.md) structure pointed to by **pCurItem**.
 
 For all other **Reason** values, the contents of this union should be ignored.
 
 ### -field DUMMYUNIONNAME.pOldSel
 
-If the **Reason** member contains CPSUICB_REASON_SEL_CHANGED, CPSUI sets this union to the previous contents of the **OldSel**/**pOldSel** member of the [**OPTITEM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure pointed to by **pCurItem**.
+If the **Reason** member contains CPSUICB_REASON_SEL_CHANGED, CPSUI sets this union to the previous contents of the **OldSel**/**pOldSel** member of the [**OPTITEM**](./ns-compstui-_optitem.md) structure pointed to by **pCurItem**.
 
 For all other **Reason** values, the contents of this union should be ignored.
 
 ### -field UserData
 
-CPSUI-supplied user data. This is the same value that the application previously supplied in a [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure.
+CPSUI-supplied user data. This is the same value that the application previously supplied in a [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure.
 
 ### -field Result
 
-Result value supplied by the [_CPSUICALLBACK](/windows-hardware/drivers/ddi/compstui/nc-compstui-_cpsuicallback)-typed callback function. By default, CPSUI sets this value to CPSUI_OK. After the callback function returns, CPSUI calls its [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function with a function code of [CPSFUNC_SET_RESULT](/previous-versions/ff547087(v=vs.85)), supplying the **Reason** member contents as the result value.
+Result value supplied by the [_CPSUICALLBACK](./nc-compstui-_cpsuicallback.md)-typed callback function. By default, CPSUI sets this value to CPSUI_OK. After the callback function returns, CPSUI calls its [ComPropSheet](./nc-compstui-pfncompropsheet.md) function with a function code of [CPSFUNC_SET_RESULT](/previous-versions/ff547087(v=vs.85)), supplying the **Reason** member contents as the result value.
 
 This member is used only if the **Reason** member is CPSUICB_REASON_APPLYNOW and the callback function does not return CPSUI_ACTION_NO_APPLY_EXIT.

--- a/wdk-ddi-src/content/compstui/ns-compstui-_cpsuidatablock.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_cpsuidatablock.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **CPSUIDATABLOCK** structure is used as a parameter for the [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function, if the function code is [CPSFUNC_SET_DATABLOCK](/previous-versions/ff547036(v=vs.85)) or [CPSFUNC_QUERY_DATABLOCK](/previous-versions/ff546425(v=vs.85)).
+The **CPSUIDATABLOCK** structure is used as a parameter for the [ComPropSheet](./nc-compstui-pfncompropsheet.md) function, if the function code is [CPSFUNC_SET_DATABLOCK](/previous-versions/ff547036(v=vs.85)) or [CPSFUNC_QUERY_DATABLOCK](/previous-versions/ff546425(v=vs.85)).
 
 ## -struct-fields
 

--- a/wdk-ddi-src/content/compstui/ns-compstui-_dlgpage.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_dlgpage.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **DLGPAGE** structure is used for specifying a property sheet page to CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function. The structure's address is included in a [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure, and all member values are supplied by the **ComPropSheet** caller.
+The **DLGPAGE** structure is used for specifying a property sheet page to CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function. The structure's address is included in a [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure, and all member values are supplied by the **ComPropSheet** caller.
 
 ## -struct-fields
 
@@ -108,6 +108,6 @@ Used only if DPF_USE_HDLGTEMPLATE is set in **Flags**.
 
 CPSUI creates a property sheet page by allocating a [**PROPSHEETPAGE**](/windows/win32/controls/pss-propsheetpage) structure and passing it to [CreatePropertySheetPage](/windows/win32/api/prsht/nf-prsht-createpropertysheetpagew). If the caller has specified a DLGPROC-typed pointer to a dialog box procedure in [DlgProc](/windows/win32/api/winuser/nc-winuser-dlgproc), that procedure is used for handling the page's window messages. If DlgProc is **NULL**, CPSUI's own dialog box procedures are used.
 
-When the dialog box procedure pointed to by DlgProc is called with a message value of [WM_INITDIALOG](/windows/win32/dlgbox/wm-initdialog), it receives the **PROPSHEETPAGE** structure as input, and it also receives a [**PSPINFO**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_pspinfo) structure.
+When the dialog box procedure pointed to by DlgProc is called with a message value of [WM_INITDIALOG](/windows/win32/dlgbox/wm-initdialog), it receives the **PROPSHEETPAGE** structure as input, and it also receives a [**PSPINFO**](./ns-compstui-_pspinfo.md) structure.
 
 If a caller-supplied dialog box procedure handles a message, it should return a nonzero value. If the function does not handle the message it should return zero, which causes CPSUI to handle the message.

--- a/wdk-ddi-src/content/compstui/ns-compstui-_extchkbox.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_extchkbox.md
@@ -125,8 +125,8 @@ Reserved, must be initialized to zero.
 
 ## -remarks
 
-An extended check box is a CPSUI-defined type of check box that can be associated with an [**OPTITEM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure. An **OPTITEM** structure can have one extended check box or one extended push button associated with it.
+An extended check box is a CPSUI-defined type of check box that can be associated with an [**OPTITEM**](./ns-compstui-_optitem.md) structure. An **OPTITEM** structure can have one extended check box or one extended push button associated with it.
 
 ## -see-also
 
-[**EXTPUSH**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_extpush)
+[**EXTPUSH**](./ns-compstui-_extpush.md)

--- a/wdk-ddi-src/content/compstui/ns-compstui-_insertpsuipage_info.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_insertpsuipage_info.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **INSERTPSUIPAGE_INFO** structure is used as an input parameter to CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function, if the function code is [CPSFUNC_INSERT_PSUIPAGE](/previous-versions/ff546414(v=vs.85)). All member values must be supplied by the **ComPropSheet** caller.
+The **INSERTPSUIPAGE_INFO** structure is used as an input parameter to CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function, if the function code is [CPSFUNC_INSERT_PSUIPAGE](/previous-versions/ff546414(v=vs.85)). All member values must be supplied by the **ComPropSheet** caller.
 
 ## -struct-fields
 
@@ -61,7 +61,7 @@ Caller-supplied integer value indicating the type of insertion being requested. 
 
 #### PSUIPAGEINSERT_DLL
 
-CPSUI calls the specified [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui) typed function, with a reason value of PROPSHEETUI_REASON_INIT. The function is contained in a separate DLL.
+CPSUI calls the specified [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md) typed function, with a reason value of PROPSHEETUI_REASON_INIT. The function is contained in a separate DLL.
 
 #### PSUIPAGEINSERT_GROUP_PARENT
 
@@ -71,25 +71,25 @@ CPSUI creates a new [group parent](/windows-hardware/drivers/print/group-parent)
 
 CPSUI inserts a page that has been created by calling [CreatePropertySheetPage](/windows/win32/api/prsht/nf-prsht-createpropertysheetpagew).
 
-(This is equivalent to calling [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) with a function code of [CPSFUNC_ADD_HPROPSHEETPAGE](/previous-versions/ff546385(v=vs.85)).)
+(This is equivalent to calling [ComPropSheet](./nc-compstui-pfncompropsheet.md) with a function code of [CPSFUNC_ADD_HPROPSHEETPAGE](/previous-versions/ff546385(v=vs.85)).)
 
 #### PSUIPAGEINSERT_PCOMPROPSHEETUI
 
-CPSUI inserts pages described by a [COMPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure.
+CPSUI inserts pages described by a [COMPROPSHEETUI](./ns-compstui-_compropsheetui.md) structure.
 
-(This is equivalent to calling [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) with a function code of [CPSFUNC_ADD_PCOMPROPSHEETUI](/previous-versions/ff546388(v=vs.85)).)
+(This is equivalent to calling [ComPropSheet](./nc-compstui-pfncompropsheet.md) with a function code of [CPSFUNC_ADD_PCOMPROPSHEETUI](/previous-versions/ff546388(v=vs.85)).)
 
 #### PSUIPAGEINSERT_PFNPROPSHEETUI
 
-CPSUI calls the specified [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui) typed function, with a reason value of PROPSHEETUI_REASON_INIT.
+CPSUI calls the specified [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md) typed function, with a reason value of PROPSHEETUI_REASON_INIT.
 
-(This is equivalent to calling [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) with a function code of [CPSFUNC_ADD_PFNPROPSHEETUI](/previous-versions/ff546391(v=vs.85)).)
+(This is equivalent to calling [ComPropSheet](./nc-compstui-pfncompropsheet.md) with a function code of [CPSFUNC_ADD_PFNPROPSHEETUI](/previous-versions/ff546391(v=vs.85)).)
 
 #### PSUIPAGEINSERT_PROPSHEETPAGE
 
 CPSUI inserts the page described by the specified PROPSHEETPAGE structure.
 
-(This is equivalent to calling [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) with a function code of [CPSFUNC_ADD_PROPSHEETPAGE](/previous-versions/ff546394(v=vs.85)).)
+(This is equivalent to calling [ComPropSheet](./nc-compstui-pfncompropsheet.md) with a function code of [CPSFUNC_ADD_PROPSHEETPAGE](/previous-versions/ff546394(v=vs.85)).)
 
 ### -field Mode
 
@@ -97,29 +97,29 @@ Caller-supplied value indicating where CPSUI should insert the new pages. It mus
 
 #### INSPSUIPAGE_MODE_AFTER
 
-CPSUI inserts pages after the page identified by the CPSUI page handle that is specified by the *lParam1* parameter to [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet).
+CPSUI inserts pages after the page identified by the CPSUI page handle that is specified by the *lParam1* parameter to [ComPropSheet](./nc-compstui-pfncompropsheet.md).
 
 #### INSPSUIPAGE_MODE_BEFORE
 
-CPSUI inserts pages before the page identified by the CPSUI page handle that is specified by the *lParam1* parameter to [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet).
+CPSUI inserts pages before the page identified by the CPSUI page handle that is specified by the *lParam1* parameter to [ComPropSheet](./nc-compstui-pfncompropsheet.md).
 
 #### INSPSUIPAGE_MODE_FIRST_CHILD
 
-CPSUI inserts pages as the first children of the parent group identified by the *hComPropSheet* parameter to [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet).
+CPSUI inserts pages as the first children of the parent group identified by the *hComPropSheet* parameter to [ComPropSheet](./nc-compstui-pfncompropsheet.md).
 
-The *lParam1* parameter to [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) is ignored.
+The *lParam1* parameter to [ComPropSheet](./nc-compstui-pfncompropsheet.md) is ignored.
 
 #### INSPUIPAGE_MODE_INDEX
 
-CPSUI inserts pages as children of the parent group identified by the *hComPropSheet* parameter to [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet).
+CPSUI inserts pages as children of the parent group identified by the *hComPropSheet* parameter to [ComPropSheet](./nc-compstui-pfncompropsheet.md).
 
-The *lParam1* parameter to [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) specifies a zero-based index identifying where, within the set of children, the specified pages should be inserted. If *lParam1* is 0, the pages are inserted starting at page 1; if *lParam1* is 1, the pages are inserted starting at page 2; and so on. If the index is greater than the number of existing children, the new pages are added as the last children. The *lParam1* value must be specified as HINSPSUIPAGE_INDEX(index).
+The *lParam1* parameter to [ComPropSheet](./nc-compstui-pfncompropsheet.md) specifies a zero-based index identifying where, within the set of children, the specified pages should be inserted. If *lParam1* is 0, the pages are inserted starting at page 1; if *lParam1* is 1, the pages are inserted starting at page 2; and so on. If the index is greater than the number of existing children, the new pages are added as the last children. The *lParam1* value must be specified as HINSPSUIPAGE_INDEX(index).
 
 #### INSPSUIPAGE_MODE_LAST_CHILD
 
-CPSUI inserts pages as the last children of the parent group identified by the *hComPropSheet* parameter to [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet).
+CPSUI inserts pages as the last children of the parent group identified by the *hComPropSheet* parameter to [ComPropSheet](./nc-compstui-pfncompropsheet.md).
 
-The *lParam1* parameter to [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) is ignored.
+The *lParam1* parameter to [ComPropSheet](./nc-compstui-pfncompropsheet.md) is ignored.
 
 ### -field dwData1
 
@@ -141,7 +141,7 @@ dwData1, dwData2, and dwData3 members contain caller-supplied values that depend
 
 dwData1 - Caller-supplied pointer to a NULL-terminated string representing the DLL path name.
 
-dwData2 - Caller-supplied pointer to a NULL-terminated string representing the name of a [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui) typed function, contained in the specified DLL.
+dwData2 - Caller-supplied pointer to a NULL-terminated string representing the name of a [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md) typed function, contained in the specified DLL.
 
 dwData3 - Caller-supplied 32-bit value, passed to the PFNPROPSHEETUI-typed function for its *lParam* parameter.
 

--- a/wdk-ddi-src/content/compstui/ns-compstui-_oiext.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_oiext.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **OIEXT** structure supplies additional, optional information about a property sheet page option that is described by an [OPTITEM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure.
+The **OIEXT** structure supplies additional, optional information about a property sheet page option that is described by an [OPTITEM](./ns-compstui-_optitem.md) structure.
 
 ## -struct-fields
 
@@ -65,11 +65,11 @@ Can contain the following bit flag:
 
 ### -field hInstCaller
 
-Instance handle to a DLL containing string and icon resources belonging to the [OPTITEM](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem), [**OPTTYPE**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_opttype), and [**OPTPARAM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optparam) structures associated with the OIEXT structure. If **NULL**, CPSUI obtains resources from the DLL identified by the **hInstCaller** member of a [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure.
+Instance handle to a DLL containing string and icon resources belonging to the [OPTITEM](./ns-compstui-_optitem.md), [**OPTTYPE**](./ns-compstui-_opttype.md), and [**OPTPARAM**](./ns-compstui-_optparam.md) structures associated with the OIEXT structure. If **NULL**, CPSUI obtains resources from the DLL identified by the **hInstCaller** member of a [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure.
 
 ### -field pHelpFile
 
-Pointer to a NULL-terminated string representing a path to a help file containing help information for the option. This can be a 32-bit pointer to a NULL-terminated string, or it can be a 16-bit string resource identifier with HIWORD set to zero. If **NULL**, CPSUI uses the help file identified by the **pHelpFile** member of a [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) structure.
+Pointer to a NULL-terminated string representing a path to a help file containing help information for the option. This can be a 32-bit pointer to a NULL-terminated string, or it can be a 16-bit string resource identifier with HIWORD set to zero. If **NULL**, CPSUI uses the help file identified by the **pHelpFile** member of a [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) structure.
 
 ### -field dwReserved
 

--- a/wdk-ddi-src/content/compstui/ns-compstui-_optparam.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_optparam.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-An array of **OPTPARAM** structures is used by CPSUI applications (including printer interface DLLs) for describing all the parameter values associated with a [property sheet option](/windows-hardware/drivers/print/property-sheet-options). The array's address is included in an [**OPTTYPE**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_opttype) structure.
+An array of **OPTPARAM** structures is used by CPSUI applications (including printer interface DLLs) for describing all the parameter values associated with a [property sheet option](/windows-hardware/drivers/print/property-sheet-options). The array's address is included in an [**OPTTYPE**](./ns-compstui-_opttype.md) structure.
 
 ## -struct-fields
 

--- a/wdk-ddi-src/content/compstui/ns-compstui-_opttype.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_opttype.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **OPTTYPE** structure is used by CPSUI applications (including printer interface DLLs) for describing the type and other characteristics of a [property sheet option](/windows-hardware/drivers/print/property-sheet-options), if the option is specified by an [**OPTITEM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure.
+The **OPTTYPE** structure is used by CPSUI applications (including printer interface DLLs) for describing the type and other characteristics of a [property sheet option](/windows-hardware/drivers/print/property-sheet-options), if the option is specified by an [**OPTITEM**](./ns-compstui-_optitem.md) structure.
 
 ## -struct-fields
 
@@ -65,7 +65,7 @@ Optional bit flags that modify the option's characteristics. The following flags
 
 #### OPTTF_NOSPACE_BEFORE_POSTFIX
 
-CPSUI should not add a space character between the string specified by the [**OPTITEM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optitem) structure's **pName** string and the [**OPTPARAM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optparam) structure's **pData** string, when displaying the option.
+CPSUI should not add a space character between the string specified by the [**OPTITEM**](./ns-compstui-_optitem.md) structure's **pName** string and the [**OPTPARAM**](./ns-compstui-_optparam.md) structure's **pData** string, when displaying the option.
 
 Valid only if the option type is or [TVOT_SCROLLBAR](/windows-hardware/drivers/print/tvot-scrollbar) or [TVOT_TRACKBAR](/windows-hardware/drivers/print/tvot-trackbar).
 
@@ -75,17 +75,17 @@ All the **OPTPARAM** structures to which **pOptParam** points are disabled, so t
 
 ### -field Count
 
-Specifies the number of [**OPTPARAM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optparam) structures to which **pOptParam** points. This member's value is dependent on the [CPSUI option type](/windows-hardware/drivers/print/cpsui-option-types).
+Specifies the number of [**OPTPARAM**](./ns-compstui-_optparam.md) structures to which **pOptParam** points. This member's value is dependent on the [CPSUI option type](/windows-hardware/drivers/print/cpsui-option-types).
 
 ### -field BegCtrlID
 
-If **pDlgPage** in [**COMPROPSHEETUI**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_compropsheetui) identifies a CPSUI-supplied page, or if **DlgTemplateID** in [**DLGPAGE**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_dlgpage) identifies a CPSUI-supplied template, **BegCtrlID** is not used.
+If **pDlgPage** in [**COMPROPSHEETUI**](./ns-compstui-_compropsheetui.md) identifies a CPSUI-supplied page, or if **DlgTemplateID** in [**DLGPAGE**](./ns-compstui-_dlgpage.md) identifies a CPSUI-supplied template, **BegCtrlID** is not used.
 
 Otherwise, **BegCtrlID** must contain the first of a sequentially numbered set of Windows control identifiers. Control identifier usage is dependent on the [CPSUI option type](/windows-hardware/drivers/print/cpsui-option-types).
 
 ### -field pOptParam
 
-Pointer to an array of [**OPTPARAM**](/windows-hardware/drivers/ddi/compstui/ns-compstui-_optparam) structures describing the parameter values that a user can select for the option.
+Pointer to an array of [**OPTPARAM**](./ns-compstui-_optparam.md) structures describing the parameter values that a user can select for the option.
 
 ### -field Style
 

--- a/wdk-ddi-src/content/compstui/ns-compstui-_propsheetui_geticon_info.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_propsheetui_geticon_info.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **PROPSHEETUI_GETICON_INFO** structure is used as an input parameter to an application's [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed function, when the function is called with a reason value of PROPSHEETUI_REASON_GET_ICON.
+The **PROPSHEETUI_GETICON_INFO** structure is used as an input parameter to an application's [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed function, when the function is called with a reason value of PROPSHEETUI_REASON_GET_ICON.
 
 ## -struct-fields
 

--- a/wdk-ddi-src/content/compstui/ns-compstui-_propsheetui_info.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_propsheetui_info.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **PROPSHEETUI_INFO** structure is used as an input parameter to [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed functions.
+The **PROPSHEETUI_INFO** structure is used as an input parameter to [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed functions.
 
 ## -struct-fields
 
@@ -69,7 +69,7 @@ CPSUI-supplied bit flags. The following flag is defined:
 
 ### -field Reason
 
-CPSUI-supplied constant specifying the action to be performed on the property sheet by the [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed function to which the PROPSHEETUI_INFO structure was passed. One of the following constants will be supplied:
+CPSUI-supplied constant specifying the action to be performed on the property sheet by the [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed function to which the PROPSHEETUI_INFO structure was passed. One of the following constants will be supplied:
 
 - PROPSHEETUI_REASON_DESTROY
 
@@ -81,28 +81,28 @@ CPSUI-supplied constant specifying the action to be performed on the property sh
 
 - PROPSHEETUI_REASON_SET_RESULT
 
-For information about the meaning of each constant, see the Remarks section of the [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui) description.
+For information about the meaning of each constant, see the Remarks section of the [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md) description.
 
 ### -field hComPropSheet
 
-CPSUI-supplied handle to a property sheet [group parent](/windows-hardware/drivers/print/group-parent). This handle can be passed to CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function.
+CPSUI-supplied handle to a property sheet [group parent](/windows-hardware/drivers/print/group-parent). This handle can be passed to CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function.
 
 ### -field pfnComPropSheet
 
-Address of CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function.
+Address of CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function.
 
 ### -field lParamInit
 
-Value received as the *lParam* parameter for the associated PFNPROPSHEETUI-typed function, when the function was first called with a **Reason** of PROPSHEETUI_REASON_INIT. For information about what this value can be, see the description of [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui).
+Value received as the *lParam* parameter for the associated PFNPROPSHEETUI-typed function, when the function was first called with a **Reason** of PROPSHEETUI_REASON_INIT. For information about what this value can be, see the description of [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md).
 
 This value is supplied by CPSUI, and is valid for all **Reason** values.
 
 ### -field UserData
 
-Optional, private value or pointer supplied by the associated [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed function, initially set to zero by CPSUI. If the function stores a value in **UserData**, then for subsequent calls to the function, the stored value or pointer is unchanged unless changed by the function.
+Optional, private value or pointer supplied by the associated [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed function, initially set to zero by CPSUI. If the function stores a value in **UserData**, then for subsequent calls to the function, the stored value or pointer is unchanged unless changed by the function.
 
 ### -field Result
 
-Result value supplied by the associated [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed function, initially set to zero by CPSUI. If the function stores a result value in **Result**, then for subsequent calls to the function, the stored value is unchanged unless changed by the function.
+Result value supplied by the associated [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed function, initially set to zero by CPSUI. If the function stores a result value in **Result**, then for subsequent calls to the function, the stored value is unchanged unless changed by the function.
 
-If the PFNPROPSHEETUI-typed function's address was specified as an argument to [CommonPropertySheetUI](/windows-hardware/drivers/ddi/compstui/nf-compstui-commonpropertysheetuia), the last value stored in **Result** is returned to **CommonPropertySheetUI** in the location pointed to by its *pResult* argument.
+If the PFNPROPSHEETUI-typed function's address was specified as an argument to [CommonPropertySheetUI](./nf-compstui-commonpropertysheetuia.md), the last value stored in **Result** is returned to **CommonPropertySheetUI** in the location pointed to by its *pResult* argument.

--- a/wdk-ddi-src/content/compstui/ns-compstui-_propsheetui_info_header.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_propsheetui_info_header.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **PROPSHEETUI_INFO_HEADER** structure is used as an input parameter to an application's [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed function, when the function is called with a reason value of PROPSHEETUI_REASON_GET_INFO_HEADER.
+The **PROPSHEETUI_INFO_HEADER** structure is used as an input parameter to an application's [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed function, when the function is called with a reason value of PROPSHEETUI_REASON_GET_INFO_HEADER.
 
 ## -struct-fields
 
@@ -73,7 +73,7 @@ String identifier, representing text to be displayed in the property sheet's tit
 
 ### -field hWndParent
 
-Handle to the window to be used as the parent of the property sheet. By default, CPSUI supplies the window handle that it received for the *hWndOwner* parameter to [CommonPropertySheetUI](/windows-hardware/drivers/ddi/compstui/nf-compstui-commonpropertysheetuia), but the application can overwrite that handle with another.
+Handle to the window to be used as the parent of the property sheet. By default, CPSUI supplies the window handle that it received for the *hWndOwner* parameter to [CommonPropertySheetUI](./nf-compstui-commonpropertysheetuia.md), but the application can overwrite that handle with another.
 
 ### -field hInst
 

--- a/wdk-ddi-src/content/compstui/ns-compstui-_setresult_info.md
+++ b/wdk-ddi-src/content/compstui/ns-compstui-_setresult_info.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **SETRESULT_INFO** structure is used as an input parameter to an application's [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed callback function.
+The **SETRESULT_INFO** structure is used as an input parameter to an application's [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed callback function.
 
 ## -struct-fields
 
@@ -69,7 +69,7 @@ CPSUI-supplied handle to an added property sheet page, obtained from the applica
 
 ## -remarks
 
-When an application calls CPSUI's [ComPropSheet](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfncompropsheet) function, specifying a function code of [CPSFUNC_SET_RESULT](/previous-versions/ff547087(v=vs.85)), CPSUI calls all registered [PFNPROPSHEETUI](/windows-hardware/drivers/ddi/compstui/nc-compstui-pfnpropsheetui)-typed functions, specifying a reason of PROPSHEETUI_REASON_SET_RESULT. When specifying this reason, CPSUI also supplies a **SETRESULT_INFO** structure.
+When an application calls CPSUI's [ComPropSheet](./nc-compstui-pfncompropsheet.md) function, specifying a function code of [CPSFUNC_SET_RESULT](/previous-versions/ff547087(v=vs.85)), CPSUI calls all registered [PFNPROPSHEETUI](./nc-compstui-pfnpropsheetui.md)-typed functions, specifying a reason of PROPSHEETUI_REASON_SET_RESULT. When specifying this reason, CPSUI also supplies a **SETRESULT_INFO** structure.
 
 The values contained in the structure's **hSetResult** and **Result** members are the *lParam1* and *lParam2* values, respectively, that were supplied to CPSUI's **ComPropSheet** function.
 

--- a/wdk-ddi-src/content/gnssdriver/ni-gnssdriver-ioctl_gnss_create_geofence.md
+++ b/wdk-ddi-src/content/gnssdriver/ni-gnssdriver-ioctl_gnss_create_geofence.md
@@ -50,7 +50,7 @@ The **IOCTL_GNSS_CREATE_GEOFENCE** control code is used by the GNSS adapter to c
 
 ### -input-buffer
 
-A pointer to a [GNSS_GEOFENCE_CREATE_PARAM](/windows-hardware/drivers/ddi/gnssdriver/ns-gnssdriver-gnss_geofence_create_param) structure that defines the geofence to be created.
+A pointer to a [GNSS_GEOFENCE_CREATE_PARAM](./ns-gnssdriver-gnss_geofence_create_param.md) structure that defines the geofence to be created.
 
 ### -input-buffer-length
 
@@ -58,7 +58,7 @@ Set to sizeof(**GNSS_GEOFENCE_CREATE_PARAM**).
 
 ### -output-buffer
 
-A pointer to a [GNSS_GEOFENCE_CREATE_RESPONSE](/windows-hardware/drivers/ddi/gnssdriver/ns-gnssdriver-gnss_geofence_create_response) structure.
+A pointer to a [GNSS_GEOFENCE_CREATE_RESPONSE](./ns-gnssdriver-gnss_geofence_create_response.md) structure.
 
 ### -output-buffer-length
 
@@ -106,8 +106,8 @@ The GNSS engine must adhere to the following guidelines for geofence tracking:
 
 [Creating IOCTL Requests in Drivers](/windows-hardware/drivers/kernel/creating-ioctl-requests-in-drivers)
 
-[WdfIoTargetSendInternalIoctlOthersSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlotherssynchronously)
+[WdfIoTargetSendInternalIoctlOthersSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlotherssynchronously.md)
 
-[WdfIoTargetSendInternalIoctlSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlsynchronously)
+[WdfIoTargetSendInternalIoctlSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlsynchronously.md)
 
-[WdfIoTargetSendIoctlSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendioctlsynchronously)
+[WdfIoTargetSendIoctlSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendioctlsynchronously.md)

--- a/wdk-ddi-src/content/gnssdriver/ni-gnssdriver-ioctl_gnss_delete_geofence.md
+++ b/wdk-ddi-src/content/gnssdriver/ni-gnssdriver-ioctl_gnss_delete_geofence.md
@@ -50,7 +50,7 @@ The **IOCTL_GNSS_DELETE_GEOFENCE** control code is used by the GNSS adapter to d
 
 ### -input-buffer
 
-A pointer to a [GNSS_GEOFENCE_DELETE_PARAM](/windows-hardware/drivers/ddi/gnssdriver/ns-gnssdriver-gnss_geofence_delete_param) structure that defines the geofence to be deleted.
+A pointer to a [GNSS_GEOFENCE_DELETE_PARAM](./ns-gnssdriver-gnss_geofence_delete_param.md) structure that defines the geofence to be deleted.
 
 ### -input-buffer-length
 
@@ -94,8 +94,8 @@ If the geofence is successfully removed, the driver returns STATUS_SUCCESS. If t
 
 [Creating IOCTL Requests in Drivers](/windows-hardware/drivers/kernel/creating-ioctl-requests-in-drivers)
 
-[WdfIoTargetSendInternalIoctlOthersSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlotherssynchronously)
+[WdfIoTargetSendInternalIoctlOthersSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlotherssynchronously.md)
 
-[WdfIoTargetSendInternalIoctlSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlsynchronously)
+[WdfIoTargetSendInternalIoctlSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlsynchronously.md)
 
-[WdfIoTargetSendIoctlSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendioctlsynchronously)
+[WdfIoTargetSendIoctlSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendioctlsynchronously.md)

--- a/wdk-ddi-src/content/gnssdriver/ni-gnssdriver-ioctl_gnss_listen_geofence_alert.md
+++ b/wdk-ddi-src/content/gnssdriver/ni-gnssdriver-ioctl_gnss_listen_geofence_alert.md
@@ -58,7 +58,7 @@ Set to 0.
 
 ### -output-buffer
 
-A pointer to a [GNSS_EVENT](/windows-hardware/drivers/ddi/gnssdriver/ns-gnssdriver-gnss_event) structure.
+A pointer to a [GNSS_EVENT](./ns-gnssdriver-gnss_event.md) structure.
 
 The EventType must be set to **GNSS_Event_GeofenceAlertData** and the **GeofenceAlertData** member filled in.
 
@@ -98,8 +98,8 @@ This IO request is kept pending until an alert is received from the GNSS engine.
 
 [Creating IOCTL Requests in Drivers](/windows-hardware/drivers/kernel/creating-ioctl-requests-in-drivers)
 
-[WdfIoTargetSendInternalIoctlOthersSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlotherssynchronously)
+[WdfIoTargetSendInternalIoctlOthersSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlotherssynchronously.md)
 
-[WdfIoTargetSendInternalIoctlSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlsynchronously)
+[WdfIoTargetSendInternalIoctlSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlsynchronously.md)
 
-[WdfIoTargetSendIoctlSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendioctlsynchronously)
+[WdfIoTargetSendIoctlSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendioctlsynchronously.md)

--- a/wdk-ddi-src/content/gnssdriver/ni-gnssdriver-ioctl_gnss_listen_geofences_trackingstatus.md
+++ b/wdk-ddi-src/content/gnssdriver/ni-gnssdriver-ioctl_gnss_listen_geofences_trackingstatus.md
@@ -58,7 +58,7 @@ Set to 0.
 
 ### -output-buffer
 
-A pointer to a [GNSS_EVENT](/windows-hardware/drivers/ddi/gnssdriver/ns-gnssdriver-gnss_event) structure.
+A pointer to a [GNSS_EVENT](./ns-gnssdriver-gnss_event.md) structure.
 
 The EventType must be set to **GNSS_Event_GeofencesTrackingStatus** and the **GeofencesTrackingStatus** member filled in.
 
@@ -112,8 +112,8 @@ Additionally, if geofence tracking is explicitly reset by the HLOS or the HLOS d
 
 [Creating IOCTL Requests in Drivers](/windows-hardware/drivers/kernel/creating-ioctl-requests-in-drivers)
 
-[WdfIoTargetSendInternalIoctlOthersSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlotherssynchronously)
+[WdfIoTargetSendInternalIoctlOthersSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlotherssynchronously.md)
 
-[WdfIoTargetSendInternalIoctlSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlsynchronously)
+[WdfIoTargetSendInternalIoctlSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendinternalioctlsynchronously.md)
 
-[WdfIoTargetSendIoctlSynchronously](/windows-hardware/drivers/ddi/wdfiotarget/nf-wdfiotarget-wdfiotargetsendioctlsynchronously)
+[WdfIoTargetSendIoctlSynchronously](../wdfiotarget/nf-wdfiotarget-wdfiotargetsendioctlsynchronously.md)

--- a/wdk-ddi-src/content/ks/nc-ks-pfnkspinpower.md
+++ b/wdk-ddi-src/content/ks/nc-ks-pfnkspinpower.md
@@ -47,7 +47,7 @@ An AVStream minidriver's *AVStrMiniPinPower* routine is called for pin-centric p
 
 ### -param Pin [in]
 
-Points to a pin-centric [**KSPIN**](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin) structure for which to register the callback.
+Points to a pin-centric [**KSPIN**](./ns-ks-_kspin.md) structure for which to register the callback.
 
 ### -param State [in]
 
@@ -58,10 +58,10 @@ Specifies the device power state being requested. Set this parameter to one of t
 > [!WARNING]
 > Do not attempt to obtain the filter control mutex from within either the Sleep or Wake callback. Doing so induces a risk of deadlock. For more information about mutexes, see [Mutexes in AVStream](/windows-hardware/drivers/stream/mutexes-in-avstream).
 
-The minidriver specifies an address for routines of this type in the *Sleep* and/or *Wake* parameters of the [KsPinRegisterPowerCallbacks](/windows-hardware/drivers/ddi/ks/nf-ks-kspinregisterpowercallbacks) routine.
+The minidriver specifies an address for routines of this type in the *Sleep* and/or *Wake* parameters of the [KsPinRegisterPowerCallbacks](./nf-ks-kspinregisterpowercallbacks.md) routine.
 
 ## -see-also
 
-[KsFilterRegisterPowerCallbacks](/windows-hardware/drivers/ddi/ks/nf-ks-ksfilterregisterpowercallbacks)
+[KsFilterRegisterPowerCallbacks](./nf-ks-ksfilterregisterpowercallbacks.md)
 
-[KsPinRegisterPowerCallbacks](/windows-hardware/drivers/ddi/ks/nf-ks-kspinregisterpowercallbacks)
+[KsPinRegisterPowerCallbacks](./nf-ks-kspinregisterpowercallbacks.md)

--- a/wdk-ddi-src/content/ks/nf-ks-ksfilterfactoryupdatecachedata.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksfilterfactoryupdatecachedata.md
@@ -48,11 +48,11 @@ The KsFilterFactoryUpdateCacheData function updates the FilterData registry key 
 
 ### -param FilterFactory [in]
 
-The [**KSFILTERFACTORY**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilterfactory) for which to update FilterData and Medium cache in the registry.
+The [**KSFILTERFACTORY**](./ns-ks-_ksfilterfactory.md) for which to update FilterData and Medium cache in the registry.
 
 ### -param FilterDescriptor [in, optional]
 
-An optional [**KSFILTER_DESCRIPTOR**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter_descriptor) for which the FilterData key and Medium cache will be updated. If **NULL**, *FilterFactory*'s descriptor is used instead. Provide if the filter factory uses dynamic pins and needs to update information for pins that have not yet been instantiated.
+An optional [**KSFILTER_DESCRIPTOR**](./ns-ks-_ksfilter_descriptor.md) for which the FilterData key and Medium cache will be updated. If **NULL**, *FilterFactory*'s descriptor is used instead. Provide if the filter factory uses dynamic pins and needs to update information for pins that have not yet been instantiated.
 
 ## -returns
 
@@ -60,9 +60,9 @@ An optional [**KSFILTER_DESCRIPTOR**](/windows-hardware/drivers/ddi/ks/ns-ks-_ks
 
 ## -remarks
 
-This function updates the FilterData key and Medium cache for all categories specified in *FilterDescriptor*. If *FilterDescriptor* is **NULL**, the FilterData and Medium cache are updated for all categories specified in *FilterFactory*'s [**KSFILTER_DESCRIPTOR**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter_descriptor) member.
+This function updates the FilterData key and Medium cache for all categories specified in *FilterDescriptor*. If *FilterDescriptor* is **NULL**, the FilterData and Medium cache are updated for all categories specified in *FilterFactory*'s [**KSFILTER_DESCRIPTOR**](./ns-ks-_ksfilter_descriptor.md) member.
 
-[KsRegisterFilterWithNoKSPins](/windows-hardware/drivers/ddi/ks/nf-ks-ksregisterfilterwithnokspins) provides similar functionality, but should not be used if two instances of [**KSFILTER_DESCRIPTOR**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter_descriptor) under the same [**KSDEVICE**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksdevice) are registered in the same category, and differ only in reference GUID. In this case, **KsRegisterFilterWithNoKSPins** updates data only for the first, even though the second may have been specified.
+[KsRegisterFilterWithNoKSPins](./nf-ks-ksregisterfilterwithnokspins.md) provides similar functionality, but should not be used if two instances of [**KSFILTER_DESCRIPTOR**](./ns-ks-_ksfilter_descriptor.md) under the same [**KSDEVICE**](./ns-ks-_ksdevice.md) are registered in the same category, and differ only in reference GUID. In this case, **KsRegisterFilterWithNoKSPins** updates data only for the first, even though the second may have been specified.
 
 Do not use this routine in place of **KsRegisterFilterWithNoKSPins** for filters with no KS pins, such as analog style crossbars. Use this routine only for a specific filter for which the minidriver is passing the corresponding filter factory.
 
@@ -75,8 +75,8 @@ For more information, see [AVStream Object Hierarchy](/windows-hardware/drivers/
 
 ## -see-also
 
-[**KSFILTERFACTORY**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilterfactory)
+[**KSFILTERFACTORY**](./ns-ks-_ksfilterfactory.md)
 
-[**KSFILTER_DESCRIPTOR**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter_descriptor)
+[**KSFILTER_DESCRIPTOR**](./ns-ks-_ksfilter_descriptor.md)
 
-[KsRegisterFilterWithNoKSPins](/windows-hardware/drivers/ddi/ks/nf-ks-ksregisterfilterwithnokspins)
+[KsRegisterFilterWithNoKSPins](./nf-ks-ksregisterfilterwithnokspins.md)

--- a/wdk-ddi-src/content/ks/nf-ks-ksgeneratethermalevent.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksgeneratethermalevent.md
@@ -50,7 +50,7 @@ There is a check that verifies whether the miniport driver has the query interfa
 
 ### -param Object [in]
 
-Can be [**KSDEVICE**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksdevice), [**KSFILTER**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter), or [**KSPIN**](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin). Depending on the object passed, the thermal notification is sent device-wide, filter-wide, or to the pin.
+Can be [**KSDEVICE**](./ns-ks-_ksdevice.md), [**KSFILTER**](./ns-ks-_ksfilter.md), or [**KSPIN**](./ns-ks-_kspin.md). Depending on the object passed, the thermal notification is sent device-wide, filter-wide, or to the pin.
 
 ### -param Value [in]
 

--- a/wdk-ddi-src/content/ks/nf-ks-kspinattemptprocessing.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspinattemptprocessing.md
@@ -48,7 +48,7 @@ The KsPinAttemptProcessing function is used to resume processing on a specific p
 
 ### -param Pin [in]
 
-A pointer to a [KSPIN](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin) structure that represents the AVStream pin object on which to attempt processing.
+A pointer to a [KSPIN](./ns-ks-_kspin.md) structure that represents the AVStream pin object on which to attempt processing.
 
 > [!WARNING]
 > This parameter is mandatory. If you call KsPinAttemptProcessing with a *Pin* value of **NULL**, system instability may result.
@@ -59,14 +59,14 @@ This parameter indicates the minidriver's preference whether the processing shou
 
 ## -remarks
 
-A minidriver may need to call KsPinAttemptProcessing to resume processing in various situations. For example, if the client has shut off the processing control gate with [KsGateTurnInputOff](/windows-hardware/drivers/ddi/ks/nf-ks-ksgateturninputoff), call this function when ready to attempt processing. Note that this only causes a processing dispatch if the process control gate is in the open state. Another situation involves the minidriver having previously returning STATUS_PENDING to a processing dispatch. For more details, see [Restarting Processing in AVStream](/windows-hardware/drivers/stream/restarting-processing-in-avstream) and [Flow Control Gates in AVStream](/windows-hardware/drivers/stream/flow-control-gates-in-avstream).
+A minidriver may need to call KsPinAttemptProcessing to resume processing in various situations. For example, if the client has shut off the processing control gate with [KsGateTurnInputOff](./nf-ks-ksgateturninputoff.md), call this function when ready to attempt processing. Note that this only causes a processing dispatch if the process control gate is in the open state. Another situation involves the minidriver having previously returning STATUS_PENDING to a processing dispatch. For more details, see [Restarting Processing in AVStream](/windows-hardware/drivers/stream/restarting-processing-in-avstream) and [Flow Control Gates in AVStream](/windows-hardware/drivers/stream/flow-control-gates-in-avstream).
 
 The processing dispatch occurs either synchronously or asynchronously, and *only* if the processing control gate is open. The *Asynchronous* flag specifies the minidriver's preference. If the minidriver requests an asynchronous process dispatch, the dispatch is always asynchronous. However, even if the caller sets *Asynchronous* to **FALSE**, a synchronous dispatch only occurs if the system is currently running at an IRQL less than the maximum processing IRQL. In other words, if the minidriver does not specify dispatch level processing and the call is made at IRQL = DISPATCH_LEVEL, then the call occurs in an asynchronous work item at PASSIVE_LEVEL regardless of the value of *Asynchronous*. For more information, see [Filter-Centric Processing](/windows-hardware/drivers/stream/filter-centric-processing) and [Pin-Centric Processing](/windows-hardware/drivers/stream/pin-centric-processing).
 
 ## -see-also
 
-[**KSFILTER_DISPATCH**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksfilter_dispatch)
+[**KSFILTER_DISPATCH**](./ns-ks-_ksfilter_dispatch.md)
 
-[KsFilterAttemptProcessing](/windows-hardware/drivers/ddi/ks/nf-ks-ksfilterattemptprocessing)
+[KsFilterAttemptProcessing](./nf-ks-ksfilterattemptprocessing.md)
 
-[KsGateCaptureThreshold](/windows-hardware/drivers/ddi/ks/nf-ks-ksgatecapturethreshold)
+[KsGateCaptureThreshold](./nf-ks-ksgatecapturethreshold.md)

--- a/wdk-ddi-src/content/ks/nf-ks-kspinregisterpowercallbacks.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspinregisterpowercallbacks.md
@@ -48,15 +48,15 @@ The KsPinRegisterPowerCallbacks function registers power management callbacks fo
 
 ### -param Pin [in]
 
-A pointer to the [**KSPIN**](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin) structure for which to register power callbacks. Note that the pin must actually process (be pin-centric) in order to receive power notification messages.
+A pointer to the [**KSPIN**](./ns-ks-_kspin.md) structure for which to register power callbacks. Note that the pin must actually process (be pin-centric) in order to receive power notification messages.
 
 ### -param Sleep [in, optional]
 
-This parameter supplies the address of a [AVStrMiniPinPower](/windows-hardware/drivers/ddi/ks/nc-ks-pfnkspinpower)  function that handles sleep requests for the device. Optional.
+This parameter supplies the address of a [AVStrMiniPinPower](./nc-ks-pfnkspinpower.md)  function that handles sleep requests for the device. Optional.
 
 ### -param Wake [in, optional]
 
-This parameter supplies the address of a [AVStrMiniPinPower](/windows-hardware/drivers/ddi/ks/nc-ks-pfnkspinpower)  function that handles wake requests for the device. Optional.
+This parameter supplies the address of a [AVStrMiniPinPower](./nc-ks-pfnkspinpower.md)  function that handles wake requests for the device. Optional.
 
 ## -remarks
 
@@ -67,6 +67,6 @@ At least one of the callbacks must be specified when calling KsPinRegisterPowerC
 
 ## -see-also
 
-[AVStrMiniPinPower](/windows-hardware/drivers/ddi/ks/nc-ks-pfnkspinpower)
+[AVStrMiniPinPower](./nc-ks-pfnkspinpower.md)
 
-[KsFilterRegisterPowerCallbacks](/windows-hardware/drivers/ddi/ks/nf-ks-ksfilterregisterpowercallbacks)
+[KsFilterRegisterPowerCallbacks](./nf-ks-ksfilterregisterpowercallbacks.md)

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointerscheduletimeout.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointerscheduletimeout.md
@@ -48,7 +48,7 @@ The KsStreamPointerScheduleTimeout function registers a timeout callback with AV
 
 ### -param StreamPointer [in]
 
-A pointer to a [**KSSTREAM_POINTER**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksstream_pointer) structure representing the stream pointer for which to register a timeout.
+A pointer to a [**KSSTREAM_POINTER**](./ns-ks-_ksstream_pointer.md) structure representing the stream pointer for which to register a timeout.
 
 ### -param Callback [in]
 
@@ -63,12 +63,12 @@ Specifies the interval in 100-nanosecond units from the current time to the time
 It is safe to call KsStreamPointerScheduleTimeout on a stream pointer that already has a timeout scheduled. In this case, AVStream cancels the previous timeout and replaces it with the new timeout.
 
 > [!NOTE]
-> If you call KsStreamPointerScheduleTimeout while the pin associated with the [**KSSTREAM_POINTER**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksstream_pointer) is still in the pause state, the scheduled timeout may not fire unless another timeout is scheduled later in the run state. At that point, it is possible for all the timeouts that were scheduled during pause to become active and fire immediately in a chain. Also see [Stream Pointers](/windows-hardware/drivers/stream/stream-pointers).
+> If you call KsStreamPointerScheduleTimeout while the pin associated with the [**KSSTREAM_POINTER**](./ns-ks-_ksstream_pointer.md) is still in the pause state, the scheduled timeout may not fire unless another timeout is scheduled later in the run state. At that point, it is possible for all the timeouts that were scheduled during pause to become active and fire immediately in a chain. Also see [Stream Pointers](/windows-hardware/drivers/stream/stream-pointers).
 
 ## -see-also
 
-[**KSSTREAM_POINTER**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksstream_pointer)
+[**KSSTREAM_POINTER**](./ns-ks-_ksstream_pointer.md)
 
-[KsStreamPointerCancelTimeout](/windows-hardware/drivers/ddi/ks/nf-ks-ksstreampointercanceltimeout)
+[KsStreamPointerCancelTimeout](./nf-ks-ksstreampointercanceltimeout.md)
 
-[KsStreamPointerDelete](/windows-hardware/drivers/ddi/ks/nf-ks-ksstreampointerdelete)
+[KsStreamPointerDelete](./nf-ks-ksstreampointerdelete.md)

--- a/wdk-ddi-src/content/ks/ns-ks-_kspin_descriptor_ex.md
+++ b/wdk-ddi-src/content/ks/ns-ks-_kspin_descriptor_ex.md
@@ -53,15 +53,15 @@ The **KSPIN_DESCRIPTOR_EX** structure describes the characteristics of a pin typ
 
 ### -field Dispatch
 
-A pointer to the [**KSPIN_DISPATCH**](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin_dispatch) structure for this pin. This pointer is optional and should only be provided by clients that wish to receive notifications. Clients that need to perform pin-centric processing (filters concerned with the routing of data, in other words hardware drivers) must provide this dispatch table and a process dispatch. See [**KSPIN_DISPATCH**](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin_dispatch) for more information.
+A pointer to the [**KSPIN_DISPATCH**](./ns-ks-_kspin_dispatch.md) structure for this pin. This pointer is optional and should only be provided by clients that wish to receive notifications. Clients that need to perform pin-centric processing (filters concerned with the routing of data, in other words hardware drivers) must provide this dispatch table and a process dispatch. See [**KSPIN_DISPATCH**](./ns-ks-_kspin_dispatch.md) for more information.
 
 ### -field AutomationTable
 
-A pointer to the [KSAUTOMATION_TABLE](/windows-hardware/drivers/ddi/ks/ns-ks-ksautomation_table_) structure for this pin. The automation table contains the properties, methods, and events supported by the pin. This automation table is merged with the automation table provided by AVStream for all pins. If the client supplies any property, event, or method handlers that are already provided by AVStream, the client's implementation supersedes that of AVStream.
+A pointer to the [KSAUTOMATION_TABLE](./ns-ks-ksautomation_table_.md) structure for this pin. The automation table contains the properties, methods, and events supported by the pin. This automation table is merged with the automation table provided by AVStream for all pins. If the client supplies any property, event, or method handlers that are already provided by AVStream, the client's implementation supersedes that of AVStream.
 
 ### -field PinDescriptor
 
-This member specifies a structure of type [**KSPIN_DESCRIPTOR**](/windows-hardware/drivers/ddi/ks/ns-ks-kspin_descriptor).
+This member specifies a structure of type [**KSPIN_DESCRIPTOR**](./ns-ks-kspin_descriptor.md).
 
 ### -field Flags
 
@@ -101,11 +101,11 @@ Specifying this flag causes the queue to force IRPs to be handled in a first-in-
 
 #### KSPIN_FLAG_GENERATE_MAPPINGS
 
-Specifying this flag causes AVStream to automatically generate scatter/gather mappings for a queued frame when the minidriver locks a stream pointer referencing that frame. Clients that intend to use this feature need to register their DMA adapter object with AVStream via the [KsDeviceRegisterAdapterObject](/windows-hardware/drivers/ddi/ks/nf-ks-ksdeviceregisteradapterobject) function. See the **DataUsed** member of [**KSSTREAM_HEADER**](/windows-hardware/drivers/ddi/ks/ns-ks-ksstream_header) for the effect of this flag on the KSSTREAM_HEADER structure. Also see [**KSSTREAM_POINTER_OFFSET**](/windows-hardware/drivers/ddi/ks/ns-ks-_ksstream_pointer_offset).
+Specifying this flag causes AVStream to automatically generate scatter/gather mappings for a queued frame when the minidriver locks a stream pointer referencing that frame. Clients that intend to use this feature need to register their DMA adapter object with AVStream via the [KsDeviceRegisterAdapterObject](./nf-ks-ksdeviceregisteradapterobject.md) function. See the **DataUsed** member of [**KSSTREAM_HEADER**](./ns-ks-ksstream_header.md) for the effect of this flag on the KSSTREAM_HEADER structure. Also see [**KSSTREAM_POINTER_OFFSET**](./ns-ks-_ksstream_pointer_offset.md).
 
 #### KSPIN_FLAG_DISTINCT_TRAILING_EDGE
 
-Indicates that the queue associated with the pin should have a trailing edge stream pointer. The trailing edge pointer is a special stream pointer that points to the oldest data in the queue unless clone pointers exist on older data. Any data frames in the window between the leading and trailing edge stream pointers are considered to have at least one reference count on them and are not completed until they move out of the window by advancing the trailing edge with [KsPinGetTrailingEdgeStreamPointer](/windows-hardware/drivers/ddi/ks/nf-ks-kspingettrailingedgestreampointer) and one of the **KsStreamPointerAdvance***Xxx* or [KsStreamPointerUnlock](/windows-hardware/drivers/ddi/ks/nf-ks-ksstreampointerunlock) functions. Pins that do not specify this flag do not have a trailing edge stream pointer.
+Indicates that the queue associated with the pin should have a trailing edge stream pointer. The trailing edge pointer is a special stream pointer that points to the oldest data in the queue unless clone pointers exist on older data. Any data frames in the window between the leading and trailing edge stream pointers are considered to have at least one reference count on them and are not completed until they move out of the window by advancing the trailing edge with [KsPinGetTrailingEdgeStreamPointer](./nf-ks-kspingettrailingedgestreampointer.md) and one of the **KsStreamPointerAdvance***Xxx* or [KsStreamPointerUnlock](./nf-ks-ksstreampointerunlock.md) functions. Pins that do not specify this flag do not have a trailing edge stream pointer.
 
 #### KSPIN_FLAG_PROCESS_IN_RUN_STATE_ONLY
 
@@ -139,9 +139,9 @@ Specifies that this pin is capable of rendering frames.
 
 When specified on a filter-centric filter pin, indicates that one or more instances of the pin type in question must have frames available in order to process data. Mutually exclusive with KSPIN_FLAG_FRAMES_NOT_REQUIRED_FOR_PROCESSING.
 
-Note that this behavior can be obtained through [KsPinAttachOrGate](/windows-hardware/drivers/ddi/ks/nf-ks-kspinattachorgate) by manually setting up an OR gate as the frame gate for every instance of the pin and attaching this OR gate to the filter's AND gate.
+Note that this behavior can be obtained through [KsPinAttachOrGate](./nf-ks-kspinattachorgate.md) by manually setting up an OR gate as the frame gate for every instance of the pin and attaching this OR gate to the filter's AND gate.
 
-When using this flag, minidrivers cannot call [KsPinAttachAndGate](/windows-hardware/drivers/ddi/ks/nf-ks-kspinattachandgate) or **KsPinAttachOrGate** on the associated pin instances. (The flag effectively does this for you for the simple OR case.) Also see [Filter-Centric Processing](/windows-hardware/drivers/stream/filter-centric-processing).
+When using this flag, minidrivers cannot call [KsPinAttachAndGate](./nf-ks-kspinattachandgate.md) or **KsPinAttachOrGate** on the associated pin instances. (The flag effectively does this for you for the simple OR case.) Also see [Filter-Centric Processing](/windows-hardware/drivers/stream/filter-centric-processing).
 
 #### KSPIN_FLAG_PROCESS_IF_ANY_IN_RUN_STATE
 
@@ -165,7 +165,7 @@ Specifies a value of type ULONG that contains the minimum number of pins of a gi
 
 ### -field AllocatorFraming
 
-A pointer to a [**KSALLOCATOR_FRAMING_EX**](/windows-hardware/drivers/ddi/ks/ns-ks-ksallocator_framing_ex) structure containing the allocator framing requirements for this pin type. Allocator framing specifies items such as memory alignment requirements, maximum frame size, and minimum frame size. This member can be **NULL**, which indicates that this pin does not support the allocator framing property.
+A pointer to a [**KSALLOCATOR_FRAMING_EX**](./ns-ks-ksallocator_framing_ex.md) structure containing the allocator framing requirements for this pin type. Allocator framing specifies items such as memory alignment requirements, maximum frame size, and minimum frame size. This member can be **NULL**, which indicates that this pin does not support the allocator framing property.
 
 ### -field IntersectHandler
 
@@ -184,10 +184,10 @@ Furthermore, if you specify KSPIN_FLAG_DO_NOT_INITIATE_PROCESSING and the pin us
 
 ## -see-also
 
-[**KSALLOCATOR_FRAMING_EX**](/windows-hardware/drivers/ddi/ks/ns-ks-ksallocator_framing_ex)
+[**KSALLOCATOR_FRAMING_EX**](./ns-ks-ksallocator_framing_ex.md)
 
-[**KSPIN_DESCRIPTOR**](/windows-hardware/drivers/ddi/ks/ns-ks-kspin_descriptor)
+[**KSPIN_DESCRIPTOR**](./ns-ks-kspin_descriptor.md)
 
-[**KSPIN_DISPATCH**](/windows-hardware/drivers/ddi/ks/ns-ks-_kspin_dispatch)
+[**KSPIN_DISPATCH**](./ns-ks-_kspin_dispatch.md)
 
-[KsDeviceRegisterAdapterObject](/windows-hardware/drivers/ddi/ks/nf-ks-ksdeviceregisteradapterobject)
+[KsDeviceRegisterAdapterObject](./nf-ks-ksdeviceregisteradapterobject.md)

--- a/wdk-ddi-src/content/ksmedia/ns-ksmedia-_kscamera_profile_info.md
+++ b/wdk-ddi-src/content/ksmedia/ns-ksmedia-_kscamera_profile_info.md
@@ -64,7 +64,7 @@ Each profile within a given **ProfileId** group must have a unique **Index** val
 
 ### -field PinCount
 
-The number of [**KSCAMERA_PROFILE_PININFO**](/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-_kscamera_profile_pininfo) structures pointed to by **Pins**.  This value must be greater than 0.
+The number of [**KSCAMERA_PROFILE_PININFO**](./ns-ksmedia-_kscamera_profile_pininfo.md) structures pointed to by **Pins**.  This value must be greater than 0.
 
 ### -field Pins
 

--- a/wdk-ddi-src/content/ksmedia/ns-ksmedia-ksaudio_channel_config.md
+++ b/wdk-ddi-src/content/ksmedia/ns-ksmedia-ksaudio_channel_config.md
@@ -183,4 +183,4 @@ For a PCM format with a 16-bit sample size, each block of audio data occupies 12
 
 [KSPROPERTY_AUDIO_CHANNEL_CONFIG](/windows-hardware/drivers/audio/ksproperty-audio-channel-config)
 
-[WAVEFORMATEXTENSIBLE](/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-waveformatextensible)
+[WAVEFORMATEXTENSIBLE](./ns-ksmedia-waveformatextensible.md)

--- a/wdk-ddi-src/content/ksproxy/nf-ksproxy-ikspropertyset-get.md
+++ b/wdk-ddi-src/content/ksproxy/nf-ksproxy-ikspropertyset-get.md
@@ -86,4 +86,4 @@ To retrieve a property, allocate a buffer, which **Get** fills with the property
 
 ## -see-also
 
-[IKsPropertySet::Set](/windows-hardware/drivers/ddi/dsound/nf-dsound-ikspropertyset-set)
+[IKsPropertySet::Set](../dsound/nf-dsound-ikspropertyset-set.md)

--- a/wdk-ddi-src/content/ksproxy/nf-ksproxy-ikspropertyset-querysupported.md
+++ b/wdk-ddi-src/content/ksproxy/nf-ksproxy-ikspropertyset-querysupported.md
@@ -59,8 +59,8 @@ Pointer to a variable that receives a bitmask enumerating the flags that indicat
 
 | Value | Description |
 |---|---|
-| KSPROPERTY_SUPPORT_GET | Supports retrieving a property. Use the [IKsPropertySet::Get](/windows-hardware/drivers/ddi/ksproxy/nf-ksproxy-ikspropertyset-get) method to retrieve the property. |
-| KSPROPERTY_SUPPORT_SET | Supports setting a property. Use the [IKsPropertySet::Set](/windows-hardware/drivers/ddi/dsound/nf-dsound-ikspropertyset-set) method to set the property. |
+| KSPROPERTY_SUPPORT_GET | Supports retrieving a property. Use the [IKsPropertySet::Get](./nf-ksproxy-ikspropertyset-get.md) method to retrieve the property. |
+| KSPROPERTY_SUPPORT_SET | Supports setting a property. Use the [IKsPropertySet::Set](../dsound/nf-dsound-ikspropertyset-set.md) method to set the property. |
 
 ## -returns
 
@@ -81,6 +81,6 @@ KS objects include, for example, KS filters, KS pins, and KS clocks.
 
 ## -see-also
 
-[IKsPropertySet::Get](/windows-hardware/drivers/ddi/ksproxy/nf-ksproxy-ikspropertyset-get)
+[IKsPropertySet::Get](./nf-ksproxy-ikspropertyset-get.md)
 
-[IKsPropertySet::Set](/windows-hardware/drivers/ddi/dsound/nf-dsound-ikspropertyset-set)
+[IKsPropertySet::Set](../dsound/nf-dsound-ikspropertyset-set.md)

--- a/wdk-ddi-src/content/ksproxy/nf-ksproxy-ikspropertyset-set.md
+++ b/wdk-ddi-src/content/ksproxy/nf-ksproxy-ikspropertyset-set.md
@@ -80,4 +80,4 @@ Returns NOERROR if successful; otherwise, returns an error code.
 
 ## -see-also
 
-[IKsPropertySet::Get](/windows-hardware/drivers/ddi/ksproxy/nf-ksproxy-ikspropertyset-get)
+[IKsPropertySet::Get](./nf-ksproxy-ikspropertyset-get.md)

--- a/wdk-ddi-src/content/miniport/ns-miniport-_io_resource_descriptor.md
+++ b/wdk-ddi-src/content/miniport/ns-miniport-_io_resource_descriptor.md
@@ -47,7 +47,7 @@ api_name:
 
 ## -description
 
-The **IO_RESOURCE_DESCRIPTOR** structure describes a range of raw hardware resources, of one type, that can be used by a device. An array of **IO_RESOURCE_DESCRIPTOR** structures is contained within each [**IO_RESOURCE_LIST**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_io_resource_list) structure.
+The **IO_RESOURCE_DESCRIPTOR** structure describes a range of raw hardware resources, of one type, that can be used by a device. An array of **IO_RESOURCE_DESCRIPTOR** structures is contained within each [**IO_RESOURCE_LIST**](../wdm/ns-wdm-_io_resource_list.md) structure.
 
 ## -struct-fields
 
@@ -64,11 +64,11 @@ Specifies whether this resource description is required, preferred, or alternati
 
 ### -field Type
 
-Identifies the resource type. For a list of valid values, see the **Type** member of the [**CM_PARTIAL_RESOURCE_DESCRIPTOR**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_cm_partial_resource_descriptor) structure.
+Identifies the resource type. For a list of valid values, see the **Type** member of the [**CM_PARTIAL_RESOURCE_DESCRIPTOR**](../wdm/ns-wdm-_cm_partial_resource_descriptor.md) structure.
 
 ### -field ShareDisposition
 
-Indicates whether the described resource can be shared. For a list of valid values, see the **ShareDisposition** member of the [**CM_PARTIAL_RESOURCE_DESCRIPTOR**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_cm_partial_resource_descriptor) structure.
+Indicates whether the described resource can be shared. For a list of valid values, see the **ShareDisposition** member of the [**CM_PARTIAL_RESOURCE_DESCRIPTOR**](../wdm/ns-wdm-_cm_partial_resource_descriptor.md) structure.
 
 ### -field Spare1
 
@@ -87,7 +87,7 @@ Contains bit flags that are specific to the resource type. The following table s
 | **CM_RESOURCE_INTERRUPT_SECONDARY_INTERRUPT** | The interrupt is a secondary interrupt. For more information about secondary interrupts, see [GPIO Interrupts](/windows-hardware/drivers/gpio/gpio-interrupts). |
 | **CM_RESOURCE_INTERRUPT_WAKE_HINT** | The interrupt is capable of waking the operating system from a low-power idle state or a system sleep state.  For more information about wake capabilities, see [Enabling Device Wake-Up](/windows-hardware/drivers/kernel/enabling-device-wake-up). |
 
-For a list of valid flags for other resource types, see the description of the **Flags** member of the [**CM_PARTIAL_RESOURCE_DESCRIPTOR**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_cm_partial_resource_descriptor) structure.
+For a list of valid flags for other resource types, see the description of the **Flags** member of the [**CM_PARTIAL_RESOURCE_DESCRIPTOR**](../wdm/ns-wdm-_cm_partial_resource_descriptor.md) structure.
 
 ### -field Spare2
 
@@ -101,7 +101,7 @@ Defines the **u** union.
 
 Specifies a range of I/O port addresses, using the following members.
 
-Drivers must use [RtlIoDecodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtliodecodememioresource) and [RtlIoEncodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlioencodememioresource) to read and update this member, rather than updating it directly.
+Drivers must use [RtlIoDecodeMemIoResource](../wdm/nf-wdm-rtliodecodememioresource.md) and [RtlIoEncodeMemIoResource](../wdm/nf-wdm-rtlioencodememioresource.md) to read and update this member, rather than updating it directly.
 
 ### -field u.Port.Length
 
@@ -123,7 +123,7 @@ The maximum bus-relative I/O port address that can be assigned to the device.
 
 Specifies a range of memory addresses, using the following members:
 
-Drivers must use [RtlIoDecodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtliodecodememioresource) and [RtlIoEncodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlioencodememioresource) to read and update this member, rather than updating it directly.
+Drivers must use [RtlIoDecodeMemIoResource](../wdm/nf-wdm-rtliodecodememioresource.md) and [RtlIoEncodeMemIoResource](../wdm/nf-wdm-rtlioencodememioresource.md) to read and update this member, rather than updating it directly.
 
 ### -field u.Memory.Length
 
@@ -161,13 +161,13 @@ Specifies a processor group number. **Group** is a valid (but optional) member o
 
 ### -field u.Interrupt.AffinityPolicy
 
-Specifies an [IRQ_DEVICE_POLICY](/windows-hardware/drivers/ddi/wdm/ne-wdm-_irq_device_policy) value that indicates how the system should distribute a device's interrupts between processors.
+Specifies an [IRQ_DEVICE_POLICY](../wdm/ne-wdm-_irq_device_policy.md) value that indicates how the system should distribute a device's interrupts between processors.
 
-Specifies an [IRQ_DEVICE_POLICY](/windows-hardware/drivers/ddi/wdm/ne-wdm-_irq_device_policy) value that indicates how the system should distribute a device's interrupts between processors.
+Specifies an [IRQ_DEVICE_POLICY](../wdm/ne-wdm-_irq_device_policy.md) value that indicates how the system should distribute a device's interrupts between processors.
 
 ### -field u.Interrupt.PriorityPolicy
 
-Specifies an [IRQ_PRIORITY](/windows-hardware/drivers/ddi/wdm/ne-wdm-_irq_priority) value that indicates the priority with which the system should dispatch the device's interrupts.
+Specifies an [IRQ_PRIORITY](../wdm/ne-wdm-_irq_priority.md) value that indicates the priority with which the system should dispatch the device's interrupts.
 
 ### -field u.Interrupt.TargetedProcessors
 
@@ -187,7 +187,7 @@ The maximum bus-relative DMA channel that can be assigned to the device.
 
 ### -field u.DmaV3
 
-Specifies the DMA settings for a driver that uses version 3 of the [DMA_OPERATIONS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_dma_operations) structure.
+Specifies the DMA settings for a driver that uses version 3 of the [DMA_OPERATIONS](../wdm/ns-wdm-_dma_operations.md) structure.
 
 The **u.DmaV3** member is available starting with Windows 8.
 
@@ -275,7 +275,7 @@ Reserved for system use.
 
 Specifies a range of memory addresses, using the following members.
 
-Drivers must use [RtlIoDecodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtliodecodememioresource) and [RtlIoEncodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlioencodememioresource) to read and update this member, rather than updating it directly.
+Drivers must use [RtlIoDecodeMemIoResource](../wdm/nf-wdm-rtliodecodememioresource.md) and [RtlIoEncodeMemIoResource](../wdm/nf-wdm-rtlioencodememioresource.md) to read and update this member, rather than updating it directly.
 
 ### -field u.Memory40.Length40
 
@@ -297,7 +297,7 @@ The maximum bus-relative memory address that can be assigned to the device.
 
 Specifies a range of memory addresses, using the following members.
 
-Drivers must use [RtlIoDecodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtliodecodememioresource) and [RtlIoEncodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlioencodememioresource) to read and update this member, rather than updating it directly.
+Drivers must use [RtlIoDecodeMemIoResource](../wdm/nf-wdm-rtliodecodememioresource.md) and [RtlIoEncodeMemIoResource](../wdm/nf-wdm-rtlioencodememioresource.md) to read and update this member, rather than updating it directly.
 
 ### -field u.Memory48.Length48
 
@@ -319,7 +319,7 @@ The maximum bus-relative memory address that can be assigned to the device.
 
 Specifies a range of memory addresses, using the following members.
 
-Drivers must use [RtlIoDecodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtliodecodememioresource) and [RtlIoEncodeMemIoResource](/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlioencodememioresource) to read and update this member, rather than updating it directly.
+Drivers must use [RtlIoDecodeMemIoResource](../wdm/nf-wdm-rtliodecodememioresource.md) and [RtlIoEncodeMemIoResource](../wdm/nf-wdm-rtlioencodememioresource.md) to read and update this member, rather than updating it directly.
 
 ### -field u.Memory64.Length64
 
@@ -391,10 +391,10 @@ The upper 32 bits of the 64-bit connection ID.
 
 ## -see-also
 
-[CM_PARTIAL_RESOURCE_DESCRIPTOR](/windows-hardware/drivers/ddi/wdm/ns-wdm-_cm_partial_resource_descriptor)
+[CM_PARTIAL_RESOURCE_DESCRIPTOR](../wdm/ns-wdm-_cm_partial_resource_descriptor.md)
 
-[IO_RESOURCE_LIST](/windows-hardware/drivers/ddi/wdm/ns-wdm-_io_resource_list)
+[IO_RESOURCE_LIST](../wdm/ns-wdm-_io_resource_list.md)
 
-[IO_RESOURCE_REQUIREMENTS_LIST](/windows-hardware/drivers/ddi/wdm/ns-wdm-_io_resource_requirements_list)
+[IO_RESOURCE_REQUIREMENTS_LIST](../wdm/ns-wdm-_io_resource_requirements_list.md)
 
-[IoConnectInterrupt](/windows-hardware/drivers/ddi/wdm/nf-wdm-ioconnectinterrupt)
+[IoConnectInterrupt](../wdm/nf-wdm-ioconnectinterrupt.md)

--- a/wdk-ddi-src/content/poscx/ne-poscx-_pos_cx_event_attributes.md
+++ b/wdk-ddi-src/content/poscx/ne-poscx-_pos_cx_event_attributes.md
@@ -45,7 +45,7 @@ api_name:
 
 ## -description
 
-The POS_CX_EVENT_ATTRIBUTES enumeration describes the priority and access rights for the POS events coming from the device. The values are a combination of the values defined in [POS_CX_EVENT_DEST](/windows-hardware/drivers/ddi/poscx/ne-poscx-_pos_cx_event_dest) and [POS_CX_EVENT_PRIORITY](/windows-hardware/drivers/ddi/poscx/ne-poscx-_pos_cx_event_priority).
+The POS_CX_EVENT_ATTRIBUTES enumeration describes the priority and access rights for the POS events coming from the device. The values are a combination of the values defined in [POS_CX_EVENT_DEST](./ne-poscx-_pos_cx_event_dest.md) and [POS_CX_EVENT_PRIORITY](./ne-poscx-_pos_cx_event_priority.md).
 
 ## -enum-fields
 
@@ -68,6 +68,6 @@ Control level priority delivered in FIFO to ALL open handles on the driver.
 
 ## -see-also
 
-[POS_CX_EVENT_DEST](/windows-hardware/drivers/ddi/poscx/ne-poscx-_pos_cx_event_dest)
+[POS_CX_EVENT_DEST](./ne-poscx-_pos_cx_event_dest.md)
 
-[POS_CX_EVENT_PRIORITY](/windows-hardware/drivers/ddi/poscx/ne-poscx-_pos_cx_event_priority)
+[POS_CX_EVENT_PRIORITY](./ne-poscx-_pos_cx_event_priority.md)

--- a/wdk-ddi-src/content/wdffdo/nc-wdffdo-evt_wdf_device_filter_resource_requirements.md
+++ b/wdk-ddi-src/content/wdffdo/nc-wdffdo-evt_wdf_device_filter_resource_requirements.md
@@ -83,9 +83,8 @@ For more information about these callback functions, see <a href="/windows-hardw
 
 For more information about hardware resources and resource requirements lists, see <a href="/windows-hardware/drivers/wdf/hardware-resources-for-kmdf-drivers">Hardware Resources for Framework-Based Drivers</a>.
 
-For information about modifying interrupt resources (for example processor affinity), see the Remarks section of [**WdfInterruptSetPolicy**](/windows-hardware/drivers/ddi/wdfinterrupt/nf-wdfinterrupt-wdfinterruptsetpolicy).
+For information about modifying interrupt resources (for example processor affinity), see the Remarks section of [**WdfInterruptSetPolicy**](../wdfinterrupt/nf-wdfinterrupt-wdfinterruptsetpolicy.md).
 
 ## -see-also
 
 <a href="/windows-hardware/drivers/ddi/wdffdo/nc-wdffdo-evt_wdf_device_remove_added_resources">EvtDeviceRemoveAddedResources</a>
-

--- a/wdk-ddi-src/content/wdm/nc-wdm-pbuild_scatter_gather_list.md
+++ b/wdk-ddi-src/content/wdm/nc-wdm-pbuild_scatter_gather_list.md
@@ -47,7 +47,7 @@ The **BuildScatterGatherList** routine prepares the system for a DMA operation, 
 
 ### -param DmaAdapter [in]
 
-Pointer to the [DMA_ADAPTER](/windows-hardware/drivers/ddi/wdm/ns-wdm-_dma_adapter) structure returned by [IoGetDmaAdapter](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdmaadapter) that represents the bus-master adapter or DMA controller.
+Pointer to the [DMA_ADAPTER](./ns-wdm-_dma_adapter.md) structure returned by [IoGetDmaAdapter](./nf-wdm-iogetdmaadapter.md) that represents the bus-master adapter or DMA controller.
 
 ### -param DeviceObject [in]
 
@@ -67,7 +67,7 @@ Specifies the length, in bytes, of the buffer to be mapped.
 
 ### -param ExecutionRoutine [in]
 
-Pointer to a driver-supplied [AdapterListControl](/windows-hardware/drivers/ddi/wdm/nc-wdm-driver_list_control) routine, which is called at IRQL = DISPATCH_LEVEL when the system DMA controller or bus-master adapter is available.
+Pointer to a driver-supplied [AdapterListControl](./nc-wdm-driver_list_control.md) routine, which is called at IRQL = DISPATCH_LEVEL when the system DMA controller or bus-master adapter is available.
 
 ### -param Context [in]
 
@@ -79,7 +79,7 @@ Indicates the direction of the DMA transfer: **TRUE** for a transfer from the bu
 
 ### -param ScatterGatherBuffer [in]
 
-Pointer to the caller-supplied buffer that the routine fills with a [SCATTER_GATHER_LIST](/windows-hardware/drivers/ddi/wdm/ns-wdm-_scatter_gather_list) structure.
+Pointer to the caller-supplied buffer that the routine fills with a [SCATTER_GATHER_LIST](./ns-wdm-_scatter_gather_list.md) structure.
 
 ### -param ScatterGatherLength [in]
 
@@ -97,32 +97,32 @@ Specifies the size, in bytes, of the buffer passed in the *ScatterGatherBuffer* 
 
 ## -remarks
 
-**BuildScatterGatherList** is not a system routine that can be called directly by name. This routine can be called only by pointer from the address returned in a           [DMA_OPERATIONS](/windows-hardware/drivers/ddi/wdm/ns-wdm-_dma_operations) structure. Drivers obtain the address of this routine by calling [IoGetDmaAdapter](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdmaadapter) with the **Version** member of the *DeviceDescription* parameter set to DEVICE_DESCRIPTION_VERSION2. If **IoGetDmaAdapter** returns **NULL**, the routine is not available on your platform.
+**BuildScatterGatherList** is not a system routine that can be called directly by name. This routine can be called only by pointer from the address returned in a           [DMA_OPERATIONS](./ns-wdm-_dma_operations.md) structure. Drivers obtain the address of this routine by calling [IoGetDmaAdapter](./nf-wdm-iogetdmaadapter.md) with the **Version** member of the *DeviceDescription* parameter set to DEVICE_DESCRIPTION_VERSION2. If **IoGetDmaAdapter** returns **NULL**, the routine is not available on your platform.
 
-**BuildScatterGatherList** performs the same operation as [GetScatterGatherList](/windows-hardware/drivers/ddi/wdm/nc-wdm-pget_scatter_gather_list), except that it uses the buffer supplied in the *ScatterGatherBuffer* parameter to hold the scatter/gather list that it creates. In contrast, **GetScatterGatherList** dynamically allocates a buffer to hold the scatter/gather list. If insufficient memory is available to allocate the buffer, **GetScatterGatherList** can fail with a STATUS_INSUFFICIENT_RESOURCES error. Drivers that must avoid this scenario can preallocate a buffer to hold the scatter/gather list, and use **BuildScatterGatherList** instead.
+**BuildScatterGatherList** performs the same operation as [GetScatterGatherList](./nc-wdm-pget_scatter_gather_list.md), except that it uses the buffer supplied in the *ScatterGatherBuffer* parameter to hold the scatter/gather list that it creates. In contrast, **GetScatterGatherList** dynamically allocates a buffer to hold the scatter/gather list. If insufficient memory is available to allocate the buffer, **GetScatterGatherList** can fail with a STATUS_INSUFFICIENT_RESOURCES error. Drivers that must avoid this scenario can preallocate a buffer to hold the scatter/gather list, and use **BuildScatterGatherList** instead.
 
-A driver can use the [CalculateScatterGatherList](/windows-hardware/drivers/ddi/wdm/nc-wdm-pcalculate_scatter_gather_list_size) routine to determine the size of buffer to allocate to hold the scatter/gather list.
+A driver can use the [CalculateScatterGatherList](./nc-wdm-pcalculate_scatter_gather_list_size.md) routine to determine the size of buffer to allocate to hold the scatter/gather list.
 
-The driver should retain the pointer to the scatter/gather list in *ScatterGatherBuffer* for use when the driver calls [PutScatterGatherList](/windows-hardware/drivers/ddi/wdm/nc-wdm-pput_scatter_gather_list). The driver must call **PutScatterGatherList** (which flushes the list) before it can access the data in the list.
+The driver should retain the pointer to the scatter/gather list in *ScatterGatherBuffer* for use when the driver calls [PutScatterGatherList](./nc-wdm-pput_scatter_gather_list.md). The driver must call **PutScatterGatherList** (which flushes the list) before it can access the data in the list.
 
 ## -see-also
 
-[BuildMdlFromScatterGatherList](/windows-hardware/drivers/ddi/wdm/nc-wdm-pbuild_mdl_from_scatter_gather_list)
+[BuildMdlFromScatterGatherList](./nc-wdm-pbuild_mdl_from_scatter_gather_list.md)
 
-[CalculateScatterGatherList](/windows-hardware/drivers/ddi/wdm/nc-wdm-pcalculate_scatter_gather_list_size)
+[CalculateScatterGatherList](./nc-wdm-pcalculate_scatter_gather_list_size.md)
 
-[**DEVICE_DESCRIPTION**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_device_description)
+[**DEVICE_DESCRIPTION**](./ns-wdm-_device_description.md)
 
-[**DEVICE_OBJECT**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_device_object)
+[**DEVICE_OBJECT**](./ns-wdm-_device_object.md)
 
-[**DMA_ADAPTER**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_dma_adapter)
+[**DMA_ADAPTER**](./ns-wdm-_dma_adapter.md)
 
-[**DMA_OPERATIONS**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_dma_operations)
+[**DMA_OPERATIONS**](./ns-wdm-_dma_operations.md)
 
-[GetScatterGatherList](/windows-hardware/drivers/ddi/wdm/nc-wdm-pget_scatter_gather_list)
+[GetScatterGatherList](./nc-wdm-pget_scatter_gather_list.md)
 
-[IoGetDmaAdapter](/windows-hardware/drivers/ddi/wdm/nf-wdm-iogetdmaadapter)
+[IoGetDmaAdapter](./nf-wdm-iogetdmaadapter.md)
 
-[PutScatterGatherList](/windows-hardware/drivers/ddi/wdm/nc-wdm-pput_scatter_gather_list)
+[PutScatterGatherList](./nc-wdm-pput_scatter_gather_list.md)
 
-[**SCATTER_GATHER_LIST**](/windows-hardware/drivers/ddi/wdm/ns-wdm-_scatter_gather_list)
+[**SCATTER_GATHER_LIST**](./ns-wdm-_scatter_gather_list.md)

--- a/wdk-ddi-src/content/winddiui/nf-winddiui-drvdocumentevent.md
+++ b/wdk-ddi-src/content/winddiui/nf-winddiui-drvdocumentevent.md
@@ -90,12 +90,12 @@ Caller-supplied pointer, the use of which is dependent on the value supplied for
 |---|---|
 | DOCUMENTEVENT_ABORTDOC | Not used. |
 | DOCUMENTEVENT_CREATEDCPOST | *pvIn* contains the address of a pointer to the [**DEVMODEW**](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure specified in the *pvOut* parameter in a previous call to this function, for which the *iEsc* parameter was set to DOCUMENTEVENT_CREATEDCPRE. |
-| DOCUMENTEVENT_CREATEDCPRE | *pvIn* points to a [**DOCEVENT_CREATEDCPRE**](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_docevent_createdcpre) structure. |
+| DOCUMENTEVENT_CREATEDCPRE | *pvIn* points to a [**DOCEVENT_CREATEDCPRE**](./ns-winddiui-_docevent_createdcpre.md) structure. |
 | DOCUMENTEVENT_DELETEDC | Not used. |
 | DOCUMENTEVENT_ENDDOCPOST | Not used. |
 | DOCUMENTEVENT_ENDDOCPRE or DOCUMENTEVENT_ENDDOC | Not used. |
 | DOCUMENTEVENT_ENDPAGE | Not used. |
-| DOCUMENTEVENT_ESCAPE | *pvIn* points to a [**DOCEVENT_ESCAPE**](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_docevent_escape) structure. |
+| DOCUMENTEVENT_ESCAPE | *pvIn* points to a [**DOCEVENT_ESCAPE**](./ns-winddiui-_docevent_escape.md) structure. |
 | DOCUMENTEVENT_QUERYFILTER | Same as for DOCUMENTEVENT_CREATEDCPRE. |
 | DOCUMENTEVENT_RESETDCPOST | *pvIn* contains the address of a pointer to the [**DEVMODEW**](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure specified in the *pvOut* parameter in a previous call to this function, for which the *iEsc* parameter was set to DOCUMENTEVENT_RESETDCPRE. |
 | DOCUMENTEVENT_RESETDCPRE | *pvIn* contains the address of a pointer to the [**DEVMODEW**](/windows/win32/api/wingdi/ns-wingdi-devmodew) structure supplied by the caller of the [**ResetDC**](/windows/win32/api/wingdi/nf-wingdi-resetdca) function. |
@@ -125,7 +125,7 @@ Function-supplied pointer to an output buffer, the use of which is dependent on 
 |---|---|
 | DOCUMENTEVENT_CREATEDCPRE | Pointer to a driver-supplied DEVMODEW structure, which GDI uses instead of the one supplied by the [**CreateDC**](/windows/win32/api/wingdi/nf-wingdi-createdca) caller. (If **NULL**, GDI uses the caller-supplied structure.) |
 | DOCUMENTEVENT_ESCAPE | Buffer pointer that is used as the *lpszOutData* parameter for the [**ExtEscape**](/windows/win32/api/wingdi/nf-wingdi-extescape) function. |
-| DOCUMENTEVENT_QUERYFILTER | Caller-supplied pointer to buffer containing a [**DOCEVENT_FILTER**](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_docevent_filter) structure. |
+| DOCUMENTEVENT_QUERYFILTER | Caller-supplied pointer to buffer containing a [**DOCEVENT_FILTER**](./ns-winddiui-_docevent_filter.md) structure. |
 | DOCUMENTEVENT_RESETDCPRE | Pointer to a driver-supplied DEVMODEW structure, which GDI uses instead of the one supplied by the [**ResetDC**](/windows/win32/api/wingdi/nf-wingdi-resetdca) function caller. (If **NULL**, GDI uses the caller-supplied structure.) |
 | All other *iEsc* values | Not used. |
 
@@ -143,12 +143,12 @@ The function's return value is dependent on the escape supplied for *iEsc*. For 
 
 A [printer interface DLL](/windows-hardware/drivers/print/printer-interface-dll) can optionally provide a **DrvDocumentEvent** function to perform preprocessing or postprocessing of GDI calls associated with rendering a document. Calls to the **DrvDocumentEvent** function are made from the user-mode GDI client, when an application makes calls into the GDI client.
 
-For an *iEsc* value of DOCUMENTEVENT_QUERYFILTER, the spooler can interpret a DOCUMENTEVENT_SUCCESS value returned by **DrvDocumentEvent** in two ways, depending on whether the driver modified certain members of the [**DOCEVENT_FILTER**](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_docevent_filter) structure. (The *pvOut* parameter points to this structure.) When the spooler allocates memory for a structure of this type, it initializes two members of this structure, **cElementsReturned** and **cElementsNeeded**, to known values. After **DrvDocumentEvent** returns, the spooler determines whether the values of these members have changed, and uses that information to interpret the **DrvDocumentEvent** return value. The following table summarizes this situation.
+For an *iEsc* value of DOCUMENTEVENT_QUERYFILTER, the spooler can interpret a DOCUMENTEVENT_SUCCESS value returned by **DrvDocumentEvent** in two ways, depending on whether the driver modified certain members of the [**DOCEVENT_FILTER**](./ns-winddiui-_docevent_filter.md) structure. (The *pvOut* parameter points to this structure.) When the spooler allocates memory for a structure of this type, it initializes two members of this structure, **cElementsReturned** and **cElementsNeeded**, to known values. After **DrvDocumentEvent** returns, the spooler determines whether the values of these members have changed, and uses that information to interpret the **DrvDocumentEvent** return value. The following table summarizes this situation.
 
 | Return value | Status of cElementsReturned, cElementsNeeded | Meaning |
 |---|---|---|
 | DOCUMENTEVENT_SUCCESS | Driver made no change to either member. | The spooler interprets this return value as equivalent to DOCUMENTEVENT_UNSUPPORTED. The spooler is unable to retrieve the event filter from the driver, so it persists in calling **DrvDocumentEvent** for all events. |
-| DOCUMENTEVENT_SUCCESS | Driver wrote to one or both members. | The spooler accepts this return value without interpretation. If the driver wrote to only one of **cElementsNeeded** and **cElementsReturned**, the spooler considers the unchanged member to have a value of zero. The spooler filters out all events listed in the **aDocEventCall** member of [**DOCEVENT_FILTER**](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_docevent_filter). |
+| DOCUMENTEVENT_SUCCESS | Driver wrote to one or both members. | The spooler accepts this return value without interpretation. If the driver wrote to only one of **cElementsNeeded** and **cElementsReturned**, the spooler considers the unchanged member to have a value of zero. The spooler filters out all events listed in the **aDocEventCall** member of [**DOCEVENT_FILTER**](./ns-winddiui-_docevent_filter.md). |
 | DOCUMENTEVENT_UNSUPPORTED | Not applicable | The driver does not support DOCUMENTEVENT_QUERYFILTER. The spooler is unable to retrieve the event filter from the driver, so it persists in calling **DrvDocumentEvent** for all events. |
 | DOCUMENTEVENT_FAILURE | Not applicable | The driver supports DOCUMENTEVENT_QUERYFILTER, but encountered an internal error. The spooler is unable to retrieve the event filter from the driver, so it persists in calling **DrvDocumentEvent** for all events. |
 
@@ -156,7 +156,7 @@ If the escape code name has no suffix or is suffixed with PRE, the GDI client ca
 
 If the escape code supplied in the *iEsc* parameter is DOCUMENTEVENT_CREATEDCPRE, the following rules apply:
 
-- If the job is being sent directly to the printer without spooling, *pvIn* --> pszDevice points to the printer name. (See the [**DOCEVENT_CREATEDCPRE**](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_docevent_createdcpre) structure for more information.)
+- If the job is being sent directly to the printer without spooling, *pvIn* --> pszDevice points to the printer name. (See the [**DOCEVENT_CREATEDCPRE**](./ns-winddiui-_docevent_createdcpre.md) structure for more information.)
 
 - If the job is being spooled, *pvIn* --> pszDevice points to the printer port name.
 
@@ -170,8 +170,8 @@ The **DrvDocumentEvent** function executes in the context of the user-mode calle
 
 ## -see-also
 
-[**DOCEVENT_CREATEDCPRE**](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_docevent_createdcpre)
+[**DOCEVENT_CREATEDCPRE**](./ns-winddiui-_docevent_createdcpre.md)
 
-[**DOCEVENT_ESCAPE**](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_docevent_escape)
+[**DOCEVENT_ESCAPE**](./ns-winddiui-_docevent_escape.md)
 
-[**DOCEVENT_FILTER**](/windows-hardware/drivers/ddi/winddiui/ns-winddiui-_docevent_filter)
+[**DOCEVENT_FILTER**](./ns-winddiui-_docevent_filter.md)

--- a/wdk-ddi-src/content/winppi/nf-winppi-gdigetpagecount.md
+++ b/wdk-ddi-src/content/winppi/nf-winppi-gdigetpagecount.md
@@ -49,7 +49,7 @@ The GdiGetPageCount function returns the number of pages in a print job.
 
 ### -param SpoolFileHandle
 
-Caller-supplied spool file handle, obtained by a previous call to [GdiGetSpoolFileHandle](/windows-hardware/drivers/ddi/winppi/nf-winppi-gdigetspoolfilehandle).
+Caller-supplied spool file handle, obtained by a previous call to [GdiGetSpoolFileHandle](./nf-winppi-gdigetspoolfilehandle.md).
 
 ## -returns
 
@@ -57,11 +57,11 @@ If the operation succeeds, the function returns the number of pages in the curre
 
 ## -remarks
 
-The GdiGetPageCount function is exported by gdi32.dll for use within a print processor's [PrintDocumentOnPrintProcessor](/windows-hardware/drivers/ddi/winsplp/nf-winsplp-printdocumentonprintprocessor) function.
+The GdiGetPageCount function is exported by gdi32.dll for use within a print processor's [PrintDocumentOnPrintProcessor](../winsplp/nf-winsplp-printdocumentonprintprocessor.md) function.
 
 > [!NOTE]
 > The GdiGetPageCount function does not return until all pages have been spooled, even if the print server administrator has specified that print jobs should be printed during spooling. Therefore, this function should not be used unless it is necessary to obtain the total page count before document processing can begin, such as for printing pages in reverse order.
 >
-> Usually, a better method for determining the page count is to count the number of calls made to [GdiGetPageHandle](/windows-hardware/drivers/ddi/winppi/nf-winppi-gdigetpagehandle).
+> Usually, a better method for determining the page count is to count the number of calls made to [GdiGetPageHandle](./nf-winppi-gdigetpagehandle.md).
 
 For additional information about this set of functions, see [Using GDI Functions in Print Processors](/windows-hardware/drivers/print/using-gdi-functions-in-print-processors).


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 