### PR TITLE
Add QoC USN and Security support

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltrequestfileinfooncreatecompletion.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltrequestfileinfooncreatecompletion.md
@@ -1,7 +1,7 @@
 ---
 UID: NF:fltkernel.FltRequestFileInfoOnCreateCompletion
 title: FltRequestFileInfoOnCreateCompletion function
-description: A minifilter calls FltRequestFileInfoOnCreateCompletion during file pre-create to request that the file manager stores the specified file information for retrieval upon create complete.
+description: A minifilter calls FltRequestFileInfoOnCreateCompletion during file pre-create to request that the file system stores the specified file information for retrieval upon create complete.
 tech.root: ifsk
 ms.date: 01/11/2019
 keywords: ["FltRequestFileInfoOnCreateCompletion function"]
@@ -42,7 +42,7 @@ api_name:
 
 ## -description
 
-A minifilter calls **FltRequestFileInfoOnCreateCompletion** during file pre-create to request that the file manager store file information for retrieval during post create.
+A minifilter calls **FltRequestFileInfoOnCreateCompletion** during file pre-create to request that the file system stores file information for retrieval during post create.
 
 ## -parameters
 
@@ -60,9 +60,10 @@ Flag bitmask indicating the type of file information that the file system should
 
 | Flag | Meaning |
 | ---- | ------- |
