### PR TITLE
Make a Note about the context in which CcDeferWrite may call back.

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ccdeferwrite.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ccdeferwrite.md
@@ -69,7 +69,7 @@ VOID (*PCC_POST_DEFERRED_WRITE) (
     _In_ PVOID Context2
     );
 ```
-This function my be called with the TopLevelIrp field in the current IRP set to FSRTL_MOD_WRITE_TOP_LEVEL_IRP.
+This function can be called with the TopLevelIrp field in the current IRP set to FSRTL_MOD_WRITE_TOP_LEVEL_IRP.
 
 ### -param Context1 [in]
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ccdeferwrite.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ccdeferwrite.md
@@ -69,7 +69,7 @@ VOID (*PCC_POST_DEFERRED_WRITE) (
     _In_ PVOID Context2
     );
 ```
-
+This function my be called with the TopLevelIrp field in the current IRP set to FSRTL_MOD_WRITE_TOP_LEVEL_IRP.
 
 ### -param Context1 [in]
 


### PR DESCRIPTION
I was surpised that my call to FltQueueDeferredIoWorkItem was failing so I poked at the Thread.

It appears that if we are called from nt!CcFlushCachePriv+0x117 The top level irp value is 3. There is another path where we are called with it zero.

I feel sure that these could be wordsmithed better, but I am unsure what the correct phraseoligy you use for Get/Set TopLevelIrp and what links could be needed.