### PR TITLE
Fix missing HREF in PsGetProcessId

### DIFF
--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psgetprocessid.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psgetprocessid.md
@@ -60,7 +60,7 @@ A pointer to a process object structure.
 
 ## -remarks
 
-The EPROCESS-typed process object structure is an opaque data structure that the operating system uses internally. To obtain a pointer to the EPROCESS structure for the current process, a driver can call [PsGetCurrentProcess](/windows-hardware/drivers/kernel/mm-bad-pointer#psgetcurrentprocess). To obtain a pointer to the EPROCESS structure for a different process, the driver can call <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-obreferenceobjectbyhandle">ObReferenceObjectByHandle</a>.
+The EPROCESS-typed process object structure is an opaque data structure that the operating system uses internally. To obtain a pointer to the EPROCESS structure for the current process, a driver can call [PsGetCurrentProcess](windows-hardware/drivers/ddi/wdm/nf-wdm-iogetcurrentprocess). To obtain a pointer to the EPROCESS structure for a different process, the driver can call <a href="/windows-hardware/drivers/ddi/wdm/nf-wdm-obreferenceobjectbyhandle">ObReferenceObjectByHandle</a>.
 
 ## -see-also
 


### PR DESCRIPTION
HREF in current page points to MM_BAD_POINTER page and expects it to have a reference/tag/whatever for PsGetCurrentProcess, which it doesn't. Replaced with href to IoGetCurrentProcess. I assume both just get process from current thread ApcState. It's 4 AM so I won't check.