### PR TITLE
Update PCIe link related structures

### DIFF
--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_capability.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_capability.md
@@ -120,15 +120,15 @@ Defines the **PCI_EXPRESS_DEVICE_STATUS_2_REGISTER** member **DeviceStatus2**.
 
 ### -field LinkCapabilities2
 
-Defines the **PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER** member **LinkCapabilities2**.
+A [PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER](ns-ntddk-pci_express_link_capabilities_2_register.md) structure that describes the PCIe link capabilities 2 register of the PCIe capability structure, extending the PCIe link capabiliites register.
 
 ### -field LinkControl2
 
-Defines the **PCI_EXPRESS_LINK_CONTROL_2_REGISTER** member **LinkControl2**.
+A [PCI_EXPRESS_LINK_CONTROL_2_REGISTER](ns-ntddk-pci_express_link_control_2_register.md) structure that describes the PCIe link control 2 register of the PCIe capability structure, extending the PCIe link control register.
 
 ### -field LinkStatus2
 
-Defines the **PCI_EXPRESS_LINK_STATUS_2_REGISTER** member **LinkStatus2**.
+A [PCI_EXPRESS_LINK_STATUS_2_REGISTER](ns-ntddk-pci_express_link_status_2_register.md) structure that describes the PCIe link capabilities 2 register of the PCIe capability structure, extending the PCIe link capabiliites register.
 
 ## -remarks
 
