### PR TITLE
Update nf-fwpsk-fwpsflowremovecontext0.md

### DIFF
--- a/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsflowremovecontext0.md
+++ b/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsflowremovecontext0.md
@@ -114,6 +114,17 @@ There is no context currently associated with the data flow.
 <tr>
 <td width="40%">
 <dl>
+<dt><b>STATUS_PENDING</b></dt>
+</dl>
+</td>
+<td width="60%">
+An active callout classification is in progress.
+
+</td>
+</tr>
+<tr>
+<td width="40%">
+<dl>
 <dt><b>Other status codes</b></dt>
 </dl>
 </td>


### PR DESCRIPTION
The Remarks section calls out STATUS_PENDING but it is not mentioned explicitly in the Return Values section. This update makes the page consistent.