-| **QoCFileStatInformation** (0x00000001) | If set, the file system will store file stat information in a QUERY_ON_CREATE_FILE_STAT_INFORMATION structure for retrieval. |
-| **QoCFileLxInformation** (0x00000002) | If set, the file system will store extended Linux-like information in a QUERY_ON_CREATE_FILE_LX_INFORMATION structure for retrieval. |
-| **QoCFileEaInformation** (0x00000004) | If set, the file system will store extended attributes (EA) in a QUERY_ON_CREATE_EA_INFORMATION structure for retrieval. |
+| **QoCFileStatInformation** (0x00000001) | If set, the file system will store file stat information in a [**QUERY_ON_CREATE_FILE_STAT_INFORMATION**](../ntifs/ns-ntifs-query_on_create_file_stat_information.md) structure for retrieval. |
+| **QoCFileLxInformation** (0x00000002) | If set, the file system will store extended Linux-like information in a [**QUERY_ON_CREATE_FILE_LX_INFORMATION**](../ntifs/ns-ntifs-query_on_create_file_lx_information.md) structure for retrieval. |
+| **QoCFileEaInformation** (0x00000004) | If set, the file system will store extended attributes (EA) in a [**QUERY_ON_CREATE_EA_INFORMATION**](../ntifs/ns-ntifs-query_on_create_ea_information.md) structure for retrieval. |
+| **QoCFileUsnInformation** (0x00000008) | If set, the file system will store USN information in a [**QUERY_ON_CREATE_USN_INFORMATION**](../ntifs/ns-ntifs-query_on_create_usn_information.md) structure for retrieval. |
 
 ## -returns
 

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltrequestsecurityinfooncreatecompletion.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltrequestsecurityinfooncreatecompletion.md
@@ -1,0 +1,87 @@
+---
+UID: NF:fltkernel.FltRequestSecurityInfoOnCreateCompletion
+title: FltRequestSecurityInfoOnCreateCompletion function
+description: A minifilter calls FltRequestSecurityInfoOnCreateCompletion during file pre-create to request that the file system stores the file security information for retrieval upon create complete.
+tech.root: ifsk
+ms.date: 01/11/2019
+keywords: ["FltRequestSecurityInfoOnCreateCompletion function"]
+ms.keywords: FltRequestSecurityInfoOnCreateCompletion, FltRetrieveFileInfoOnCreateCompletion, FltRetrieveFileInfoOnCreateCompletionEx
+req.header: fltkernel.h
+req.include-header: Fltkernel.h
+req.target-type: 
+req.target-min-winverclnt: Windows 11, version 24H2
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.lib: 
+req.dll: 
+req.irql: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+targetos: Windows
+f1_keywords:
+ - FltRequestSecurityInfoOnCreateCompletion
+ - fltkernel/FltRequestSecurityInfoOnCreateCompletion
+topic_type:
+ - apiref
+api_type:
+ - HeaderDef
+api_location:
+ - fltkernel.h
+api_name:
+ - FltRequestSecurityInfoOnCreateCompletion
+---
+
+# FltRequestSecurityInfoOnCreateCompletion function
+
+
+## -description
+
+A minifilter calls **FltRequestSecurityInfoOnCreateCompletion** during file pre-create to request that the file system stores file security information for retrieval during post create.
+
+## -parameters
+
+### -param Filter
+
+Opaque filter pointer that uniquely identifies the minifilter driver.
+
+### -param Data
+
+Pointer to the [**FLT_CALLBACK_DATA**](ns-fltkernel-_flt_callback_data.md) callback data representing the I/O create operation.
+
+### -param SecurityInformation
+
+[**SECURITY_INFORMATION**](/windows-hardware/drivers/ifs/security-information) value specifying the information to be set as a combination of one or more of the following. 
+
+| Value | Meaning |
+| ----- | ------- |
+| OWNER_SECURITY_INFORMATION | Indicates the owner identifier of the object is to be set. Requires WRITE_OWNER access. |
+| GROUP_SECURITY_INFORMATION | Indicates the primary group identifier of the object is to be set. Requires WRITE_OWNER access. |
+| DACL_SECURITY_INFORMATION | Indicates the discretionary access control list (DACL) of the object is to be set. Requires WRITE_DAC access. |
+| SACL_SECURITY_INFORMATION | Indicates the system ACL (SACL) of the object is to be set. Requires ACCESS_SYSTEM_SECURITY access. |
+
+## -returns
+
+**FltRequestSecurityInfoOnCreateCompletion** can return one of the following values:
+
+| Return code | Description |
+| ----------- | ----------- |
+| **STATUS_SUCCESS** | The file system successfully stored the requested file security information. |
+| **STATUS_INSUFFICIENT_RESOURCES** | **FltRequestSecurityInfoOnCreateCompletion** was unable to allocate sufficient memory in which to store the requested file information. |
+| **STATUS_INVALID_PARAMETER_2** | The provided callback data object was not an IRP-based create operation. |
+
+## -remarks
+
+The minifilter can retrieve the file information by calling [**FltRetrieveFileInfoOnCreateCompletionEx**](nf-fltkernel-fltretrievefileinfooncreatecompletionex.md) or [**FltRetrieveFileInfoOnCreateCompletion**](nf-fltkernel-fltretrievefileinfooncreatecompletion.md) during post create. A minifilter's performance is typically better when it requests and retrieves file information in this manner, rather than querying file information at a later time.
+
+## -see-also
+
+[**FltRetrieveFileInfoOnCreateCompletion**](nf-fltkernel-fltretrievefileinfooncreatecompletion.md)
+
+[**FltRetrieveFileInfoOnCreateCompletionEx**](nf-fltkernel-fltretrievefileinfooncreatecompletionex.md)
+

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltretrievefileinfooncreatecompletion.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltretrievefileinfooncreatecompletion.md
@@ -59,9 +59,11 @@ Flag that indicates the type of information to return. Note that flags cannot be
 
 | Flag | Meaning |
 | ---- | ------- |
