### PR TITLE
ntdddisk-_disk_performance.md : Fix StorageManagerName description formatting

### DIFF
--- a/wdk-ddi-src/content/ntdddisk/ns-ntdddisk-_disk_performance.md
+++ b/wdk-ddi-src/content/ntdddisk/ns-ntdddisk-_disk_performance.md
@@ -101,7 +101,7 @@ Contains a unique number assigned to every disk or volume across a particular st
 
 ### -field StorageManagerName
 
-Contains an 8-character string that indicates which device driver provided the performance statistics. In Windows 2000, this can be either "LogiDisk" for the driver <i>logidisk.sys</i> or "PhysDisk" for the driver <i>physdisk.sys</i>. These drivers collect performance statistics for devices and physical disks respectively. In Windows XP and later operating systems, this can be any of the following three strings: "FTDISK" for the driver <i>ftdisk.sys</i>, "DMIO" for the driver <i>dmio.sys</i>, or PARTMGR" for the driver <i>partmgr.sys</i>. These three drivers collect performance statistics for basic disk volumes, dynamic disk volumes, and physical disks respectively. Note that these strings are 8-character case-sensitive strings with blank fill. For example, in the case of the string "FTDISK", the <b>StorageManagerName</b> character array should contain two trailing blanks ("FTDISK<b><b>"), and in the case of the string "DMIO", the array should contain four trailing blanks ("DMIO<b><b><b><b>").
+Contains an 8-character string that indicates which device driver provided the performance statistics. In Windows 2000, this can be either "LogiDisk" for the driver <i>logidisk.sys</i> or "PhysDisk" for the driver <i>physdisk.sys</i>. These drivers collect performance statistics for devices and physical disks respectively. In Windows XP and later operating systems, this can be any of the following three strings: "FTDISK" for the driver <i>ftdisk.sys</i>, "DMIO" for the driver <i>dmio.sys</i>, or "PARTMGR" for the driver <i>partmgr.sys</i>. These three drivers collect performance statistics for basic disk volumes, dynamic disk volumes, and physical disks respectively. Note that these strings are 8-character case-sensitive strings with blank fill. For example, in the case of the string "FTDISK", the <b>StorageManagerName</b> character array should contain two trailing blanks ("FTDISK&nbsp&nbsp"), and in the case of the string "DMIO", the array should contain four trailing blanks ("DMIO&nbsp&nbsp&nbsp&nbsp").
 
 ## -remarks
 
@@ -110,8 +110,6 @@ Counting halts whenever the performance counters are disabled, but the counters 
 ## -see-also
 
 <a href="/windows-hardware/drivers/ddi/ntdddisk/ni-ntdddisk-ioctl_disk_performance">IOCTL_DISK_PERFORMANCE</a>
-
-
 
 <a href="/windows-hardware/drivers/ddi/ntdddisk/ni-ntdddisk-ioctl_disk_performance_off">IOCTL_DISK_PERFORMANCE_OFF</a>
 


### PR DESCRIPTION
The trailing-blank examples do not correctly show up, and text is wrongly set in bold.

Since a picture is worth 1000 words, here's the problem:
![image](https://github.com/MicrosoftDocs/windows-driver-docs-ddi/assets/1969829/5423f1de-89b3-4657-ac2f-ea3c099189e0)

Two questions/suggestions for the reviewers:
1. Would it be better to show these character-array string examples in monospace instead?
2. Since there are two examples provided out of the three possible documented cases, would it be worth adding the `"PARTMGR "` example as well?
