### PR TITLE
New Documentation Page for a new FWPS API 

### DIFF
--- a/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsallocatedeepclonenetbufferlist0.md
+++ b/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsallocatedeepclonenetbufferlist0.md
@@ -1,203 +1,107 @@
 ---
 UID: NF:fwpsk.FwpsAllocateDeepCloneNetBufferList0
-title: FwpsAllocateDeepCloneNetBufferList0 function (fwpsk.h)
-description: The FwpsAllocateDeepCloneNetBufferList0 function allocates a NET_BUFFER_LIST structure that is a deep clone of an existing NET_BUFFER_LIST structure.
-old-location: netvista\FwpsAllocateDeepCloneNetBufferList0.htm
 tech.root: netvista
-ms.date: 05/02/2023
-keywords: ["FwpsAllocateDeepCloneNetBufferList0 function"]
-ms.keywords: FwpsAllocateDeepCloneNetBufferList0, FwpsAllocateDeepCloneNetBufferList0 function [Network Drivers Starting with Windows 11], fwpsk/FwpsAllocateDeepCloneNetBufferList0, netvista.FwpsAllocateDeepCloneNetBufferList0, wfp_ref_2_funct_3_fwps_A-B_1b361080-1a63-485a-89fc-05ef6b0cb1df.xml
-req.header: fwpsk.h
-req.include-header: Fwpsk.h
-req.target-type: Universal
-req.target-min-winverclnt: Available starting with Windows 11.
-req.target-min-winversvr: 
-req.kmdf-ver: 
-req.umdf-ver: 
+title: FwpsAllocateDeepCloneNetBufferList0
+ms.date: 07/10/2023
+targetos: Windows
+description: The FwpsAllocateDeepCloneNetBufferList0 function allocates a NET_BUFFER_LIST structure that is a deep clone of an existing NET_BUFFER_LIST structure.
+prerelease: false
+req.assembly: 
+req.construct-type: function
 req.ddi-compliance: 
-req.unicode-ansi: 
+req.dll: 
+req.header: fwpsk.h
 req.idl: 
+req.include-header: Fwpsk.h
+req.irql: <= DISPATCH_LEVEL
+req.kmdf-ver: 
+req.lib: Fwpkclnt.lib
 req.max-support: 
 req.namespace: 
-req.assembly: 
+req.redist: 
+req.target-min-winverclnt: Available starting with Windows 11.
+req.target-min-winversvr: 
+req.target-type: Universal
 req.type-library: 
-req.lib: Fwpkclnt.lib
-req.dll: 
-req.irql: <= DISPATCH_LEVEL
-targetos: Windows
-req.typenames: 
-f1_keywords:
- - FwpsAllocateDeepCloneNetBufferList0
- - fwpsk/FwpsAllocateDeepCloneNetBufferList0
+req.umdf-ver: 
+req.unicode-ansi: 
 topic_type:
- - APIRef
- - kbSyntax
+ - apiref
 api_type:
  - LibDef
 api_location:
- - fwpkclnt.lib
- - fwpkclnt.dll
+ - fwpsk.h
 api_name:
+ - FwpsAllocateDeepCloneNetBufferList0
+f1_keywords:
+ - FwpsAllocateDeepCloneNetBufferList0
+ - fwpsk/FwpsAllocateDeepCloneNetBufferList0
+dev_langs:
+ - c++
+helpviewer_keywords:
  - FwpsAllocateDeepCloneNetBufferList0
 ---
 
-# FwpsAllocateDeepCloneNetBufferList0 function
-
-
 ## -description
 
-The 
-  <b>FwpsAllocateDeepCloneNetBufferList0</b> function allocates a 
-  <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure that is a deep clone of an existing
-  <b>NET_BUFFER_LIST</b> structure.
-<div> </div>
+The **FwpsAllocateDeepCloneNetBufferList0** function allocates a [**NET_BUFFER_LIST**](../nbl/ns-nbl-net_buffer_list.md) structure that is a deep clone of an existing **NET_BUFFER_LIST** structure.
 
 ## -parameters
 
 ### -param originalNetBufferList [in, out]
 
