### PR TITLE
Update HidD_SetFeature kernel-mode mapping

### DIFF
--- a/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_setfeature.md
+++ b/wdk-ddi-src/content/hidsdi/nf-hidsdi-hidd_setfeature.md
@@ -83,7 +83,7 @@ Before it calls the **HidD_SetFeature** routine, the caller must do the followin
 
 For an example of how to prepare and a HID report and send it to a [top-level collection](/windows-hardware/drivers/hid/top-level-collections), see the [HClient](/samples/microsoft/windows-driver-samples/hclient-sample-application/) sample application.
 
-Only user-mode applications can call **HidD_SetFeature**. Kernel-mode drivers can use an [IOCTL_HID_SET_OUTPUT_REPORT](../hidclass/ni-hidclass-ioctl_hid_set_output_report.md) request.
+Only user-mode applications can call **HidD_SetFeature**. Kernel-mode drivers can use an [IOCTL_HID_SET_FEATURE](../hidclass/ni-hidclass-ioctl_hid_set_feature.md) request.
 
 ## -see-also
 


### PR DESCRIPTION
`HidD_SetFeature` should in my mind map to `IOCTL_HID_SET_FEATURE` instead of `IOCTL_HID_SET_OUTPUT_REPORT` in kernel-mode. This is furthermore the IOCTL used in the https://github.com/microsoft/Windows-driver-samples/blob/main/hid/firefly/driver/vfeature.c sample for sending a HID feature-report to an IntelliMouse device.