-| **QoCFileStatInformation** (0x00000001) | The file system will return file stat information in a QUERY_ON_CREATE_FILE_STAT_INFORMATION structure. |
-| **QoCFileLxInformation** (0x00000002) | The file system will return extended Linux-like information in a QUERY_ON_CREATE_FILE_LX_INFORMATION structure. |
-| **QoCFileEaInformation** (0x00000004) | The file system will return extended attributes (EA) in a QUERY_ON_CREATE_EA_INFORMATION structure. |
+| **QoCFileStatInformation** (0x00000001) | The file system will return file stat information in a [**QUERY_ON_CREATE_FILE_STAT_INFORMATION**](../ntifs/ns-ntifs-query_on_create_file_stat_information.md) structure. |
+| **QoCFileLxInformation** (0x00000002) | The file system will return extended Linux-like information in a [**QUERY_ON_CREATE_FILE_LX_INFORMATION**](../ntifs/ns-ntifs-query_on_create_file_lx_information.md) structure. |
+| **QoCFileEaInformation** (0x00000004) | The file system will return extended attributes (EA) in a [**QUERY_ON_CREATE_EA_INFORMATION**](../ntifs/ns-ntifs-query_on_create_ea_information.md) structure. |
+| **QoCFileUsnInformation** (0x00000008) | The file system will return USN information in a [**QUERY_ON_CREATE_USN_INFORMATION**](../ntifs/ns-ntifs-query_on_create_usn_information.md) structure. |
+| **QoCFileSecurityInformation** (0x00000010) | The file system will return file security information in a [**QUERY_ON_CREATE_SECURITY_INFORMATION**](../ntifs/ns-ntifs-query_on_create_security_information.md) structure. |
 
 ### -param Size [out]
 

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltretrievefileinfooncreatecompletionex.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltretrievefileinfooncreatecompletionex.md
@@ -65,6 +65,8 @@ Flag that indicates the type of file information to return. Note that flags cann
 | **QoCFileStatInformation** (0x00000001) | The file system will return file stat information in a [**QUERY_ON_CREATE_FILE_STAT_INFORMATION**](../ntifs/ns-ntifs-query_on_create_file_stat_information.md) structure. |
 | **QoCFileLxInformation** (0x00000002) | The file system will return extended Linux-like information in a [**QUERY_ON_CREATE_FILE_LX_INFORMATION**](../ntifs/ns-ntifs-query_on_create_file_lx_information.md) structure. |
 | **QoCFileEaInformation** (0x00000004) | The file system will return extended attributes (EA) in a [**QUERY_ON_CREATE_EA_INFORMATION**](../ntifs/ns-ntifs-query_on_create_ea_information.md) structure. |
+| **QoCFileUsnInformation** (0x00000008) | The file system will return USN information in a [**QUERY_ON_CREATE_USN_INFORMATION**](../ntifs/ns-ntifs-query_on_create_usn_information.md) structure. |
+| **QoCFileSecurityInformation** (0x00000010) | The file system will return file security information in a [**QUERY_ON_CREATE_SECURITY_INFORMATION**](../ntifs/ns-ntifs-query_on_create_security_information.md) structure. |
 
 ### -param RetInfoSize [out]
 
@@ -97,7 +99,10 @@ Receives a pointer to the requested **InfoClass** structure. If the file system 
 NTSTATUS status;
 status = FltRequestFileInfoOnCreateCompletion( Filter,
                                                CallbackData,
-                                               QoCFileStatInformation | QoCFileLxInformation | QoCFileEaInformation );
+                                               QoCFileStatInformation
+                                                | QoCFileLxInformation
+                                                | QoCFileEaInformation 
+                                                | QoCFileUsnInformation );
 
 // Post-create:
 NTSTATUS status;
@@ -105,6 +110,7 @@ ULONG fileStatSize, fileLxSize, fileEaSize;
 QUERY_ON_CREATE_FILE_STAT_INFORMATION* fileStatInfo;
 QUERY_ON_CREATE_FILE_LX_INFORMATION* fileLxInfo;
 QUERY_ON_CREATE_EA_INFORMATION* fileEaInfo;
