### PR TITLE
Add Min versions to request/retrieve FileInfoOnCreateCompletion

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltrequestfileinfooncreatecompletion.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltrequestfileinfooncreatecompletion.md
@@ -9,7 +9,7 @@ ms.keywords: FltRequestFileInfoOnCreateCompletion, FltRetrieveFileInfoOnCreateCo
 req.header: fltkernel.h
 req.include-header: Fltkernel.h
 req.target-type: 
-req.target-min-winverclnt: 
+req.target-min-winverclnt: Windows 10, version 1809
 req.target-min-winversvr: 
 req.kmdf-ver: 
 req.umdf-ver: 

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltretrievefileinfooncreatecompletion.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltretrievefileinfooncreatecompletion.md
@@ -9,7 +9,7 @@ ms.keywords: FltRetrieveFileInfoOnCreateCompletion
 req.header: fltkernel.h
 req.include-header: 
 req.target-type: 
-req.target-min-winverclnt: 
+req.target-min-winverclnt: Windows 10, version 1809
 req.target-min-winversvr: 
 req.kmdf-ver: 
 req.umdf-ver: 


### PR DESCRIPTION
The restriction was copied from Retrieve Ex and inferred as being the same because of the way the functions are defined in FltKernel