### PR TITLE
Add details to the return status section. (FLT_GENERATE_FILENAME)

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nc-fltkernel-pflt_generate_file_name.md
+++ b/wdk-ddi-src/content/fltkernel/nc-fltkernel-pflt_generate_file_name.md
@@ -84,6 +84,9 @@ A pointer to a filter manager-allocated <a href="/windows-hardware/drivers/ddi/f
 
 This callback routine returns STATUS_SUCCESS or an appropriate NTSTATUS value.
 
+Filters should not return STATUS_NOT_IMPLEMENTED or STATUS_NOT_SUPPORTED.
+
+
 ## -remarks
 
 A minifilter driver that provides file names for the filter manager's name cache can register a routine of type <i>PFLT_GENERATE_FILE_NAME</i> as the minifilter driver's <i>GenerateFileNameCallback</i> routine. 


### PR DESCRIPTION
When filter manager verifier is running it will complain if certain statuses are returned by a GenerateFileName call back (even if the status came directly from a lower name provider).

It is not clear why this restriction is in place, this PR merely notes the failing statuses.