### PR TITLE
Fixed spelling of RtlIsEnclaveFeaturePresent function

### DIFF
--- a/wdk-ddi-src/content/ntddk/ns-ntddk-kuser_shared_data.md
+++ b/wdk-ddi-src/content/ntddk/ns-ntddk-kuser_shared_data.md
@@ -404,7 +404,7 @@ The count of unparked processors.
 
 ### -field EnclaveFeatureMask[4]
 
-A bitmask of enclave features supported on this system. This field must be accessed via the **RtlIsEnclareFeaturePresent** API for an accurate result.
+A bitmask of enclave features supported on this system. This field must be accessed via the **RtlIsEnclaveFeaturePresent** API for an accurate result.
 
 ### -field TelemetryCoverageRound
 


### PR DESCRIPTION
Just a spelling fix for the `RtlIsEnclaveFeaturePresent` function, referenced before as RtlIsEncla**r**eFeaturePresent.