### PR TITLE
fix: correct typos in nf-*.md frontmatter (req.target-type, req.irql)

### DIFF
--- a/wdk-ddi-src/content/d3dkmthk/nf-d3dkmthk-d3dkmtcreateoutputdupl.md
+++ b/wdk-ddi-src/content/d3dkmthk/nf-d3dkmthk-d3dkmtcreateoutputdupl.md
@@ -7,7 +7,7 @@ keywords: ["D3DKMTCreateOutputDupl function"]
 ms.keywords: D3DKMTCreateOutputDupl
 req.header: d3dkmthk.h
 req.include-header: D3dkmthk.h
-req.target-type: Univwrsal
+req.target-type: Universal
 req.target-min-winverclnt: Windows 8
 req.target-min-winversvr: Windows Server 2012
 req.kmdf-ver: 

--- a/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_getextendedattributes.md
+++ b/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_getextendedattributes.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Hidparse.lib
 req.dll: 
-req.irql: <= DISPATCH_ LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmunmapviewinsystemspace.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmunmapviewinsystemspace.md
@@ -15,7 +15,7 @@ req.kmdf-ver:
 req.umdf-ver: 
 req.lib: 
 req.dll: 
-req.irql: <=(APC_LEVEL)
+req.irql: <= APC_LEVEL
 req.ddi-compliance: 
 req.unicode-ansi: 
 req.idl: 

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtllookupperfilecontext.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtllookupperfilecontext.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=  APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_buildregistercompositedevice.md
+++ b/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_buildregistercompositedevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Usbdex.lib
 req.dll: 
-req.irql: < = DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
> **Context:** This is part of a series of pull requests.
>
> I am working on a sister project to [sparse](https://github.com/cristeigabriela/sparse), the sdk-api parser, and in the process, I automated finding issues in windows-driver-docs-ddi (I've also done this for sdk-api.)
>
> I'm now submitting patches for everything I've found for review. All the changes were tested in a branch where all of them are applied, and every single YAML frontmatter parses correctly.

<details>
<summary><b>All 12 PRs in this series — merging guide</b></summary>

| # | PR | Branch | Files |
|---|----|--------|-------|
| 1 | #1660 | `fix/typos-frontmatter` | 5 |
| 2 | #1661 | `fix/acxmisc-acxobjectbagretrieveblob-irql` | 1 |
| 3 | #1662 | `fix/iddcx-irql-empty` | 14 |
| 4 | #1663 | `fix/silo-and-reparse-irql` | 8 |
| 5 | #1664 | `fix/portcls-na-dll` | 2 |
| 6 | #1665 | `fix/irql-apc-level-spacing` | 41 |
| 7 | #1666 | `fix/irql-passive-abbreviation` | 2 |
| 8 | #1667 | `fix/irql-dispatch-level-spacing` | 301 |
| 9 | #1668 | `fix/ntoskrnl-lib-misfiled-as-dll` | 3 |
| 10 | #1669 | `fix/strip-irql-prose-prefix` | 80 |
| 11 | #1670 | `fix/irql-trailing-period-and-passive-case` | 133 |
| 12 | #1671 | `fix/irql-prose-to-operator` | 239 |

All of the 12 PRs have zero pairwise file overlap. They can be merged individually, in any order, and there will not be merge conflicts between them.

After every PR is merged, all 10,915 `nf-*.md` frontmatter blocks will *still* parse cleanly as YAML.

A reference branch with all of the PRs merged at once is at [`integration/all-open-prs`](https://github.com/cristeigabriela/windows-driver-docs-ddi/tree/integration/all-open-prs).

</details>

Multiple typos/inconsistencies found in the following nfs' frontmatter:

## **Files & edits** (5):
| # | File | Field | Before | After |
|---|------|-------|--------|-------|
| 1 | `d3dkmthk/nf-d3dkmthk-d3dkmtcreateoutputdupl.md` | `req.target-type` | `Univwrsal` | `Universal` |
| 2 | `hidpi/nf-hidpi-hidp_getextendedattributes.md` | `req.irql` | `<= DISPATCH_ LEVEL` | `<= DISPATCH_LEVEL` |
| 3 | `usbdlib/nf-usbdlib-usbd_buildregistercompositedevice.md` | `req.irql` | `< = DISPATCH_LEVEL` | `<= DISPATCH_LEVEL` |
| 4 | `ntddk/nf-ntddk-mmunmapviewinsystemspace.md` | `req.irql` | `<=(APC_LEVEL)` | `<= APC_LEVEL` |
| 5 | `ntifs/nf-ntifs-fsrtllookupperfilecontext.md` | `req.irql` | `<=  APC_LEVEL` | `<= APC_LEVEL` |