@@ -163,3 +163,10 @@ For additional information about the PCIe capability structure, see the [PCI Exp
 [PCI_EXPRESS_LINK_CONTROL_REGISTER](./ns-ntddk-_pci_express_link_control_register.md)
 
 [PCI_EXPRESS_SLOT_STATUS_REGISTER](./ns-ntddk-_pci_express_slot_status_register.md)
+
+[PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER](ns-ntddk-pci_express_link_capabilities_2_register.md)
+
+[PCI_EXPRESS_LINK_CONTROL_2_REGISTER](ns-ntddk-pci_express_link_control_2_register.md) 
+
+[PCI_EXPRESS_LINK_STATUS_2_REGISTER](ns-ntddk-pci_express_link_status_2_register.md)
+

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_capability.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_capability.md
@@ -120,7 +120,7 @@ Defines the **PCI_EXPRESS_DEVICE_STATUS_2_REGISTER** member **DeviceStatus2**.
 
 ### -field LinkCapabilities2
 
-A [PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER](ns-ntddk-pci_express_link_capabilities_2_register.md) structure that describes the PCIe link capabilities 2 register of the PCIe capability structure, extending the PCIe link capabiliites register.
+A [PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER](ns-ntddk-pci_express_link_capabilities_2_register.md) structure that describes the PCIe link capabilities 2 register of the PCIe capability structure, extending the PCIe link capabilities register.
 
 ### -field LinkControl2
 
@@ -128,7 +128,7 @@ A [PCI_EXPRESS_LINK_CONTROL_2_REGISTER](ns-ntddk-pci_express_link_control_2_regi
 
 ### -field LinkStatus2
 
-A [PCI_EXPRESS_LINK_STATUS_2_REGISTER](ns-ntddk-pci_express_link_status_2_register.md) structure that describes the PCIe link capabilities 2 register of the PCIe capability structure, extending the PCIe link capabiliites register.
+A [PCI_EXPRESS_LINK_STATUS_2_REGISTER](ns-ntddk-pci_express_link_status_2_register.md) structure that describes the PCIe link capabilities 2 register of the PCIe capability structure, extending the PCIe link capabilities register.
 
 ## -remarks
 

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_capabilities_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_capabilities_register.md
@@ -52,7 +52,7 @@ api_name:
 
 ## -description
 
-The PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure describes a PCI Express (PCIe) link capabilities register of a PCIe capability structure.
+The **PCI_EXPRESS_LINK_CAPABILITIES_REGISTER** structure describes a PCI Express (PCIe) link capabilities register of a PCIe capability structure.
 
 ## -struct-fields
 
@@ -60,14 +60,12 @@ The PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure describes a PCI Express (PC
 
 ### -field AsULONG
 
-A ULONG representation of the contents of the PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure.
-
-
+A **ULONG** representation of the contents of the **PCI_EXPRESS_LINK_CAPABILITIES_REGISTER** structure.
 
 
 ### -field DUMMYSTRUCTNAME.MaximumLinkSpeed
 
-The maximum link speed of the PCIe link (when PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER is not implemented or the value of SupportedLinkSpeedsVector is 0). If PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER is implemented, then SupportedLinkSpeedsVector is used and MaximumLinkSpeed is disregarded on Windows.
+The maximum link speed of the PCIe link (when [PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER](ns-ntddk-pci_express_link_capabilities_2_register.md) is not implemented or the value of [SupportedLinkSpeedsVector](ns-ntddk-pci_express_link_capabilities_2_register.md#--field-DUMMYSTRUCTNAME.SupportedLinkSpeedsVector) is 0). If [PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER](ns-ntddk-pci_express_link_capabilities_2_register.md) is implemented, then **SupportedLinkSpeedsVector** is used and **MaximumLinkSpeed** is disregarded on Windows.
 
 <table>
 <tr>
@@ -302,13 +300,12 @@ typedef union _PCI_EXPRESS_LINK_CAPABILITIES_REGISTER {
 
 ## -remarks
 
-The PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure is available in Windows Server 2008 and later versions of Windows.
+The **PCI_EXPRESS_LINK_CAPABILITIES_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure is contained in the <a href="/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability">PCI_EXPRESS_CAPABILITY</a> structure.
+A **PCI_EXPRESS_LINK_CAPABILITIES_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-<a href="/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability">PCI_EXPRESS_CAPABILITY</a>
+[PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md)
 
-<a href="/windows-hardware/drivers/ddi/ntddk/ns-ntddk-pci_express_link_capabilities_2_register">PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER</a>
-
+[PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER](ns-ntddk-pci_express_link_capabilities_2_register.md)

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_capabilities_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_capabilities_register.md
@@ -49,6 +49,7 @@ api_name:
 # _PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure (ntddk.h)
 
 
+
 ## -description
 
 The PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure describes a PCI Express (PCIe) link capabilities register of a PCIe capability structure.
@@ -62,25 +63,99 @@ The PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure describes a PCI Express (PC
 A ULONG representation of the contents of the PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure.
 
 
+
+
+### -field DUMMYSTRUCTNAME.MaximumLinkSpeed
+
+The maximum link speed of the PCIe link (when PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER is not implemented or the value of SupportedLinkSpeedsVector is 0). If PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER is implemented, then SupportedLinkSpeedsVector is used and MaximumLinkSpeed is disregarded on Windows.
+
+<table>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><b>1</b></td>
+<td>2.5 GT/s</td>
+</tr>
+<tr>
+<td><b>2</b></td>
+<td>5.0 GT/s</td>
+</tr>
+<tr>
+<td>All other values</td>
+<td>Reserved</td>
+</tr>
+</table>
+ 
+
+### -field DUMMYSTRUCTNAME.MaximumLinkWidth
+
+The maximum link width (number of lanes) implemented by the component. Possible values are:
+
+
+<table>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><b>1</b></td>
+<td>x1 (1 lane)</td>
+</tr>
+<tr>
+<td><b>2</b></td>
+<td>x2 (2 lanes)</td>
+</tr>
+<tr>
+<td><b>4</b></td>
+<td>x4 (4 lanes)</td>
+</tr>
+<tr>
+<td><b>8</b></td>
+<td>x8 (8 lanes)</td>
+</tr>
+<tr>
+<td><b>12</b></td>
+<td>x12 (12 lanes)</td>
+</tr>
+<tr>
+<td><b>16</b></td>
+<td>x16 (16 lanes)</td>
+</tr>
+<tr>
+<td><b>32</b></td>
+<td>x32 (32 lanes)</td>
+</tr>
+<tr>
+<td>All other values</td>
+<td>Reserved.</td>
+</tr>
+</table>
+
+
 ### -field DUMMYSTRUCTNAME.ActiveStatePMSupport
 
 The level of active state power management supported on the PCIe link. Possible values are:
 
-
-
-
-
-#### L0sEntrySupport
-
-L0s is supported.
-
-
-
-#### L0sAndL1EntrySupport
-
-L0s and L1 are supported.
-
-All other values are reserved.
+<table>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><b>L0sEntrySupport</b></td>
+<td>L0s is supported.</td>
+</tr>
+<tr>
+<td><b>L0sAndL1EntrySupport</b></td>
+<td>L0s and L1 are supported.</td>
+</tr>
+<tr>
+<td>All other values</td>
+<td>Reserved.</td>
+</tr>
+</table>
 
 
 ### -field DUMMYSTRUCTNAME.ClockPowerManagement
@@ -98,54 +173,44 @@ A single bit that indicates that the component supports the optional capability 
 The L0s exit latency for the PCIe link. This value indicates the length of time this port requires to complete a transition from L0s to L0.
 
 
-
-
-
-#### L0s_Below64ns
-
-Less than 64 nanoseconds
-
-
-
-#### L0s_64ns_128ns
-
-64 nanoseconds to 128 nanoseconds
-
-
-
-#### L0s_128ns_256ns
-
-128 nanoseconds to 256 nanoseconds
-
-
-
-#### L0s_256ns_512ns
-
-256 nanoseconds to 512 nanoseconds
-
-
-
-#### L0s_512ns_1us
-
-512 nanoseconds to 1 microsecond
-
-
-
-#### L0s_1us_2us
-
-1 microsecond to 2 microseconds
-
-
-
-#### L0s_2us_4us
-
-2 microseconds to 4 microseconds
-
-
-
-#### L0s_Above4us
-
-More than 4 microseconds
+<table>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><b>L0s_Below64ns</b></td>
+<td>Less than 64 nanoseconds</td>
+</tr>
+<tr>
+<td><b>L0s_64ns_128ns</b></td>
+<td>64 nanoseconds to 128 nanoseconds</td>
+</tr>
+<tr>
+<td><b>L0s_128ns_256ns</b></td>
+<td>128 nanoseconds to 256 nanoseconds</td>
+</tr>
+<tr>
+<td><b>L0s_256ns_512ns</b></td>
+<td>256 nanoseconds to 512 nanoseconds</td>
+</tr>
+<tr>
+<td><b>L0s_512ns_1us</b></td>
+<td>512 nanoseconds to 1 microsecond</td>
+</tr>
+<tr>
+<td><b>L0s_1us_2us</b></td>
+<td>1 microsecond to 2 microseconds</td>
+</tr>
+<tr>
+<td><b>L0s_2us_4us</b></td>
+<td>2 microseconds to 4 microseconds</td>
+</tr>
+<tr>
+<td><b>L0s_Above4us</b></td>
+<td>More than 4 microseconds</td>
+</tr>
+</table>
 
 
 ### -field DUMMYSTRUCTNAME.L1ExitLatency
@@ -153,133 +218,47 @@ More than 4 microseconds
 The L1 exit latency for the PCIe link. This value indicates the length of time this port requires to complete a transition from L1 to L0.
 
 
+<table>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><b>L1_Below1us</b></td>
+<td>Less than 1 microsecond</td>
+</tr>
+<tr>
+<td><b>L1_1us_2us</b></td>
+<td>1 microsecond to 2 microseconds</td>
+</tr>
+<tr>
+<td><b>L1_2us_4us</b></td>
+<td>2 microseconds to 4 microseconds</td>
+</tr>
+<tr>
+<td><b>L1_4us_8us</b></td>
+<td>4 microseconds to 8 microseconds</td>
+</tr>
+<tr>
+<td><b>L1_8us_16us</b></td>
+<td>8 microseconds to 16 microseconds</td>
+</tr>
+<tr>
+<td><b>L1_16us_32us</b></td>
+<td>16 microseconds to 32 microseconds</td>
+</tr>
+<tr>
+<td><b>L1_32us_64us</b></td>
+<td>32 microseconds to 64 microseconds</td>
+</tr>
+<tr>
+<td><b>L1_Above64us</b></td>
+<td>More than 64 microseconds</td>
+</tr>
+</table>
 
-
-
-#### L1_Below1us
-
-Less than 1 microsecond
-
-
-
-#### L1_1us_2us
-
-1 microsecond to 2 microseconds
-
-
-
-#### L1_2us_4us
-
-2 microseconds to 4 microseconds
-
-
-
-#### L1_4us_8us
-
-4 microseconds to 8 microseconds
-
-
-
-#### L1_8us_16us
-
-8 microseconds to 16 microseconds
-
-
-
-#### L1_16us_32us
-
-16 microseconds to 32 microseconds
-
-
-
-#### L1_32us_64us
-
-32 microseconds to 64 microseconds
-
-
-
-#### L1_Above64us
-
-More than 64 microseconds
 
 This value is ignored if the <b>ActiveStatePMSupport </b>member is not set to <b>L0sAndL1EntrySupport</b>.
-
-
-### -field DUMMYSTRUCTNAME.MaximumLinkSpeed
-
-The maximum link speed of the PCIe link. The only valid value is:
-
-
-
-
-
-#### 1
-
-2.5 gigabits per second
-
-All other values are reserved.
-
-
-### -field DUMMYSTRUCTNAME.MaximumLinkWidth
-
-The maximum link width (number of lanes) implemented by the component. Possible values are:
-
-
-
-
-
-#### 1
-
-x1 (1 lane)
-
-
-
-#### 2
-
-x2 (2 lanes)
-
-
-
-#### 4
-
-x4 (4 lanes)
-
-
-
-#### 8
-
-x8 (8 lanes)
-
-
-
-#### 12
-
-x12 (12 lanes)
-
-
-
-#### 16
-
-x16 (16 lanes)
-
-
-
-#### 32
-
-x32 (32 lanes)
-
-All other values are reserved.
-
-
-### -field DUMMYSTRUCTNAME.PortNumber
-
-The PCIe port number for the PCIe link.
-
-
-### -field DUMMYSTRUCTNAME.Rsvd
-
-Reserved.
-
 
 ### -field DUMMYSTRUCTNAME.SurpriseDownErrorReportingCapable
 
@@ -288,6 +267,16 @@ A single bit that indicates that the component supports the optional capability 
 ### -field DUMMYSTRUCTNAME.LinkBandwidthNotificationCapability
 
 ### -field DUMMYSTRUCTNAME.AspmOptionalityCompliance
+
+
+### -field DUMMYSTRUCTNAME.Rsvd
+
+Reserved.
+
+### -field DUMMYSTRUCTNAME.PortNumber
+
+The PCIe port number for the PCIe link.
+
 
 ## -syntax
 
@@ -302,7 +291,9 @@ typedef union _PCI_EXPRESS_LINK_CAPABILITIES_REGISTER {
     ULONG ClockPowerManagement  :1;
     ULONG SurpriseDownErrorReportingCapable  :1;
     ULONG DataLinkLayerActiveReportingCapable  :1;
-    ULONG Rsvd  :3;
+    ULONG LinkBandwidthNotificationCapability:1;
+    ULONG AspmOptionalityCompliance:1;
+    ULONG Rsvd  :1;
     ULONG PortNumber  :8;
   };
   ULONG  AsULONG;
@@ -318,4 +309,6 @@ A PCI_EXPRESS_LINK_CAPABILITIES_REGISTER structure is contained in the <a href="
 ## -see-also
 
 <a href="/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability">PCI_EXPRESS_CAPABILITY</a>
+
+<a href="/windows-hardware/drivers/ddi/ntddk/ns-ntddk-pci_express_link_capabilities_2_register">PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER</a>
 

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_control_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_control_register.md
@@ -59,7 +59,7 @@ The **PCI_EXPRESS_LINK_CONTROL_REGISTER** structure describes a PCI Express (PCI
 
 ### -field AsUSHORT
 
-A USHORT representation of the contents of the PCI_EXPRESS_LINK_CONTROL_REGISTER structure.
+A **USHORT** representation of the contents of the **PCI_EXPRESS_LINK_CONTROL_REGISTER** structure.
 
 
 ### -field DUMMYSTRUCTNAME.ActiveStatePMControl
@@ -149,11 +149,12 @@ typedef union _PCI_EXPRESS_LINK_CONTROL_REGISTER {
 
 ## -remarks
 
-The PCI_EXPRESS_LINK_CONTROL_REGISTER structure is available in Windows Server 2008 and later versions of Windows.
+The **PCI_EXPRESS_LINK_CONTROL_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_LINK_CONTROL_REGISTER structure is contained in the <a href="/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability">PCI_EXPRESS_CAPABILITY</a> structure.
+A **PCI_EXPRESS_LINK_CONTROL_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-<a href="/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability">PCI_EXPRESS_CAPABILITY</a>
+[PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md)
 
+[PCI_EXPRESS_LINK_CONTROL_2_REGISTER](ns-ntddk-pci_express_link_control_2_register.md)

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_control_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_control_register.md
@@ -51,7 +51,7 @@ api_name:
 
 ## -description
 
-The PCI_EXPRESS_LINK_CONTROL_REGISTER structure describes a PCI Express (PCIe) link control register of a PCIe capability structure.
+The **PCI_EXPRESS_LINK_CONTROL_REGISTER** structure describes a PCI Express (PCIe) link control register of a PCIe capability structure.
 
 ## -struct-fields
 
@@ -66,31 +66,28 @@ A USHORT representation of the contents of the PCI_EXPRESS_LINK_CONTROL_REGISTER
 
 The level of active state power management that is enabled on the PCIe link. Possible values are:
 
-
-
-
-
-#### L0sAndL1EntryDisabled
-
-L0s and L1 are both disabled.
-
-
-
-#### L0sEntryEnabled
-
-L0s is enabled.
-
-
-
-#### L1EntryEnabled
-
-L1 is enabled.
-
-
-
-#### L0sAndL1EntryEnabled
-
-L0s and L1 are both enabled.
+<table>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+<tr>
+<td><b>L0sAndL1EntryDisabled</b></td>
+<td>L0s and L1 are both disabled.</td>
+</tr>
+<tr>
+<td><b>L0sEntryEnabled</b></td>
+<td>L0s is enabled.</td>
+</tr>
+<tr>
+<td><b>L1EntryEnabled</b></td>
+<td>L1 is enabled.</td>
+</tr>
+<tr>
+<td><b>L0sAndL1EntryEnabled</b></td>
+<td>L0s and L1 are both enabled.</td>
+</tr>
+</table>
 
 
 ### -field DUMMYSTRUCTNAME.CommonClockConfig
@@ -126,7 +123,6 @@ A single bit that is used to initiate retraining of the link. Reads of this bit 
 ### -field DUMMYSTRUCTNAME.Rsvd1
 
 Reserved.
-
 
 ### -field DUMMYSTRUCTNAME.Rsvd2
 

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_status_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_status_register.md
@@ -51,7 +51,7 @@ api_name:
 
 ## -description
 
-The PCI_EXPRESS_LINK_STATUS_REGISTER structure describes a PCI Express (PCIe) link status register of a PCIe capability structure.
+The **PCI_EXPRESS_LINK_STATUS_REGISTER** structure describes a PCI Express (PCIe) link status register of a PCIe capability structure.
 
 ## -syntax
 
@@ -80,7 +80,7 @@ typedef union _PCI_EXPRESS_LINK_STATUS_REGISTER {
 
 ### -field AsUSHORT
 
-A USHORT representation of the contents of the PCI_EXPRESS_LINK_STATUS_REGISTER structure.
+A **USHORT** representation of the contents of the **PCI_EXPRESS_LINK_STATUS_REGISTER** structure.
 
 
 ### -field DUMMYSTRUCTNAME.DataLinkLayerActive
@@ -208,11 +208,13 @@ typedef union _PCI_EXPRESS_LINK_STATUS_REGISTER {
 
 ## -remarks
 
-The PCI_EXPRESS_LINK_STATUS_REGISTER structure is available in Windows Server 2008 and later versions of Windows.
+The **PCI_EXPRESS_LINK_STATUS_REGISTER** structure is available in Windows Server 2008 and later versions of Windows.
 
-A PCI_EXPRESS_LINK_STATUS_REGISTER structure is contained in the <a href="/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability">PCI_EXPRESS_CAPABILITY</a> structure.
+A **PCI_EXPRESS_LINK_STATUS_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md) structure.
 
 ## -see-also
 
-<a href="/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_pci_express_capability">PCI_EXPRESS_CAPABILITY</a>
+[PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md)
+
+[PCI_EXPRESS_LINK_STATUS_2_REGISTER](ns-ntddk-pci_express_link_status_2_register.md)
 

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_status_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-_pci_express_link_status_register.md
@@ -90,7 +90,7 @@ A single bit that indicates that the data link control and management state mach
 
 ### -field DUMMYSTRUCTNAME.LinkSpeed
 
-The negotiated link speed of the PCIe link.  Possible values are:
+The negotiated link speed of the PCIe link. The encoded value specifies a Bit Location in the SupportedLinkSpeedsVector (Link Capabilities 2 Register) that corresponds to the negotiated link speed. Supported values are:
 
 <table>
 <tr>
@@ -99,11 +99,23 @@ The negotiated link speed of the PCIe link.  Possible values are:
 </tr>
 <tr>
 <td><b>1</b></td>
-<td>2.5 gigabits per second.</td>
+<td>2.5 GT/s (SupportedLinkSpeedsVector field bit 0)</td>
 </tr>
 <tr>
 <td><b>2</b></td>
-<td>5.0 gigabits per second.</td>
+<td>5.0 GT/s (SupportedLinkSpeedsVector field bit 1)</td>
+</tr>
+<tr>
+<td><b>3</b></td>
+<td>8.0 GT/s (SupportedLinkSpeedsVector field bit 2)</td>
+</tr>
+<tr>
+<td><b>4</b></td>
+<td>16.0 GT/s (SupportedLinkSpeedsVector field bit 3)</td>
+</tr>
+<tr>
+<td><b>5</b></td>
+<td>32.0 GT/s (SupportedLinkSpeedsVector field bit 4)</td>
 </tr>
 <tr>
 <td>All other values</td>

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_capabilities_2_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_capabilities_2_register.md
@@ -46,29 +46,61 @@ helpviewer_keywords:
 
 ## -description
 
-This topic describes the **PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER** union.
+The **PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER** structure describes a PCI Express (PCIe) link capabilities 2 register of a PCIe capability structure. This is an extension of the PCIe link capabilities register.
 
 ## -struct-fields
 
 ### -field DUMMYSTRUCTNAME
 
-Defines the **DUMMYSTRUCTNAME** structure.
-
 ### -field DUMMYSTRUCTNAME.Rsvd0
 
-Defines the **ULONG** member **Rsvd0**.
+Reserved.
 
 ### -field DUMMYSTRUCTNAME.SupportedLinkSpeedsVector
 
-Defines the **ULONG** member **SupportedLinkSpeedsVector**.
+Indicates the supported link speeds of the PCIe link. For each bit position, a value of 1b indicates that the corresponding link speed is supported; otherwise, that speed is not supported. Note that this field is preferred as the source of truth over the **MaximumLinkSpeed** field in a **PCI_EXPRESS_LINK_CAPABILITIES_REGISTER**.
+
+Bit definitions within this field with the corresponding link speed are:
+
+<table>
+<tr>
+<th>Bit Position</th>
+<th>Supported Link Speed</th>
+</tr>
+<tr>
+<td><b>0</b></td>
+<td>2.5 GT/s</td>
+</tr>
+<tr>
+<td><b>1</b></td>
+<td>5.0 GT/s</td>
+</tr>
+<tr>
+<td><b>2</b></td>
+<td>8.0 GT/s</td>
+</tr>
+<tr>
+<td><b>3</b></td>
+<td>16.0 GT/s</td>
+</tr>
+<tr>
+<td><b>4</b></td>
+<td>32.0 GT/s</td>
+</tr>
+<tr>
+<td><b>All other bit positions</b></td>
+<td>Reserved</td>
+</tr>
+</table>
+
 
 ### -field DUMMYSTRUCTNAME.Rsvd8_31
 
-Defines the **ULONG** member **Rsvd8_31**.
+Reserved.
 
 ### -field AsULONG
 
-Defines the **ULONG** member **AsULONG**.
+A **ULONG** representation of the contents of the **PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER** structure.
 
 ## -remarks
 

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_capabilities_2_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_capabilities_2_register.md
@@ -58,7 +58,7 @@ Reserved.
 
 ### -field DUMMYSTRUCTNAME.SupportedLinkSpeedsVector
 
-Indicates the supported link speeds of the PCIe link. For each bit position, a value of 1b indicates that the corresponding link speed is supported; otherwise, that speed is not supported. Note that this field is preferred as the source of truth over the **MaximumLinkSpeed** field in a **PCI_EXPRESS_LINK_CAPABILITIES_REGISTER**.
+Indicates the supported link speeds of the PCIe link. For each bit position, a value of 1b indicates that the corresponding link speed is supported; otherwise, that speed is not supported. Note that this field is preferred as the source of truth over the [MaximumLinkSpeed](ns-ntddk-_pci_express_link_capabilities_register.md#-field-DUMMYSTRUCTNAME.MaximumLinkSpeed) field.
 
 Bit definitions within this field with the corresponding link speed are:
 
@@ -104,4 +104,10 @@ A **ULONG** representation of the contents of the **PCI_EXPRESS_LINK_CAPABILITIE
 
 ## -remarks
 
+A **PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md) structure.
+
 ## -see-also
+
+[PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md)
+
+[PCI_EXPRESS_LINK_CAPABILITIES_REGISTER](ns-ntddk-_pci_express_link_capabilities_register.md)

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_control_2_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_control_2_register.md
@@ -46,25 +46,64 @@ helpviewer_keywords:
 
 ## -description
 
-This topic describes the **PCI_EXPRESS_LINK_CONTROL_2_REGISTER** union.
+The **PCI_EXPRESS_LINK_CONTROL_2_REGISTER** structure describes a PCI Express (PCIe) link control 2 register of a PCIe capability structure. This is an extension of the PCIe link control register.
 
 ## -struct-fields
 
 ### -field DUMMYSTRUCTNAME
 
-Defines the **DUMMYSTRUCTNAME** structure.
-
 ### -field DUMMYSTRUCTNAME.TargetLinkSpeed
 
-Defines the **USHORT** member **TargetLinkSpeed**.
+For Downstream Ports, this field sets an upper limit on a PCIe link's operational speed by restricting the values advertised by the Upstream component in its training sequences.
+The encoded value specifies a bit location in the Supported Link Speeds Vector (in the Link Capabilities 2 Register) corresponding to the desired operational link speed.
+
+Defined encodings are:
+
+<table>
+<tr>
+<th>Value (binary)</th>
+<th>Supported Link Speeds Vector field bit position</th>
+<th>Link Speed</th>
+</tr>
+<tr>
+<td><b>0001b</b></td>
+<td>0</td>
+<td>2.5 GT/s</td>
+</tr>
+<tr>
+<td><b>0010b</b></td>
+<td>1</td>
+<td>5.0 GT/s</td>
+</tr>
+<tr>
+<td><b>0011b</b></td>
+<td>2</td>
+<td>8.0 GT/s</td>
+</tr>
+<tr>
+<td><b>0100b</b></td>
+<td>3</td>
+<td>16.0 GT/s</td>
+</tr>
+<tr>
+<td><b>0101b</b></td>
+<td>4</td>
+<td>32.0 GT/s</td>
+</tr>
+<tr>
+<td><b>All other values</b></td>
+<td>Reserved</td>
+<td>Reserved</td>
+</tr>
+</table>
 
 ### -field DUMMYSTRUCTNAME.Rsvd4_15
 
-Defines the **USHORT** member **Rsvd4_15**.
+Reserved.
 
 ### -field AsUSHORT
 
-Defines the **USHORT** member **AsUSHORT**.
+A **USHORT** representation of the contents of the **PCI_EXPRESS_LINK_CONTROL_2_REGISTER** structure.
 
 ## -remarks
 

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_control_2_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_control_2_register.md
@@ -107,4 +107,11 @@ A **USHORT** representation of the contents of the **PCI_EXPRESS_LINK_CONTROL_2_
 
 ## -remarks
 
+A **PCI_EXPRESS_LINK_CONTROL_2_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md) structure.
+
 ## -see-also
+
+[PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md)
+
+[PCI_EXPRESS_LINK_CONTROL_REGISTER](ns-ntddk-pci_express_link_control_register.md)
+

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_status_2_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_status_2_register.md
@@ -46,22 +46,19 @@ helpviewer_keywords:
 
 ## -description
 
-This topic describes the **PCI_EXPRESS_LINK_STATUS_2_REGISTER** union.
+**PCI_EXPRESS_LINK_STATUS_2_REGISTER** describes a PCI Express (PCIe) link status 2 register of a PCIe capability structure. Currently, all fields are reserved and not supported in Windows.
 
 ## -struct-fields
 
 ### -field DUMMYSTRUCTNAME
 
-Defines the **DUMMYSTRUCTNAME** structure.
-
 ### -field DUMMYSTRUCTNAME.Rsvd0_15
-
-Defines the **USHORT** member **Rsvd0_15**.
 
 ### -field AsUSHORT
 
-Defines the **USHORT** member **AsUSHORT**.
+A USHORT representation of the contents of the PCI_EXPRESS_LINK_STATUS_2_REGISTER structure.
 
 ## -remarks
 
 ## -see-also
+

--- a/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_status_2_register.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-pci_express_link_status_2_register.md
@@ -60,5 +60,11 @@ A USHORT representation of the contents of the PCI_EXPRESS_LINK_STATUS_2_REGISTE
 
 ## -remarks
 
+A **PCI_EXPRESS_LINK_STATUS_2_REGISTER** structure is contained in the [PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md) structure.
+
 ## -see-also
+
+[PCI_EXPRESS_CAPABILITY_REGISTER](ns-ntddk-_pci_express_capability.md)
+
+[PCI_EXPRESS_LINK_STATUS_REGISTER](./ns-ntddk-_pci_express_link_status_register.md)
 


### PR DESCRIPTION
This modifies documentation of all PCIe link related structures:
- Link Capabilities Register
- Link Control Register
- Link Status Register
- Link Capabilities 2 Register
- Link Control 2 Register
- Link Status 2 Register
- Express Capability

This also updates all link speed information on each of these pages up to PCIe Gen 5 link speeds.