### PR TITLE
Fixed errors in the descriptions of ZwQueryVirtualMemory and NtQueryVirtualMemory

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntqueryvirtualmemory.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntqueryvirtualmemory.md
@@ -62,7 +62,7 @@ The memory information class about which to retrieve information. Currently, the
 
 ### -param MemoryInformation [out]
 
-Pointer to a buffer that receives the specified information.  The format and content of the buffer depend on the information class specified in the *MemoryInformationClass* parameter. When the value **MemoryBasicInformation** is passed to *MemoryInformationClass*, the *MemoryInformationClass* parameter value is a [**MEMORY_BASIC_INFORMATION**](./ns-ntifs-_memory_basic_information.md) structure.
+Pointer to a buffer that receives the specified information.  The format and content of the buffer depend on the information class specified in the *MemoryInformationClass* parameter. When the value **MemoryBasicInformation** is passed to *MemoryInformationClass*, the *MemoryInformation* parameter value is a [**MEMORY_BASIC_INFORMATION**](./ns-ntifs-_memory_basic_information.md) structure.
 
 ### -param MemoryInformationLength [in]
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-zwqueryvirtualmemory.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-zwqueryvirtualmemory.md
@@ -62,7 +62,7 @@ The memory information class about which to retrieve information. Currently, the
 
 ### -param MemoryInformation [out]
 
-A pointer to a buffer that receives the specified information.  The format and content of the buffer depend on the specified information class specified in the **MemoryInformationClass** parameter. When the value **MemoryBasicInformation** is passed to **MemoryInformationClass**, the **MemoryInformationClass** parameter value is a [**MEMORY_INFORMATION_CLASS**](ne-ntifs-_memory_information_class.md).
+A pointer to a buffer that receives the specified information.  The format and content of the buffer depend on the specified information class specified in the **MemoryInformationClass** parameter. When the value **MemoryBasicInformation** is passed to **MemoryInformationClass**, the **MemoryInformation** parameter value is a [**MEMORY_BASIC_INFORMATION**](./ns-ntifs-_memory_basic_information.md) structure.
 
 ### -param MemoryInformationLength [in]
 


### PR DESCRIPTION
Fixed errors in the descriptions of both functions
ZwQueryVirtualMemory: Wrong structure and parameter name (in the description)
NtQueryVirtualMemory: Wrong parameter name (in the description)