### PR TITLE
Corrections, clarifications, and additions to oplock documentation

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatefile.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatefile.md
@@ -242,7 +242,7 @@ In Windows 7, if other handles exist on the file when an application uses the F
 
 If this create operation would break an oplock that already exists on the file, then setting the FILE_OPEN_REQUIRING_OPLOCK flag will cause the create operation to fail with STATUS_CANNOT_BREAK_OPLOCK. The existing oplock will not be broken by this create operation.
 
-An application that uses the FILE_OPEN_REQUIRING_OPLOCK flag must request an oplock after this call succeeds, or all subsequent attempts to open the file will be blocked without the benefit of normal oplock processing. Similarly, if this call succeeds but the subsequent oplock request fails, an application that uses this flag must close its handle after it detects that the oplock request has failed. The application must not perform any other file system operation on the file before requsting the oplock (besides closing the file handle), otherwise a deadlock may occur.
+An application that uses the FILE_OPEN_REQUIRING_OPLOCK flag must request an oplock after this call succeeds, or all subsequent attempts to open the file will be blocked without the benefit of normal oplock processing. Similarly, if this call succeeds but the subsequent oplock request fails, an application that uses this flag must close its handle after it detects that the oplock request has failed. The application must not perform any other file system operation on the file before requesting the oplock (besides closing the file handle), otherwise a deadlock may occur.
 
 > [!NOTE]
 > The FILE_OPEN_REQUIRING_OPLOCK flag is available in Windows 7, Windows Server 2008 R2 and later Windows operating systems. The Microsoft file systems that implement this flag in Windows 7 are NTFS, FAT, and exFAT.

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatefile.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatefile.md
@@ -242,7 +242,7 @@ In Windows 7, if other handles exist on the file when an application uses the F
 
 If this create operation would break an oplock that already exists on the file, then setting the FILE_OPEN_REQUIRING_OPLOCK flag will cause the create operation to fail with STATUS_CANNOT_BREAK_OPLOCK. The existing oplock will not be broken by this create operation.
 
-An application that uses the FILE_OPEN_REQUIRING_OPLOCK flag must request an oplock after this call succeeds, or all subsequent attempts to open the file will be blocked without the benefit of normal oplock processing. Similarly, if this call succeeds but the subsequent oplock request fails, an application that uses this flag must close its handle after it detects that the oplock request has failed.
+An application that uses the FILE_OPEN_REQUIRING_OPLOCK flag must request an oplock after this call succeeds, or all subsequent attempts to open the file will be blocked without the benefit of normal oplock processing. Similarly, if this call succeeds but the subsequent oplock request fails, an application that uses this flag must close its handle after it detects that the oplock request has failed. The application must not perform any other file system operation on the file before requsting the oplock (besides closing the file handle), otherwise a deadlock may occur.
 
 > [!NOTE]
 > The FILE_OPEN_REQUIRING_OPLOCK flag is available in Windows 7, Windows Server 2008 R2 and later Windows operating systems. The Microsoft file systems that implement this flag in Windows 7 are NTFS, FAT, and exFAT.


### PR DESCRIPTION
Documentation update:

* [`wdk-ddi-src/content/ntifs/nf-ntifs-ntcreatefile.md`](diffhunk://#diff-6614e90550ea75778f528f62d288616968646d7dad3953eee2c1dbafd25b2799L245-R245): Added a note specifying that the application must not perform any other file system operation on the file before requesting the oplock to avoid deadlocks.