### PR TITLE
Put in a note about The IOSB in the CBD after a wait

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcheckoplockex.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcheckoplockex.md
@@ -107,6 +107,8 @@ This routine has the following parameters:
 
 A pointer to the callback data structure for the I/O operation.
 
+**Note** That when your WaitCompleteRoutine is called the IoStatus sub-structure may have been filled in with a failure status (for instance STATUS_CANCELLED).  You should inspect this status and react appropriately.
+
 #### Context
 
 A context information pointer that was passed in the *Context* parameter to **FltCheckOplockEx**.

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcheckoplockex.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcheckoplockex.md
@@ -107,7 +107,7 @@ This routine has the following parameters:
 
 A pointer to the callback data structure for the I/O operation.
 
-**Note** That when your WaitCompleteRoutine is called the IoStatus sub-structure may have been filled in with a failure status (for instance STATUS_CANCELLED).  You should inspect this status and react appropriately.
+**Note** that when your *WaitCompleteRoutine* is called, the IoStatus sub-structure might be filled in with a failure status (for instance STATUS_CANCELLED).  You should inspect this status and react appropriately.
 
 #### Context
 


### PR DESCRIPTION
…called

Recently tripped over this, so I though I should make it explicit.

Lori, Ted: You may well find that there are other functions needing a similar annotation (e.g. FltCheckOplock).  This is the on I used and the one that bit me.