### PR TITLE
Document NDIS_RSS_CAPS_RSS_AVAILABLE_ON_PORTS

### DIFF
--- a/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_receive_scale_capabilities.md
+++ b/wdk-ddi-src/content/ntddndis/ns-ntddndis-_ndis_receive_scale_capabilities.md
@@ -6,7 +6,7 @@ old-location: netvista\ndis_receive_scale_capabilities.htm
 tech.root: netvista
 ms.date: 05/02/2018
 keywords: ["NDIS_RECEIVE_SCALE_CAPABILITIES structure"]
-ms.keywords: "*PNDIS_RECEIVE_SCALE_CAPABILITIES, NDIS_RECEIVE_SCALE_CAPABILITIES, NDIS_RECEIVE_SCALE_CAPABILITIES structure [Network Drivers Starting with Windows Vista], NDIS_RSS_CAPS_CLASSIFICATION_AT_DPC, NDIS_RSS_CAPS_CLASSIFICATION_AT_ISR, NDIS_RSS_CAPS_HASH_TYPE_TCP_IPV4, NDIS_RSS_CAPS_HASH_TYPE_TCP_IPV6, NDIS_RSS_CAPS_HASH_TYPE_TCP_IPV6_EX, NDIS_RSS_CAPS_HASH_TYPE_UDP_IPV4, NDIS_RSS_CAPS_HASH_TYPE_UDP_IPV6, NDIS_RSS_CAPS_HASH_TYPE_UDP_IPV6_EX, NDIS_RSS_CAPS_MESSAGE_SIGNALED_INTERRUPTS, NDIS_RSS_CAPS_SUPPORTS_MSI_X, NDIS_RSS_CAPS_USING_MSI_X, NdisHashFunctionReserved1, NdisHashFunctionReserved2, NdisHashFunctionReserved3, NdisHashFunctionToeplitz, PNDIS_RECEIVE_SCALE_CAPABILITIES, PNDIS_RECEIVE_SCALE_CAPABILITIES structure pointer [Network Drivers Starting with Windows Vista], _NDIS_RECEIVE_SCALE_CAPABILITIES, netvista.ndis_receive_scale_capabilities, ntddndis/NDIS_RECEIVE_SCALE_CAPABILITIES, ntddndis/PNDIS_RECEIVE_SCALE_CAPABILITIES, receive_scaling_structures_ref_b9df619b-57b8-4fa3-b292-bba02175a23a.xml"
+ms.keywords: "*PNDIS_RECEIVE_SCALE_CAPABILITIES, NDIS_RECEIVE_SCALE_CAPABILITIES, NDIS_RECEIVE_SCALE_CAPABILITIES structure [Network Drivers Starting with Windows Vista], NDIS_RSS_CAPS_CLASSIFICATION_AT_DPC, NDIS_RSS_CAPS_CLASSIFICATION_AT_ISR, NDIS_RSS_CAPS_HASH_TYPE_TCP_IPV4, NDIS_RSS_CAPS_HASH_TYPE_TCP_IPV6, NDIS_RSS_CAPS_HASH_TYPE_TCP_IPV6_EX, NDIS_RSS_CAPS_HASH_TYPE_UDP_IPV4, NDIS_RSS_CAPS_HASH_TYPE_UDP_IPV6, NDIS_RSS_CAPS_HASH_TYPE_UDP_IPV6_EX, NDIS_RSS_CAPS_MESSAGE_SIGNALED_INTERRUPTS, NDIS_RSS_CAPS_SUPPORTS_MSI_X, NDIS_RSS_CAPS_RSS_AVAILABLE_ON_PORTS, NDIS_RSS_CAPS_USING_MSI_X, NdisHashFunctionReserved1, NdisHashFunctionReserved2, NdisHashFunctionReserved3, NdisHashFunctionToeplitz, PNDIS_RECEIVE_SCALE_CAPABILITIES, PNDIS_RECEIVE_SCALE_CAPABILITIES structure pointer [Network Drivers Starting with Windows Vista], _NDIS_RECEIVE_SCALE_CAPABILITIES, netvista.ndis_receive_scale_capabilities, ntddndis/NDIS_RECEIVE_SCALE_CAPABILITIES, ntddndis/PNDIS_RECEIVE_SCALE_CAPABILITIES, receive_scaling_structures_ref_b9df619b-57b8-4fa3-b292-bba02175a23a.xml"
 req.header: ntddndis.h
 req.include-header: Ndis.h
 req.target-type: Windows
@@ -116,6 +116,16 @@ Set this flag if the NIC can indicate to the <a href="/windows-hardware/drivers/
 <td width="60%">
 Set this flag if the NIC is using message signaled interrupts (MSIs). This flag is supported in
        NDIS 6.20 and later.
+
+</td>
+</tr>
+<tr>
+<td width="40%"><a id="NDIS_RSS_CAPS_RSS_AVAILABLE_ON_PORTS"></a><a id="ndis_rss_caps_rss_available_on_ports"></a><dl>
+<dt><b>NDIS_RSS_CAPS_RSS_AVAILABLE_ON_PORTS</b></dt>
+</dl>
+</td>
+<td width="60%">
+Set this flag if the NIC supports independent RSS configuration of ports. This flag is supported in NDIS 6.30 and later.
 
 </td>
 </tr>


### PR DESCRIPTION
This flag was previously defined but not documented. Add the missing documentation.