### PR TITLE
FsRtlFastUnlockSingle requires non paged parameters

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastunlocksingle.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlfastunlocksingle.md
@@ -65,12 +65,12 @@ A pointer to the file object for the file.
 ### -param FileOffset [in]
 
 
-A pointer to a variable that specifies the starting byte offset within the file of the range to be unlocked.
+A pointer to a variable that specifies the starting byte offset within the file of the range to be unlocked.  The memory pointed to must not be pageable.
 
 ### -param Length [in]
 
 
-A pointer to a variable that specifies the length, in bytes, of the range to be unlocked.
+A pointer to a variable that specifies the length, in bytes, of the range to be unlocked.  The memory pointed to must not be pageable.
 
 ### -param ProcessId [in]
 


### PR DESCRIPTION
For historic reasons the length and offset parameters are passed by reference.  The referenced memory must be in NPP (or similar) since the FsRtl package uses spinlocks.

This documentation change is for but one function (because that's the one that BSOD'd me) but I'd wager that other locking functions require similar attention.