### PR TITLE
Update nc-fltkernel-pflt_filter_unload_callback.md

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nc-fltkernel-pflt_filter_unload_callback.md
+++ b/wdk-ddi-src/content/fltkernel/nc-fltkernel-pflt_filter_unload_callback.md
@@ -79,7 +79,7 @@ When a minifilter driver does register a *FilterUnloadCallback* routine:
 
 * If the FLTFL_FILTER_UNLOAD_MANDATORY flag is set in the *Flags* parameter, the unload operation is mandatory, and the minifilter driver cannot prevent itself from being unloaded.
 
-See [Loading and Unloading](/windows-hardware/drivers/ifs/loading-and-unloading) for more information about possible unload causes and the minifilter driver unload process.
+See [When the FilterUnloadCallback Routine Is Called](/windows-hardware/drivers/ifs/when-the-filterunloadcallback-routine-is-called) for more information about possible unload causes and the minifilter driver unload process.
 
 ## -see-also
 


### PR DESCRIPTION
The supplied "Loading and unloading" link does not provide the specific details about when and why the mandatory flag would be set nor its relationship to the FLTFL_REGISTRATION_DO_NOT_SUPPORT_SERVICE_STOP flag.  I was going to submit an edit for that page but then I found the 'When the FilterUnLoadCallback Routine Is Called' page and felt it better addressed the topic of minifilter unloading.