### PR TITLE
Update nf-ntifs-zwnotifychangekey.md

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-zwnotifychangekey.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-zwnotifychangekey.md
@@ -58,6 +58,7 @@ Optional handle to a caller-created event to be set to the Signaled state when t
 ### -param ApcRoutine [in, optional]
 
 Pointer to a caller-supplied APC routine to run after the operation completes. This parameter is optional and can be NULL.
+* For a kernel-mode call, set this parameter to a pointer to a [**WORK_QUEUE_ITEM**](../wdm/ns-wdm-_work_queue_item.md) struct
 
 ### -param ApcContext [in, optional]
 
@@ -124,3 +125,4 @@ For calls from kernel-mode drivers, the **Nt*Xxx*** and **Zw*Xxx*** versions of 
 [**ZwCreateKey**](../wdm/nf-wdm-zwcreatekey.md)
 
 [**ZwOpenKey**](../wdm/nf-wdm-zwopenkey.md)
+


### PR DESCRIPTION
ApcRoutine is in fact a WORK_QUEUE_ITEM struct for kernel callers.

This is also a request for documentation on how to use this API within the context of a user or private hive.
Since the notification requires to keep the handle opened to the key, any call to NtUnloadKey on the hive will fail until the handle is closed, and to my knowledge there is no way to get a notification to proactively close the handle before the kernel tries to unload the hive.