### PR TITLE
Update nf-d3dkmthk-d3dkmtenumadapters3.md to specify correct library

### DIFF
--- a/wdk-ddi-src/content/d3dkmthk/nf-d3dkmthk-d3dkmtenumadapters3.md
+++ b/wdk-ddi-src/content/d3dkmthk/nf-d3dkmthk-d3dkmtenumadapters3.md
@@ -12,7 +12,7 @@ req.target-min-winverclnt: Windows 10, version 2004
 req.target-min-winversvr: 
 req.kmdf-ver: 
 req.umdf-ver: 
-req.lib: Gdi32.lib
+req.lib: onecoreuap.lib
 req.dll: Gdi32.dll
 req.irql: 
 req.ddi-compliance: 


### PR DESCRIPTION
D3dKMTEnumAdapters3 needs to link with onecoreuap.lib instead of gdi32.lib