### PR TITLE
fix: clear stray SAL annotation _Must_inspect_result_ from req.irql on 14 IddCx functions

### DIFF
--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxadapterinitasync.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxadapterinitasync.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxadapterupdatemaxdisplaypipelinerate.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxadapterupdatemaxdisplaypipelinerate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxdeviceinitconfig.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxdeviceinitconfig.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxdeviceinitialize.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxdeviceinitialize.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxmonitorarrival.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxmonitorarrival.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxmonitordeparture.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxmonitordeparture.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxmonitorupdatemodes.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxmonitorupdatemodes.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainfinishedprocessingframe.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainfinishedprocessingframe.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchaingetdirtyrects.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchaingetdirtyrects.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchaingetmoveregions.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchaingetmoveregions.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainreleaseandacquirebuffer.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainreleaseandacquirebuffer.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainreportframestatistics.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainreportframestatistics.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainsetdevice.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainsetdevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainupdatestaticdesktopreencodeframecount.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxswapchainupdatestaticdesktopreencodeframecount.md
@@ -24,7 +24,7 @@ req.assembly:
 req.type-library: 
 req.lib: IddCxStub.lib
 req.dll: IddCx.dll
-req.irql: _Must_inspect_result_
+req.irql: 
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
> **Context:** This is part of a series of pull requests.
>
> I am working on a sister project to [sparse](https://github.com/cristeigabriela/sparse), the sdk-api parser, and in the process, I automated finding issues in windows-driver-docs-ddi (I've also done this for sdk-api.)
>
> I'm now submitting patches for everything I've found for review. All the changes were tested in a branch where all of them are applied, and every single YAML frontmatter parses correctly.

<details>
<summary><b>All 12 PRs in this series — merging guide</b></summary>

| # | PR | Branch | Files |
|---|----|--------|-------|
| 1 | #1660 | `fix/typos-frontmatter` | 5 |
| 2 | #1661 | `fix/acxmisc-acxobjectbagretrieveblob-irql` | 1 |
| 3 | #1662 | `fix/iddcx-irql-empty` | 14 |
| 4 | #1663 | `fix/silo-and-reparse-irql` | 8 |
| 5 | #1664 | `fix/portcls-na-dll` | 2 |
| 6 | #1665 | `fix/irql-apc-level-spacing` | 41 |
| 7 | #1666 | `fix/irql-passive-abbreviation` | 2 |
| 8 | #1667 | `fix/irql-dispatch-level-spacing` | 301 |
| 9 | #1668 | `fix/ntoskrnl-lib-misfiled-as-dll` | 3 |
| 10 | #1669 | `fix/strip-irql-prose-prefix` | 80 |
| 11 | #1670 | `fix/irql-trailing-period-and-passive-case` | 133 |
| 12 | #1671 | `fix/irql-prose-to-operator` | 239 |

All of the 12 PRs have zero pairwise file overlap. They can be merged individually, in any order, and there will not be merge conflicts between them.

After every PR is merged, all 10,915 `nf-*.md` frontmatter blocks will *still* parse cleanly as YAML.

A reference branch with all of the PRs merged at once is at [`integration/all-open-prs`](https://github.com/cristeigabriela/windows-driver-docs-ddi/tree/integration/all-open-prs).

</details>

These functions have no IRQL restraints in the respective `IddCx.h` headers, and so I've removed the IRQL specification from here as well.

I assume the current values are a parser error (I can imagine how, in Clang I would imagine the way this would be implemented is looking at the AST children of the function and expecting a specific order. Or maybe it's something simpler.)