-
-A pointer to the original 
-     <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure that is being
-     cloned.
+A pointer to the original [**NET_BUFFER_LIST**](../nbl/ns-nbl-net_buffer_list.md) structure that is being cloned.
 
 ### -param netBufferListPoolHandle [in, optional]
 
-
-A 
-     <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> pool handle that was
-     obtained from a previous call to the 
-     <a href="/windows-hardware/drivers/ddi/nblapi/nf-nblapi-ndisallocatenetbufferlistpool">
-     NdisAllocateNetBufferListPool</a> function. This parameter is optional and can be <b>NULL</b>.
+A [**NET_BUFFER_LIST**](../nbl/ns-nbl-net_buffer_list.md) pool handle that was obtained from a previous call to the [**NdisAllocateNetBufferListPool**](../nblapi/nf-nblapi-ndisallocatenetbufferlistpool.md) function. This parameter is optional and can be **NULL**.
 
 ### -param netBufferPoolHandle [in, optional]
 
-
-A 
-     <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer">NET_BUFFER</a> pool handle that was obtained from a
-     previous call to the 
-     <a href="/windows-hardware/drivers/ddi/ndis/nf-ndis-ndisallocatenetbufferpool">NdisAllocateNetBufferPool</a> function. This parameter is optional and can be <b>NULL</b>.
+A [**NET_BUFFER_LIST**](../nbl/ns-nbl-net_buffer_list.md) pool handle that was obtained from a previous call to the [**NdisAllocateNetBufferPool**](../ndis/nf-ndis-ndisallocatenetbufferpool.md) function. This parameter is optional and can be **NULL**.
 
 ### -param netBufferList [out]
 
-
-A pointer to a variable that receives a pointer to the deep clone 
-     <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure.
+A pointer to a variable that receives a pointer to the deep clone [**NET_BUFFER_LIST**](../nbl/ns-nbl-net_buffer_list.md) structure.
 
 ## -returns
 
-The 
-     <b>FwpsAllocateDeepCloneNetBufferList0</b> function returns one of the following NTSTATUS codes.
+The **FwpsAllocateDeepCloneNetBufferList0** function returns one of the following NTSTATUS codes.
 
-<table>
-<tr>
-<th>Return code</th>
-<th>Description</th>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>STATUS_SUCCESS</b></dt>
-</dl>
-</td>
-<td width="60%">
-The deep clone 
-       <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure was
-       successfully allocated.
-
-</td>
-</tr>
-<tr>
-<td width="40%">
-<dl>
-<dt><b>Other status codes</b></dt>
-</dl>
-</td>
-<td width="60%">
-An error occurred.
-
-</td>
-</tr>
-</table>
+|Return code|Description|
+|--- |--- |
+|**STATUS_SUCCESS**|The deep clone [**NET_BUFFER_LIST**](../nbl/ns-nbl-net_buffer_list.md) structure was successfully allocated.|
+|**Other status codes**|An error occurred.|
 
 ## -remarks
 
-A callout driver calls the 
-    <b>FwpsAllocateDeepCloneNetBufferList0</b> function to allocate a deep clone 
-    <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure of an existing
-    NET_BUFFER_LIST structure.
+A callout driver calls the **FwpsAllocateDeepCloneNetBufferList0** function to allocate a deep clone [**NET_BUFFER_LIST**](../nbl/ns-nbl-net_buffer_list.md) structure of an existing **NET_BUFFER_LIST** structure.
 
