### PR TITLE
Update ns-d3d12umddi-d3d12ddicb_allocate_0022.md

### DIFF
--- a/wdk-ddi-src/content/d3d12umddi/ns-d3d12umddi-d3d12ddicb_allocate_0022.md
+++ b/wdk-ddi-src/content/d3d12umddi/ns-d3d12umddi-d3d12ddicb_allocate_0022.md
@@ -63,7 +63,7 @@ The handle of a resource.
 
 ### -field hKMResource
 
-A handle of a kernel resource.
+Reserved.
 
 ### -field NumAllocations
 


### PR DESCRIPTION
ALLOCATECB_0022 neither reads nor writes this field. Documenting as reserved to reduce confusion.