### PR TITLE
Update nf-ntstrsafe-rtlstringcchprintfw.md

### DIFF
--- a/wdk-ddi-src/content/ntstrsafe/nf-ntstrsafe-rtlstringcchprintfw.md
+++ b/wdk-ddi-src/content/ntstrsafe/nf-ntstrsafe-rtlstringcchprintfw.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ntstrsafe.lib
 req.dll: 
-req.irql: Any if strings being manipulated are always resident in memory, otherwise PASSIVE_LEVEL
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
Note that RtlStringCchPrintfW must be called from PASSIVE_LEVEL.