+QUERY_ON_CREATE_USN_INFORMATION* fileUsnInfo;
 
 status = FltRetrieveFileInfoOnCreateCompletionEx( Filter,
                                                   CallbackData,
@@ -121,6 +127,11 @@ status = FltRetrieveFileInfoOnCreateCompletionEx( Filter,
                                                   QoCFileEaInformation, 
                                                   &fileEaSize, 
                                                   &fileEaInfo );
+status = FltRetrieveFileInfoOnCreateCompletionEx( Filter,
+                                                  CallbackData,
+                                                  QoCFileUsnInformation, 
+                                                  &fileUsnInfo, 
+                                                  &fileUsnInfo );
 ```
 
 Once **FltRetrieveFileInfoOnCreateCompletionEx** returns, a minifilter can write into the buffer that **RetInfoBuffer** points to. Any filters above that minifilter will see the changes if they call **FltRetrieveFileInfoOnCreateCompletionEx** on the modified information type.

--- a/wdk-ddi-src/content/ntifs/ns-ntifs-query_on_create_security_information.md
+++ b/wdk-ddi-src/content/ntifs/ns-ntifs-query_on_create_security_information.md
@@ -1,0 +1,72 @@
+---
+UID: NS:ntifs._QUERY_ON_CREATE_SECURITY_INFORMATION
+tech.root: ifsk
+title: QUERY_ON_CREATE_SECURITY_INFORMATION
+ms.date: 03/24/2024
+targetos: Windows
+description: The QUERY_ON_CREATE_SECURITY_INFORMATION structure is used to write file information when FltRequestSecurityInfoOnCreateCompletion is called in pre-create.
+req.construct-type: structure
+req.ddi-compliance: 
+req.dll: 
+req.header: ntifs.h
+req.include-header: 
+req.kmdf-ver: 
+req.lib: 
+req.max-support: 
+req.redist: 
+req.target-min-winverclnt: Windows 11, version 24H2
+req.target-min-winversvr: 
+req.target-type: 
+req.typenames: QUERY_ON_CREATE_SECURITY_INFORMATION, *PQUERY_ON_CREATE_SECURITY_INFORMATION
+req.umdf-ver: 
+req.unicode-ansi: 
+topic_type:
+ - apiref
+api_type:
+ - HeaderDef
+api_location:
+ - ntifs.h
+api_name:
+ - _QUERY_ON_CREATE_SECURITY_INFORMATION
+ - PQUERY_ON_CREATE_SECURITY_INFORMATION
+ - QUERY_ON_CREATE_SECURITY_INFORMATION
+f1_keywords:
+ - _QUERY_ON_CREATE_SECURITY_INFORMATION
+ - ntifs/_QUERY_ON_CREATE_SECURITY_INFORMATION
+ - PQUERY_ON_CREATE_SECURITY_INFORMATION
+ - ntifs/PQUERY_ON_CREATE_SECURITY_INFORMATION
+ - QUERY_ON_CREATE_SECURITY_INFORMATION
+ - ntifs/QUERY_ON_CREATE_SECURITY_INFORMATION
+dev_langs:
+ - c++
+---
+
+## -description
+
+The **QUERY_ON_CREATE_SECURITY_INFORMATION** structure is used to write file information when [**FltRequestSecurityInfoOnCreateCompletion**](../fltkernel/nf-fltkernel-fltrequestsecurityinfooncreatecompletion.md) is called in pre-create.
+
+## -struct-fields
+
+### -field Reserved
+
+This is undefined and reserved for future use.
+
+### -field SecurityDescriptorSize
+
+Size, in bytes, of the SecurityDescriptor buffer.
+
+### -field SecurityDescriptor
+
+Pointer to a buffer that receives a copy of the security descriptor for the specified object. The [**SECURITY_DESCRIPTOR**](../ntifs/ns-ntifs-_security_descriptor.md) structure is returned in self-relative format.
+
+## -remarks
+
+The system allocates this structure and the file system fills in the requested information, if supported, while it processes a file create. Filter Manager will eventually free the allocated structure.
+
+## -see-also
+
+[**FltQuerySecurityObject**](../fltkernel/nf-fltkernel-fltquerysecurityobject.md)
+
+[**FltRequestFileInfoOnCreateCompletion**](../fltkernel/nf-fltkernel-fltrequestfileinfooncreatecompletion.md)
+
+[**FltRetrieveFileInfoOnCreateCompletionEx**](../fltkernel/nf-fltkernel-fltretrievefileinfooncreatecompletionex.md)

--- a/wdk-ddi-src/content/ntifs/ns-ntifs-query_on_create_usn_information.md
+++ b/wdk-ddi-src/content/ntifs/ns-ntifs-query_on_create_usn_information.md
@@ -1,0 +1,66 @@
+---
+UID: NS:ntifs._QUERY_ON_CREATE_USN_INFORMATION
+tech.root: ifsk
+title: QUERY_ON_CREATE_USN_INFORMATION
+ms.date: 03/24/2024
+targetos: Windows
+description: The QUERY_ON_CREATE_USN_INFORMATION structure is used to write file information when FltRequestFileInfoOnCreateCompletion is called with the QoCFileUsnInformation flag set in the InfoClassFlags parameter.
+req.construct-type: structure
+req.ddi-compliance: 
+req.dll: 
+req.header: ntifs.h
+req.include-header: 
+req.kmdf-ver: 
+req.lib: 
+req.max-support: 
+req.redist: 
+req.target-min-winverclnt: Windows 11, version 24H2
+req.target-min-winversvr: 
+req.target-type: 
+req.typenames: QUERY_ON_CREATE_USN_INFORMATION, *PQUERY_ON_CREATE_USN_INFORMATION
+req.umdf-ver: 
+req.unicode-ansi: 
+topic_type:
+ - apiref
+api_type:
+ - HeaderDef
+api_location:
+ - ntifs.h
+api_name:
+ - _QUERY_ON_CREATE_USN_INFORMATION
+ - PQUERY_ON_CREATE_USN_INFORMATION
+ - QUERY_ON_CREATE_USN_INFORMATION
+f1_keywords:
+ - _QUERY_ON_CREATE_USN_INFORMATION
+ - ntifs/_QUERY_ON_CREATE_USN_INFORMATION
+ - PQUERY_ON_CREATE_USN_INFORMATION
+ - ntifs/PQUERY_ON_CREATE_USN_INFORMATION
+ - QUERY_ON_CREATE_USN_INFORMATION
+ - ntifs/QUERY_ON_CREATE_USN_INFORMATION
+dev_langs:
+ - c++
+---
+
+## -description
+
+The **QUERY_ON_CREATE_USN_INFORMATION** structure is used to write file information when [**FltRequestFileInfoOnCreateCompletion**](../fltkernel/nf-fltkernel-fltrequestfileinfooncreatecompletion.md) is called with the **QoCFileUsnInformation** flag set in the **InfoClassFlags** parameter.
+
+## -struct-fields
+
+### -field Usn
+
+The USN (Update Sequence Number) for this file or directory.
+
+### -field FileReferenceNumber
+
+The 128-bit file ID (aka ordinal number) of the file or directory.
+
+## -remarks
+
+The system allocates this structure and the file system fills in the requested information, if supported, while it processes a file create. Filter Manager will eventually free the allocated structure.
+
+## -see-also
+
+[**FltRequestFileInfoOnCreateCompletion**](../fltkernel/nf-fltkernel-fltrequestfileinfooncreatecompletion.md)
+
+[**FltRetrieveFileInfoOnCreateCompletionEx**](../fltkernel/nf-fltkernel-fltretrievefileinfooncreatecompletionex.md)


### PR DESCRIPTION
Update the below routines and types to talk about
the QoC (query on create) support for USN and file
security information added in Ge.
 * FltRequestFileInfoOnCreateCompletion
 * FltRequestSecurityInfoOnCreateCompletion
 * FltRetrieveFileInfoOnCreateCompletion
 * FltRetrieveFileInfoOnCreateCompletionEx
 * QUERY_ON_CREATE_SECURITY_INFORMATION
 * QUERY_ON_CREATE_USN_INFORMATION