### PR TITLE
Clarify APC requirements

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltquerydirectoryfile.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltquerydirectoryfile.md
@@ -119,7 +119,7 @@ The final call to **FltQueryDirectoryFile** returns an empty output buffer and r
 
 For information about other file information query routines, see [File Objects](../index.yml).
 
-Callers of **FltQueryDirectoryFile** must be running at IRQL = PASSIVE_LEVEL and with APCs enabled. For more information, see [Disabling APCs](/windows-hardware/drivers/kernel/disabling-apcs).
+Callers of **FltQueryDirectoryFile** must be running at IRQL = PASSIVE_LEVEL and with special kernel APCs enabled. For more information, see [Disabling APCs](/windows-hardware/drivers/kernel/disabling-apcs).
 
 ## -see-also
 

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltquerydirectoryfileex.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltquerydirectoryfileex.md
@@ -117,7 +117,7 @@ The final call to **FltQueryDirectoryFileEx** returns an empty output buffer and
 
 **FltQueryDirectoryFileEx** returns zero in any member of a FILE_*XXX*_INFORMATION structure that is not supported by the file system.
 
-Callers of **FltQueryDirectoryFileEx** must be running at IRQL = PASSIVE_LEVEL and with APCs enabled. For more information, see [Disabling APCs](/windows-hardware/drivers/kernel/disabling-apcs).
+Callers of **FltQueryDirectoryFileEx** must be running at IRQL = PASSIVE_LEVEL and with special kernel APCs enabled. For more information, see [Disabling APCs](/windows-hardware/drivers/kernel/disabling-apcs).
 
 ## -see-also
 

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltqueryinformationfile.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltqueryinformationfile.md
@@ -107,7 +107,7 @@ A minifilter driver calls **FltQueryInformationFile** to retrieve information fo
 
 **FltQueryInformationFile** returns zero in any member of a FILE_*XXX*_INFORMATION structure that is not supported by a particular file system. 
 
-Callers of **FltQueryInformationFile** must be running at IRQL = PASSIVE_LEVEL and [with APCs enabled](/windows-hardware/drivers/kernel/disabling-apcs).
+Callers of **FltQueryInformationFile** must be running at IRQL = PASSIVE_LEVEL and [with special kernel APCs enabled](/windows-hardware/drivers/kernel/disabling-apcs).
 
 **NOTE:**
 Do not call this routine with a non-NULL top level IRP value, as this can cause a system deadlock.


### PR DESCRIPTION
Some Flt API pages say that the API must be called with APCs enabled. They actually only need special kernel APCs enabled.