### PR TITLE
Correct CM IRQL documentation

### DIFF
--- a/wdk-ddi-src/content/wdm/nc-wdm-ex_callback_function.md
+++ b/wdk-ddi-src/content/wdm/nc-wdm-ex_callback_function.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Called at PASSIVE_LEVEL (see Remarks section).
+req.irql: <= APC_LEVEL (see Remarks section).
 targetos: Windows
 req.typenames: 
 f1_keywords:
@@ -156,7 +156,7 @@ The following table summarizes the requirements for buffer accesses by the *Regi
 
 For more information about *RegistryCallback* routines and registry filter drivers, see [Filtering Registry Calls](/windows-hardware/drivers/kernel/filtering-registry-calls).
 
-A *RegistryCallback* executes at IRQL = PASSIVE_LEVEL and in the context of the thread that is performing the registry operation.
+A *RegistryCallback* executes at IRQL <= APC_LEVEL and in the context of the thread that is performing the registry operation.
 
 ### Examples
 

--- a/wdk-ddi-src/content/wdm/nf-wdm-zwopenkeyex.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-zwopenkeyex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: PASSIVE_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
It looks like the ability to report problems has been removed from the this repository. So I'm creating a pull request to highlight either a problem in the documentation or an error in programming the Windows Kernel. I'm not sure which one is correct. I would like someone from Microsoft to confirm if the documentation (and WDK SAL) needs to be updated.

Please reference this issue: https://github.com/winsiderss/systeminformer/issues/2498#issuecomment-2927522289

It appears that there are paths implemented in the Windows Kernel which can cause registry APIs to be invoked at `APC_LEVEL`. If this is now blessed by Microsoft then the documentation should be updated for:
1. The callback registered by `CmRegisterCallback`/`CmRegisterCallbackEx`.
2. The associated registry APIs (e.g `ZwOpenKeyEx`) should have their documentation updated.
3. The SAL in the WDK for the related registry APIs should be updated, they currently decorate with `_IRQL_requires_max_(PASSIVE_LEVEL)`:
```c
#if (NTDDI_VERSION >= NTDDI_WIN2K)
//@[comment("MVI_tracked")]
_IRQL_requires_max_(PASSIVE_LEVEL)
NTSYSAPI
NTSTATUS
NTAPI
ZwOpenKey(
    _Out_ PHANDLE KeyHandle,
    _In_ ACCESS_MASK DesiredAccess,
    _In_ POBJECT_ATTRIBUTES ObjectAttributes
    );
#endif

#if (NTDDI_VERSION >= NTDDI_WIN7)
_IRQL_requires_max_(PASSIVE_LEVEL)
NTSYSAPI
NTSTATUS
NTAPI
ZwOpenKeyEx(
    _Out_ PHANDLE KeyHandle,
    _In_ ACCESS_MASK DesiredAccess,
    _In_ POBJECT_ATTRIBUTES ObjectAttributes,
    _In_ ULONG OpenOptions
    );
#endif
```

Note that this commit does not go through and update all the documentation that might be necessary. I'm happy to continue this work to update all the documentation to be `<= APC_LEVEL` (where relevant). But before doing all that work I would like confirmation from Microsoft where (and if) this should be updated in the documentation.