### PR TITLE
Change WDI_BAND_ID definition from 900GHz to 900MHz

### DIFF
--- a/wdk-ddi-src/content/dot11wificxtypes/ne-dot11wificxtypes-wdi_band_id.md
+++ b/wdk-ddi-src/content/dot11wificxtypes/ne-dot11wificxtypes-wdi_band_id.md
@@ -58,7 +58,7 @@ The band ID is unknown.
 
 ### -field WDI_BAND_ID_900:4
 
-900 GHz.
+900 MHz.
 
 ### -field WDI_BAND_ID_6000:6
 


### PR DESCRIPTION
Under the _WDI_BAND_ID enumeration, there is a band called `WDI_BAND_ID_900`. When reading through the definitions, its defined as `900GHz` which seems like a typo.

In the documentation specified [here ](https://github.com/MicrosoftDocs/windows-driver-docs/blob/448e26a41d24d263156296f177a707b7546ecf94/windows-driver-docs-pr/network/wdi-band-id.md?plain=1#L25) its labelled correctly as 900MHz.