### PR TITLE
network: fix the spelling of NDIS_NIC_SWITCH_FRIENDLYNAME

### DIFF
--- a/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_nic_switch_info.md
+++ b/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_nic_switch_info.md
@@ -93,7 +93,7 @@ An NDIS_NIC_SWITCH_ID value that specifies a switch identifier. The switch ident
 
 ### -field SwitchFriendlyName
 
-An NDIS_NIC_SWITCH_FRIENDLY_NAME value that contains the user-friendly description of the switch.
+An NDIS_NIC_SWITCH_FRIENDLYNAME value that contains the user-friendly description of the switch.
 
 ### -field NumVFs
 

--- a/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_nic_switch_parameters.md
+++ b/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_nic_switch_parameters.md
@@ -107,7 +107,7 @@ An NDIS_NIC_SWITCH_ID value that contains a switch identifier. The switch identi
 
 ### -field SwitchFriendlyName
 
-An NDIS_NIC_SWITCH_FRIENDLY_NAME value that contains a description for the switch.
+An NDIS_NIC_SWITCH_FRIENDLYNAME value that contains a description for the switch.
 
 ### -field NumVFs
 


### PR DESCRIPTION
The actual code does not have a 4th underbar