-This function is a wrapper around the 
-    <a href="/windows-hardware/drivers/ddi/ndis/nf-ndis-ndisallocateclonenetbufferlist">
-    NdisAllocateCloneNetBufferList</a> function, but it is specialized for use by WFP 
-    <a href="/windows-hardware/drivers/network/packet-injection-functions">packet injection functions</a>.
+This function is a wrapper around the [**NdisAllocateCloneNetBufferList**](../ndis/nf-ndis-ndisallocateclonenetbufferlist.md) function, but it is specialized for use by WFP [packet injection functions](/windows-hardware/drivers/network/packet-injection-functions).
 
-If the deep clone NET_BUFFER_LIST structure should have attributes that are associated with a specific pool,
-    the callout driver must specify the pool handle in the 
-    <i>NetBufferListPoolHandle</i> or 
-    <i>NetBufferPoolHandle</i> parameter. If these parameters are <b>NULL</b>, the default pool preallocated by NDIS
-    is used.
+If the deep clone **NET_BUFFER_LIST** structure should have attributes that are associated with a specific pool, the callout driver must specify the pool handle in the _NetBufferListPoolHandle_ or _NetBufferPoolHandle_ parameter. If these parameters are **NULL**, the default pool preallocated by NDIS is used.
 
-The  deep clone NET_BUFFER_LIST structure describes the same data that is described by the original
-    NET_BUFFER_LIST structure. The 
-    <b>FwpsAllocateDeepCloneNetBufferList0</b> function does copy the data that is described by the original
-    MDLs to new data buffers. The clone NET_BUFFER_LIST structure does include an initial 
-    <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list_context">
-    NET_BUFFER_LIST_CONTEXT</a> structure.
+The deep clone **NET_BUFFER_LIST** structure describes the same data that is described by the original **NET_BUFFER_LIST** structure. The **FwpsAllocateDeepCloneNetBufferList0** function copies the data that is described by the original MDLs to new data buffers. The clone **NET_BUFFER_LIST** structure includes an initial [**NET_BUFFER_LIST_CONTEXT**](../nbl/ns-nbl-net_buffer_list_context.md) structure.
 
-This function sets the 
-    <b>ParentNetBufferList</b> member of the newly created clone NET_BUFFER_LIST structure to point to the
-    parent NET_BUFFER_LIST structure. The parent structure's 
-    <b>ChildRefCount</b> member is incremented by 1.
+This function sets the **ParentNetBufferList** member of the newly created clone **NET_BUFFER_LIST** structure to point to the parent **NET_BUFFER_LIST** structure. The parent structure's **ChildRefCount** member is incremented by **1**.
 
-A callout driver can modify the clone NET_BUFFER_LIST structure and inject it into the network stack
-    in place of the original NET_BUFFER_LIST structure by calling the 
-    <a href="/windows-hardware/drivers/network/packet-injection-functions">packet injection functions</a>. After
-    the data described by the clone NET_BUFFER_LIST structure has been successfully injected into the network
-    stack, the callout driver frees the clone NET_BUFFER_LIST structure by calling the 
-    <a href="/windows-hardware/drivers/ddi/fwpsk/nf-fwpsk-fwpsfreeclonenetbufferlist0">FwpsFreeCloneNetBufferList0</a> function.
+A callout driver can modify the clone **NET_BUFFER_LIST** structure and inject it into the network stack in place of the original **NET_BUFFER_LIST** structure by calling the [packet injection functions](/windows-hardware/drivers/network/packet-injection-functions). After the data described by the clone **NET_BUFFER_LIST** structure has been successfully injected into the network stack, the callout driver frees the clone **NET_BUFFER_LIST** structure by calling the [**FwpsFreeCloneNetBufferList0**](nf-fwpsk-fwpsfreeclonenetbufferlist0.md) function.
 
