### PR TITLE
Update nf-wdm-exacquirepushlockexclusive.md

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-exacquirepushlockexclusive.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exacquirepushlockexclusive.md
@@ -62,7 +62,7 @@ When the caller is given exclusive access to the given push lock, depends on the
 
 - If the push lock has already been acquired for exclusive or shared access by another thread, the current thread is put into a wait state until the push lock can be acquired. 
 
-The caller is required call  [**KeEnterCriticalRegion**](../ntddk/nf-ntddk-keentercriticalregion.md) before calling **ExAcquirePushLockExclusive**.
+Before calling this routine, the driver must disable normal kernel APC delivery by calling [**KeEnterCriticalRegion**](../ntddk/nf-ntddk-keentercriticalregion.md). Reenable delivery after the push lock is released by calling [**KeLeaveCriticalRegion**](../ntddk/nf-ntddk-keleavecriticalregion). For more information, see [Disabling APCs](https://learn.microsoft.com/windows-hardware/drivers/kernel/disabling-apcs).
 
 To release the push lock after it is acquired, call [**ExReleasePushLockExclusive**](nf-wdm-exreleasepushlockexclusive.md). Every call to ExAcquirePushLockExclusive must be matched by a subsequent call to [**ExReleasePushLockExclusive**](nf-wdm-exreleasepushlockexclusive.md).
 


### PR DESCRIPTION
Updating details for critical regions to be more verbose about how to disable APCs while owning a push lock