### PR TITLE
Update nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinunupcasedexpr…

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinunupcasedexpression~r3.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinunupcasedexpression~r3.md
@@ -3,7 +3,7 @@ UID: NF:ntifs.FsRtlIsNameInUnUpcasedExpression
 title: FsRtlIsNameInUnUpcasedExpression function (ntifs.h)
 description: The FsRtlIsNameInUnUpcasedExpression routine determines whether a Unicode string matches the specified pattern.
 tech.root: ifsk
-ms.date: 10/19/2018
+ms.date: 12/09/2025
 keywords: ["FsRtlIsNameInUnUpcasedExpression function"]
 ms.keywords: FsRtlIsNameInUnUpcasedExpression
 req.header: ntifs.h
@@ -42,7 +42,7 @@ api_name:
 
 ## -description
 
-The **FsRtlIsNameInUnUpcasedExpression** routine determines whether a Unicode string matches the specified pattern. Unlike the [FsRtlIsNameInExpression routine](./nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinexpression.md), *FsRtlIsNameInUnUpcasedExpression* does not expect the Expression to be in upper case if *IgnoreCase* is TRUE.
+The **FsRtlIsNameInUnUpcasedExpression** routine determines whether a Unicode string matches the specified pattern. Unlike the [**FsRtlIsNameInExpression** routine](./nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinexpression.md), **FsRtlIsNameInUnUpcasedExpression** does not expect the Expression to be in upper case if *IgnoreCase* is TRUE.
 
 ## -parameters
 
@@ -78,15 +78,13 @@ Wildcard character|Meaning
 |DOS_QM|Matches any single character or, upon encountering a period or end of name string, advances the expression to the end of the set of contiguous DOS_QMs.|
 |DOS_STAR|Matches zero or more characters until encountering and matching the final period in the name.|
 
-In low resource conditions, **FsRtlIsNameInExpression** can raise a structured exception with a code of `STATUS_NO_MEMORY`, which callers should be prepared to handle. For more information, see [Structured Exception Handling](/windows/win32/debug/structured-exception-handling).
+In low resource conditions, **FsRtlIsNameInUnUpcasedExpression** can raise a structured exception with a code of `STATUS_NO_MEMORY`, which callers should be prepared to handle. For more information, see [Structured Exception Handling](/windows/win32/debug/structured-exception-handling).
 
- 
-**Note**  
-
-If only one of the string parameters has a length of zero, FsRtlIsNameInUnUpcasedExpression returns FALSE. This means that "*" does not match a null string. 
-If both parameters are null strings, FsRtlIsNameInUnUpcasedExpression returns TRUE.
+If only one of the string parameters has a length of zero, **FsRtlIsNameInUnUpcasedExpression** returns FALSE. This means that "*" does not match a null string. 
+If both parameters are null strings, **FsRtlIsNameInUnUpcasedExpression** returns TRUE.
 
 ## -see-also
 
 - [FsRtlIsNameInExpression](./nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinexpression.md)
+
 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinunupcasedexpression~r3.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinunupcasedexpression~r3.md
@@ -78,6 +78,8 @@ Wildcard character|Meaning
 |DOS_QM|Matches any single character or, upon encountering a period or end of name string, advances the expression to the end of the set of contiguous DOS_QMs.|
 |DOS_STAR|Matches zero or more characters until encountering and matching the final period in the name.|
 
+In low resource conditions, **FsRtlIsNameInExpression** can raise a structured exception with a code of `STATUS_NO_MEMORY`, which callers should be prepared to handle. For more information, see [Structured Exception Handling](/windows/win32/debug/structured-exception-handling).
+
  
 **Note**  
 
@@ -87,3 +89,4 @@ If both parameters are null strings, FsRtlIsNameInUnUpcasedExpression returns TR
 ## -see-also
 
 - [FsRtlIsNameInExpression](./nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinexpression.md)
+


### PR DESCRIPTION
…ession~r3.md

This note can be found in FsRtlIsNameInExpression:

https://github.com/MicrosoftDocs/windows-driver-docs-ddi/blob/03c03153a3fe74a8b7ca01050fcff32c8dc773b8/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinexpression.md#L91

but it applies to both, this was verified with a debugger.

Also note that the edit link on this page is broken:
https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlisnameinunupcasedexpression-r3

That's because the URL ends with `-r3`, but the file in github ends with `~r3`.