### PR TITLE
Update ne-netadapter-net_packet_filter_flags.md

### DIFF
--- a/wdk-ddi-src/content/netadapter/ne-netadapter-net_packet_filter_flags.md
+++ b/wdk-ddi-src/content/netadapter/ne-netadapter-net_packet_filter_flags.md
@@ -66,6 +66,8 @@ The driver uses the **NET_PACKET_FILTER_FLAGS** enumeration to specify the net a
 
 An initialized [**NET_ADAPTER_RECEIVE_FILTER_CAPABILITIES**](ns-netadapter-net_adapter_receive_filter_capabilities.md) structure is an input to [**NetAdapterSetReceiveFilterCapabilities**](nf-netadapter-netadaptersetreceivefiltercapabilities.md).
 
+**Important:** If the driver does not report support for all of the packet filters expected by an upper layer, NetAdapterCx will fail the `OID_GEN_CURRENT_PACKET_FILTER` request. This will cause the upper layer will fail to bind to your driver. For reliable binding, your driver must report support for all packet filter types.
+
 ## -see-also
 
 [**NET_ADAPTER_RECEIVE_FILTER_CAPABILITIES**](ns-netadapter-net_adapter_receive_filter_capabilities.md)

--- a/wdk-ddi-src/content/netadapter/ne-netadapter-net_packet_filter_flags.md
+++ b/wdk-ddi-src/content/netadapter/ne-netadapter-net_packet_filter_flags.md
@@ -66,7 +66,8 @@ The driver uses the **NET_PACKET_FILTER_FLAGS** enumeration to specify the net a
 
 An initialized [**NET_ADAPTER_RECEIVE_FILTER_CAPABILITIES**](ns-netadapter-net_adapter_receive_filter_capabilities.md) structure is an input to [**NetAdapterSetReceiveFilterCapabilities**](nf-netadapter-netadaptersetreceivefiltercapabilities.md).
 
-**Important:** If the driver does not report support for all of the packet filters expected by an upper layer, NetAdapterCx will fail the `OID_GEN_CURRENT_PACKET_FILTER` request. This will cause the upper layer will fail to bind to your driver. For reliable binding, your driver must report support for all packet filter types.
+> [!IMPORTANT]
+> If the driver doesn't report support for all of the packet filters expected by an upper layer, NetAdapterCx will fail the **OID_GEN_CURRENT_PACKET_FILTER** request, which causes the upper layer to fail to bind to your driver. For reliable binding, your driver must report support for all packet filter types.
 
 ## -see-also
 


### PR DESCRIPTION
The current documentation seems to indicate that the filters are optional, but if the driver lacks support for any of the filters, the driver is likely to fail to bind to upper layers, causing confusing and hard-to-diagnose issues.

NDIS docs indicate that set OID_GEN_CURRENT_PACKET_FILTER is mandatory. Drivers must not fail this set -- failure will prevent the upper layer from binding.

NetAdapterCx's handler for this OID will fail the OID if the device does not support all of the requested filter types.

Therefore, it is pretty much mandatory for the driver to report support for all filter types even if they don't actually support them.

See bug 48485248.