### PR TITLE
Update nf-ntstrsafe-rtlunicodestringcopystring.md

### DIFF
--- a/wdk-ddi-src/content/ntstrsafe/nf-ntstrsafe-rtlunicodestringcopystring.md
+++ b/wdk-ddi-src/content/ntstrsafe/nf-ntstrsafe-rtlunicodestringcopystring.md
@@ -76,7 +76,7 @@ A pointer to a null-terminated string. This string will be copied into the buffe
 </dl>
 </td>
 <td width="60%">
-This <i>success</i> status means that source data was present, the string was copied without truncation.
+This <i>success</i> status means that source data was present and the string was copied without truncation.
 
 </td>
 </tr>

--- a/wdk-ddi-src/content/ntstrsafe/nf-ntstrsafe-rtlunicodestringcopystring.md
+++ b/wdk-ddi-src/content/ntstrsafe/nf-ntstrsafe-rtlunicodestringcopystring.md
@@ -76,7 +76,7 @@ A pointer to a null-terminated string. This string will be copied into the buffe
 </dl>
 </td>
 <td width="60%">
-This <i>success</i> status means that source data was present, the string was copied without truncation, and the resultant destination buffer is null-terminated.
+This <i>success</i> status means that source data was present, the string was copied without truncation.
 
 </td>
 </tr>


### PR DESCRIPTION
The description says that the function does *not* copy the null terminator