### PR TITLE
Do not expect that Acquires will be matched by Release

### DIFF
--- a/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_parameters.md
+++ b/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_parameters.md
@@ -105,7 +105,7 @@ The following I/O operations do not have parameters, and therefore do not have a
 - IRP_MJ_SHUTDOWN
 - IRP_MJ_VOLUME_DISMOUNT
 
-For the operations that come in Acquire/Release pairs (ModWrite, CcFlush, Section), there is no guarantee that the release call will happen even after a sucessfull call to the post acquire callback.  An example would be a if an instance detach occurs.
+Note that the terms "acquire" or "release" in some operation names, such as `IRP_MJ_ACQUIRE_FOR_CC_FLUSH` and `IRP_MJ_RELEASE_FOR_CC_FLUSH`, do not imply any guarantees that a minifilter will always see both operations. Just as with operations such as `IRP_MJ_CREATE` and `IRP_MJ_CLEANUP`, a minifilter may be prevented from observing the second operation by other factors, such as receiving an _[InstanceTeardownStartCallback](/windows-hardware/drivers/ddi/fltkernel/nc-fltkernel-pflt_instance_teardown_callback)_ before the second operation occurs.
 
 Counterinutitively, you should therefore avoid acquring resources in the Acquire call and releasing them in the release call.  If you have to you should either stall the instance detach (*before* Instance TearDownStart callback) or arrange for the resources to be released during instance tear down.
 

--- a/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_parameters.md
+++ b/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_parameters.md
@@ -105,6 +105,11 @@ The following I/O operations do not have parameters, and therefore do not have a
 - IRP_MJ_SHUTDOWN
 - IRP_MJ_VOLUME_DISMOUNT
 
+For the operations that come in Acquire/Release pairs (ModWrite, CcFlush, Section), there is no guarantee that the release call will happen even after a sucessfull call to the post acquire callback.  An example would be a if an instance detach occurs.
+
+Counterinutitively, you should therefore avoid acquring resources in the Acquire call and releasing them in the release call.  If you have to you should either stall the instance detach (*before* Instance TearDownStart callback) or arrange for the resources to be released during instance tear down.
+
+
 ## -see-also
 
 [FLT_CALLBACK_DATA](./ns-fltkernel-_flt_callback_data.md)

--- a/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_parameters.md
+++ b/wdk-ddi-src/content/fltkernel/ns-fltkernel-_flt_parameters.md
@@ -107,9 +107,6 @@ The following I/O operations do not have parameters, and therefore do not have a
 
 Note that the terms "acquire" or "release" in some operation names, such as `IRP_MJ_ACQUIRE_FOR_CC_FLUSH` and `IRP_MJ_RELEASE_FOR_CC_FLUSH`, do not imply any guarantees that a minifilter will always see both operations. Just as with operations such as `IRP_MJ_CREATE` and `IRP_MJ_CLEANUP`, a minifilter may be prevented from observing the second operation by other factors, such as receiving an _[InstanceTeardownStartCallback](/windows-hardware/drivers/ddi/fltkernel/nc-fltkernel-pflt_instance_teardown_callback)_ before the second operation occurs.
 
-Counterinutitively, you should therefore avoid acquring resources in the Acquire call and releasing them in the release call.  If you have to you should either stall the instance detach (*before* Instance TearDownStart callback) or arrange for the resources to be released during instance tear down.
-
-
 ## -see-also
 
 [FLT_CALLBACK_DATA](./ns-fltkernel-_flt_callback_data.md)


### PR DESCRIPTION
This is very grotty and edge case but kinda matters (and is also incredibly non-intuitive unless you think too har about the FltMgr implementation) but as a good rule you should not acquire any resources in the Acquire calls (which provoke many philosophical questions).

This is a bad initial attempt to explain this.  I'm sure Lori and Ted will do better, but that was 10 days of my life I wont get back debugging this so I wanted to capture it (and share my angst with the guys over in Redmond :-)