### PR TITLE
Extend WdfRequestSetCompletionRoutine to mention need for request formatting

### DIFF
--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestsetcompletionroutine.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestsetcompletionroutine.md
@@ -78,6 +78,8 @@ A bug check occurs if the driver supplies an invalid object handle.
 
 If your driver forwards I/O requests, but if you want your driver to be notified when a lower-level driver completes the request, your driver can provide a <a href="/windows-hardware/drivers/ddi/wdfrequest/nc-wdfrequest-evt_wdf_request_completion_routine">CompletionRoutine</a> callback function and call <b>WdfRequestSetCompletionRoutine</b> to register the function. The framework calls the callback function after a lower-level driver completes the I/O request. 
 
+If the driver sets an I/O completion callback, the driver must format the request before sending it to the default I/O target even if the driver does not change any of the parameters in the request. Formatting can be done using <a href="/windows-hardware/drivers/ddi/wdfrequest/nf-wdfrequest-wdfrequestformatrequestusingcurrenttype">WdfRequestFormatRequestUsingCurrentType</a>.
+
 For more information about <b>WdfRequestSetCompletionRoutine</b>, see <a href="/windows-hardware/drivers/wdf/completing-i-o-requests">Completing I/O Requests</a>.
 
 


### PR DESCRIPTION
The [Developing Drivers with the Windows Driver Foundation](https://learn.microsoft.com/en-us/windows-hardware/drivers/wdf/developing-drivers-with-wdf) book states the following:
> If the driver sets an I/O completion callback, the driver must format the request before sending it to the default I/O target even if the driver does not change any of the parameters in the request.

Proposing to extend the documentation to mention this requirement, and `WdfRequestFormatRequestUsingCurrentType` and as formatting function.