### PR TITLE
Widen warning about when not to call FltCreateFile

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefile.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefile.md
@@ -143,7 +143,7 @@ Driver routines that do not run in the system process context must set the OBJ_K
 > [!NOTE]
 > Do not call this routine with a non-NULL top level IRP value, as this can cause a system deadlock.
 >
-> Do not call this routine with APC's disabled (an outstanding FsRtlEnterFileSystem or KeEnterCritical region), as this cas cause a thread deadlock
+> Do not call this routine with APCs disabled (an outstanding [**FsRtlEnterFileSystem**](/windows-hardware/drivers/ifs/fsrtlenterfilesystem) or [**KeEnterCriticalRegion**](../ntddk/nf-ntddk-keentercriticalregion.md), as this can cause a thread deadlock.
 
 Certain *DesiredAccess* flags and combinations of flags have the following effects:
 

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefile.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcreatefile.md
@@ -142,6 +142,8 @@ Driver routines that do not run in the system process context must set the OBJ_K
 
 > [!NOTE]
 > Do not call this routine with a non-NULL top level IRP value, as this can cause a system deadlock.
+>
+> Do not call this routine with APC's disabled (an outstanding FsRtlEnterFileSystem or KeEnterCritical region), as this cas cause a thread deadlock
 
 Certain *DesiredAccess* flags and combinations of flags have the following effects:
 


### PR DESCRIPTION
In particular you should not send any creates down (this change is for FltCreateFile but the same is true for IoCreateFile and all the FltCreateFile variants) to FASTFAT with kernel APCs disabled at all.  If the IRP is cancelled FASTFAT will see an eventual Oplock Break come in as an APC (for some magical reason NTFS is OK).

EnhancedOplocks var 13 subvar 1 is a good repro.