### PR TITLE
Update ns-fwpsk-fwps_callout2_.md

### DIFF
--- a/wdk-ddi-src/content/fwpsk/ns-fwpsk-fwps_callout2_.md
+++ b/wdk-ddi-src/content/fwpsk/ns-fwpsk-fwps_callout2_.md
@@ -191,7 +191,7 @@ A callout driver specifies this flag when registering a callout that will be add
 </dl>
 </td>
 <td width="60%">
-A callout driver specifies this flag to indicate that the callout supports UDP receive offload (URO) with large packets of up to 64K. If this flag is not specified, and a callout is registered, then URO is disabled for all traffic that is processed by any filters that specify the callout for the filter's action. <b>Note:</b If this flag is specified then callouts must not clone and reinject inbound URO packets.
+A callout driver specifies this flag to indicate that the callout supports UDP receive offload (URO) with large packets of up to 64K. If this flag is not specified, and a callout is registered, then URO is disabled for all traffic that is processed by any filters that specify the callout for the filter's action. <b>Note:</b> If this flag is specified then callouts must not clone and reinject inbound URO packets.
 </td>
 </tr>
  

--- a/wdk-ddi-src/content/fwpsk/ns-fwpsk-fwps_callout2_.md
+++ b/wdk-ddi-src/content/fwpsk/ns-fwpsk-fwps_callout2_.md
@@ -184,6 +184,17 @@ A callout driver specifies this flag when registering a callout that will be add
 </td>
 </tr>
 
+<tr>
+<td width="40%"><a id="FWP_CALLOUT_FLAG_ALLOW_URO"></a><a id="fwp_callout_flag_allow_uro"></a><dl>
+<dt><b>FWP_CALLOUT_FLAG_ALLOW_URO</b></dt>
+<dt>0x00000200</dt>
+</dl>
+</td>
+<td width="60%">
+A callout driver specifies this flag to indicate that the callout supports UDP receive offload (URO) with large packets of up to 64K. If this flag is not specified, and a callout is registered, then URO is disabled for all traffic that is processed by any filters that specify the callout for the filter's action. <b>Note:</b If this flag is specified then callouts must not clone and reinject inbound UDP packets.
+</td>
+</tr>
+ 
 </table>
 
 ### -field classifyFn

--- a/wdk-ddi-src/content/fwpsk/ns-fwpsk-fwps_callout2_.md
+++ b/wdk-ddi-src/content/fwpsk/ns-fwpsk-fwps_callout2_.md
@@ -191,7 +191,7 @@ A callout driver specifies this flag when registering a callout that will be add
 </dl>
 </td>
 <td width="60%">
-A callout driver specifies this flag to indicate that the callout supports UDP receive offload (URO) with large packets of up to 64K. If this flag is not specified, and a callout is registered, then URO is disabled for all traffic that is processed by any filters that specify the callout for the filter's action. <b>Note:</b If this flag is specified then callouts must not clone and reinject inbound UDP packets.
+A callout driver specifies this flag to indicate that the callout supports UDP receive offload (URO) with large packets of up to 64K. If this flag is not specified, and a callout is registered, then URO is disabled for all traffic that is processed by any filters that specify the callout for the filter's action. <b>Note:</b If this flag is specified then callouts must not clone and reinject inbound URO packets.
 </td>
 </tr>
  


### PR DESCRIPTION
Re-introducing URO flag but with a note suggesting Callouts MUST NOT clone and re-inject packets.