### PR TITLE
Correct HidP_GetUsageValue Return values

### DIFF
--- a/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_getusagevalue.md
+++ b/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_getusagevalue.md
@@ -113,7 +113,7 @@ The routine successfully returned the value data.
 <tr>
 <td width="40%">
 <dl>
-<dt><b>HIDP_INVALID_REPORT_LENGTH</b></dt>
+<dt><b>HIDP_STATUS_INVALID_REPORT_LENGTH</b></dt>
 </dl>
 </td>
 <td width="60%">
@@ -124,7 +124,7 @@ The report length is not valid.
 <tr>
 <td width="40%">
 <dl>
-<dt><b>HIDP_INVALID_REPORT_TYPE</b></dt>
+<dt><b>HIDP_STATUS_INVALID_REPORT_TYPE</b></dt>
 </dl>
 </td>
 <td width="60%">


### PR DESCRIPTION
In the table of possible return values for `HidP_GetUsageValue` , `HIDP_INVALID_REPORT_LENGTH` and `HIDP_INVALID_REPORT_TYPE` don't exist as identifiers. `HIDP_STATUS_INVALID_REPORT_LENGTH` and `HIDP_STATUS_INVALID_REPORT_TYPE` do exist, however, as on lines 2011 and 2012 in hidpi.h. Is this just a simple mistake? The nonexistent identifiers also are used in some other related pages.