### PR TITLE
Feedback on broken link in ni-mountdev-ioctl_mountdev_query_unique_id.md

### DIFF
--- a/wdk-ddi-src/content/mountdev/ni-mountdev-ioctl_mountdev_query_unique_id.md
+++ b/wdk-ddi-src/content/mountdev/ni-mountdev-ioctl_mountdev_query_unique_id.md
@@ -45,6 +45,7 @@ api_name:
 
 ## -description
 
+<!-- BUGBUG!! Article mentions IOCTL_MOUNTDEV_UNIQUE_ID_CHANGE_NOTIFY but fails to document it, and the link is dead/non-existent -->
 Support for this IOCTL by mount manager clients is mandatory. Upon receiving this IOCTL, the mount manager client must provide a counted byte string identifier that is unique to the client (that is, the device or the volume). The client cannot change this unique ID without alerting the mount manager (see <a href="/windows-hardware/drivers/storage/index">IOCTL_MOUNTDEV_UNIQUE_ID_CHANGE_NOTIFY</a>).
 
 ## -ioctlparameters


### PR DESCRIPTION
# Issue/Feedback-only pseudo-PR! DO NOT MERGE!!

This article mentions a mountmgr callback via IOCTL_MOUNTDEV_UNIQUE_ID_CHANGE_NOTIFY, but the link to it seems to be either broken or non-existent.

Why is this so? Is this IOCTL deprecated, and if so, since when?
Note that an external place where it is kind of mentioned, is in an OSR article:
https://www.osronline.com/article.cfm%5Eid=107.htm

# Issue/Feedback-only pseudo-PR! DO NOT MERGE!!