-A callout driver can insert or replace individual net buffers (<a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer">NET_BUFFER</a>) or MDLs inside the deep clone net buffer
-    list. Such a driver must also undo the modifications before it calls the 
-    <a href="/windows-hardware/drivers/ddi/fwpsk/nf-fwpsk-fwpsfreeclonenetbufferlist0">
-    FwpsFreeCloneNetBufferList0</a> function.
+A callout driver can insert or replace individual net buffers ([**NET_BUFFER**](../nbl/ns-nbl-net_buffer.md)) or MDLs inside the deep clone **NET_BUFFER_LIST**. The driver must undo these modifications before it calls the [**FwpsFreeCloneNetBufferList0**](nf-fwpsk-fwpsfreeclonenetbufferlist0.md) function.
 
-<h3><a id="Guidelines_for_Managing_Cloned_Packets"></a><a id="guidelines_for_managing_cloned_packets"></a><a id="GUIDELINES_FOR_MANAGING_CLONED_PACKETS"></a>Guidelines for Managing Cloned Packets</h3>
-A callout driver must not hold cloned packets indefinitely. A cloned packet can interfere with power
-     management operations on an idle computer.
+### Guidelines for managing cloned packets
+A callout driver must not hold cloned packets indefinitely. A cloned packet can interfere with power management operations on an idle computer.
 
-The intended use for deep cloned packets in WFP is to get clarification from a user-mode application or
-     other relatively fast operation that needs a packet independent of the original. The callout driver must not 
-     hold cloned packets while, for example, waiting for user input, or waiting for web service clearance, or waiting 
-     for any other operation that might take an arbitrary amount of time.
+The intended use for deep cloned packets in WFP is to get clarification from a user-mode application or other relatively fast operation that needs a packet independent of the original. The callout driver must not hold cloned packets while waiting for user input, web service clearance, or any other operation that might take an arbitrary amount of time.
 
 Callout drivers should always return held packets as quickly as possible.
 
 ## -see-also
 
-<a href="/windows-hardware/drivers/ddi/fwpsk/nf-fwpsk-fwpsfreeclonenetbufferlist0">FwpsFreeCloneNetBufferList0</a>
-
-
-
-<a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer">NET_BUFFER</a>
-
-
-
-<a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a>
-
-
-
-<a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list_context">NET_BUFFER_LIST_CONTEXT</a>
-
-
-
-<a href="/windows-hardware/drivers/ddi/nblapi/nf-nblapi-ndisallocatenetbufferlistpool">
-   NdisAllocateNetBufferListPool</a>
-
-
-
-<a href="/windows-hardware/drivers/ddi/ndis/nf-ndis-ndisallocatenetbufferpool">NdisAllocateNetBufferPool</a>
-
-
-
-<a href="/windows-hardware/drivers/network/packet-injection-functions">Packet Injection Functions</a>
+[**FwpsFreeCloneNetBufferList0**](nf-fwpsk-fwpsfreeclonenetbufferlist0.md) 
+[**NET_BUFFER**](../nbl/ns-nbl-net_buffer.md) 
+[**NET_BUFFER_LIST**](../nbl/ns-nbl-net_buffer_list.md) 
+[**NET_BUFFER_LIST_CONTEXT**](../nbl/ns-nbl-net_buffer_list_context.md) 
+[**NdisAllocateNetBufferListPool**](../nblapi/nf-nblapi-ndisallocatenetbufferlistpool.md) 
+[**NdisAllocateNetBufferPool**](../ndis/nf-ndis-ndisallocatenetbufferpool.md) 
+[Packet injection functions](/windows-hardware/drivers/network/packet-injection-functions)

--- a/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsallocatedeepclonenetbufferlist0.md
+++ b/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsallocatedeepclonenetbufferlist0.md
@@ -1,0 +1,203 @@
+---
+UID: NF:fwpsk.FwpsAllocateDeepCloneNetBufferList0
+title: FwpsAllocateDeepCloneNetBufferList0 function (fwpsk.h)
+description: The FwpsAllocateDeepCloneNetBufferList0 function allocates a NET_BUFFER_LIST structure that is a deep clone of an existing NET_BUFFER_LIST structure.
+old-location: netvista\FwpsAllocateDeepCloneNetBufferList0.htm
+tech.root: netvista
+ms.date: 05/02/2023
+keywords: ["FwpsAllocateDeepCloneNetBufferList0 function"]
+ms.keywords: FwpsAllocateDeepCloneNetBufferList0, FwpsAllocateDeepCloneNetBufferList0 function [Network Drivers Starting with Windows 11], fwpsk/FwpsAllocateDeepCloneNetBufferList0, netvista.FwpsAllocateDeepCloneNetBufferList0, wfp_ref_2_funct_3_fwps_A-B_1b361080-1a63-485a-89fc-05ef6b0cb1df.xml
+req.header: fwpsk.h
+req.include-header: Fwpsk.h
+req.target-type: Universal
+req.target-min-winverclnt: Available starting with Windows 11.
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: Fwpkclnt.lib
+req.dll: 
+req.irql: <= DISPATCH_LEVEL
+targetos: Windows
+req.typenames: 
+f1_keywords:
+ - FwpsAllocateDeepCloneNetBufferList0
+ - fwpsk/FwpsAllocateDeepCloneNetBufferList0
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - LibDef
+api_location:
+ - fwpkclnt.lib
+ - fwpkclnt.dll
+api_name:
+ - FwpsAllocateDeepCloneNetBufferList0
+---
+
+# FwpsAllocateDeepCloneNetBufferList0 function
+
+
+## -description
+
+The 
+  <b>FwpsAllocateDeepCloneNetBufferList0</b> function allocates a 
+  <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure that is a deep clone of an existing
+  <b>NET_BUFFER_LIST</b> structure.
+<div> </div>
+
+## -parameters
+
+### -param originalNetBufferList [in, out]
+
+
+A pointer to the original 
+     <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure that is being
+     cloned.
+
+### -param netBufferListPoolHandle [in, optional]
+
+
+A 
+     <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> pool handle that was
+     obtained from a previous call to the 
+     <a href="/windows-hardware/drivers/ddi/nblapi/nf-nblapi-ndisallocatenetbufferlistpool">
+     NdisAllocateNetBufferListPool</a> function. This parameter is optional and can be <b>NULL</b>.
+
+### -param netBufferPoolHandle [in, optional]
+
+
+A 
+     <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer">NET_BUFFER</a> pool handle that was obtained from a
+     previous call to the 
+     <a href="/windows-hardware/drivers/ddi/ndis/nf-ndis-ndisallocatenetbufferpool">NdisAllocateNetBufferPool</a> function. This parameter is optional and can be <b>NULL</b>.
+
+### -param netBufferList [out]
+
+
+A pointer to a variable that receives a pointer to the deep clone 
+     <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure.
+
+## -returns
+
+The 
+     <b>FwpsAllocateDeepCloneNetBufferList0</b> function returns one of the following NTSTATUS codes.
+
+<table>
+<tr>
+<th>Return code</th>
+<th>Description</th>
+</tr>
+<tr>
+<td width="40%">
+<dl>
+<dt><b>STATUS_SUCCESS</b></dt>
+</dl>
+</td>
+<td width="60%">
+The deep clone 
+       <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure was
+       successfully allocated.
+
+</td>
+</tr>
+<tr>
+<td width="40%">
+<dl>
+<dt><b>Other status codes</b></dt>
+</dl>
+</td>
+<td width="60%">
+An error occurred.
+
+</td>
+</tr>
+</table>
+
+## -remarks
+
+A callout driver calls the 
+    <b>FwpsAllocateDeepCloneNetBufferList0</b> function to allocate a deep clone 
+    <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a> structure of an existing
+    NET_BUFFER_LIST structure.
+
+This function is a wrapper around the 
+    <a href="/windows-hardware/drivers/ddi/ndis/nf-ndis-ndisallocateclonenetbufferlist">
+    NdisAllocateCloneNetBufferList</a> function, but it is specialized for use by WFP 
+    <a href="/windows-hardware/drivers/network/packet-injection-functions">packet injection functions</a>.
+
+If the deep clone NET_BUFFER_LIST structure should have attributes that are associated with a specific pool,
+    the callout driver must specify the pool handle in the 
+    <i>NetBufferListPoolHandle</i> or 
+    <i>NetBufferPoolHandle</i> parameter. If these parameters are <b>NULL</b>, the default pool preallocated by NDIS
+    is used.
+
+The  deep clone NET_BUFFER_LIST structure describes the same data that is described by the original
+    NET_BUFFER_LIST structure. The 
+    <b>FwpsAllocateDeepCloneNetBufferList0</b> function does copy the data that is described by the original
+    MDLs to new data buffers. The clone NET_BUFFER_LIST structure does include an initial 
+    <a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list_context">
+    NET_BUFFER_LIST_CONTEXT</a> structure.
+
+This function sets the 
+    <b>ParentNetBufferList</b> member of the newly created clone NET_BUFFER_LIST structure to point to the
+    parent NET_BUFFER_LIST structure. The parent structure's 
+    <b>ChildRefCount</b> member is incremented by 1.
+
+A callout driver can modify the clone NET_BUFFER_LIST structure and inject it into the network stack
+    in place of the original NET_BUFFER_LIST structure by calling the 
+    <a href="/windows-hardware/drivers/network/packet-injection-functions">packet injection functions</a>. After
+    the data described by the clone NET_BUFFER_LIST structure has been successfully injected into the network
+    stack, the callout driver frees the clone NET_BUFFER_LIST structure by calling the 
+    <a href="/windows-hardware/drivers/ddi/fwpsk/nf-fwpsk-fwpsfreeclonenetbufferlist0">FwpsFreeCloneNetBufferList0</a> function.
+
+A callout driver can insert or replace individual net buffers (<a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer">NET_BUFFER</a>) or MDLs inside the deep clone net buffer
+    list. Such a driver must also undo the modifications before it calls the 
+    <a href="/windows-hardware/drivers/ddi/fwpsk/nf-fwpsk-fwpsfreeclonenetbufferlist0">
+    FwpsFreeCloneNetBufferList0</a> function.
+
+<h3><a id="Guidelines_for_Managing_Cloned_Packets"></a><a id="guidelines_for_managing_cloned_packets"></a><a id="GUIDELINES_FOR_MANAGING_CLONED_PACKETS"></a>Guidelines for Managing Cloned Packets</h3>
+A callout driver must not hold cloned packets indefinitely. A cloned packet can interfere with power
+     management operations on an idle computer.
+
+The intended use for deep cloned packets in WFP is to get clarification from a user-mode application or
+     other relatively fast operation that needs a packet independent of the original. The callout driver must not 
+     hold cloned packets while, for example, waiting for user input, or waiting for web service clearance, or waiting 
+     for any other operation that might take an arbitrary amount of time.
+
+Callout drivers should always return held packets as quickly as possible.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/fwpsk/nf-fwpsk-fwpsfreeclonenetbufferlist0">FwpsFreeCloneNetBufferList0</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer">NET_BUFFER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list">NET_BUFFER_LIST</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/nbl/ns-nbl-net_buffer_list_context">NET_BUFFER_LIST_CONTEXT</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/nblapi/nf-nblapi-ndisallocatenetbufferlistpool">
+   NdisAllocateNetBufferListPool</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/ndis/nf-ndis-ndisallocatenetbufferpool">NdisAllocateNetBufferPool</a>
+
+
+
+<a href="/windows-hardware/drivers/network/packet-injection-functions">Packet Injection Functions</a>


### PR DESCRIPTION
Adds a new documentation page for FwpsAllocateDeepCloneNetBufferList0 which is a new allocation function in the WFP Public API space that performs a deep clone of a NET_BUFFER_LIST.