### PR TITLE
fix: convert SAL `_IRQL_requires_max_` to canonical `<= LEVEL` on silo/reparse functions

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltaddopenreparseentry.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltaddopenreparseentry.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: _IRQL_requires_max_(APC_LEVEL)
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcopyopenreparselist.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltcopyopenreparselist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: _IRQL_requires_max_(APC_LEVEL)
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltfreeopenreparselist.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltfreeopenreparselist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: _IRQL_requires_max_(APC_LEVEL)
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltremoveopenreparseentry.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltremoveopenreparseentry.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: _IRQL_requires_max_(APC_LEVEL)
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psdereferencesilocontext.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psdereferencesilocontext.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: _IRQL_requires_max_(DISPATCH_LEVEL)
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psgetcurrentserversilo.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psgetcurrentserversilo.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: _IRQL_requires_max_(DISPATCH_LEVEL)
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psgetcurrentsilo.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psgetcurrentsilo.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: _IRQL_requires_max_(DISPATCH_LEVEL)
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psreferencesilocontext.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psreferencesilocontext.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: _IRQL_requires_max_(DISPATCH_LEVEL)
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
> **Context:** This is part of a series of pull requests.
>
> I am working on a sister project to [sparse](https://github.com/cristeigabriela/sparse), the sdk-api parser, and in the process, I automated finding issues in windows-driver-docs-ddi (I've also done this for sdk-api.)
>
> I'm now submitting patches for everything I've found for review. All the changes were tested in a branch where all of them are applied, and every single YAML frontmatter parses correctly.

<details>
<summary><b>All 12 PRs in this series — merging guide</b></summary>

| # | PR | Branch | Files |
|---|----|--------|-------|
| 1 | #1660 | `fix/typos-frontmatter` | 5 |
| 2 | #1661 | `fix/acxmisc-acxobjectbagretrieveblob-irql` | 1 |
| 3 | #1662 | `fix/iddcx-irql-empty` | 14 |
| 4 | #1663 | `fix/silo-and-reparse-irql` | 8 |
| 5 | #1664 | `fix/portcls-na-dll` | 2 |
| 6 | #1665 | `fix/irql-apc-level-spacing` | 41 |
| 7 | #1666 | `fix/irql-passive-abbreviation` | 2 |
| 8 | #1667 | `fix/irql-dispatch-level-spacing` | 301 |
| 9 | #1668 | `fix/ntoskrnl-lib-misfiled-as-dll` | 3 |
| 10 | #1669 | `fix/strip-irql-prose-prefix` | 80 |
| 11 | #1670 | `fix/irql-trailing-period-and-passive-case` | 133 |
| 12 | #1671 | `fix/irql-prose-to-operator` | 239 |

All of the 12 PRs have zero pairwise file overlap. They can be merged individually, in any order, and there will not be merge conflicts between them.

After every PR is merged, all 10,915 `nf-*.md` frontmatter blocks will *still* parse cleanly as YAML.

A reference branch with all of the PRs merged at once is at [`integration/all-open-prs`](https://github.com/cristeigabriela/windows-driver-docs-ddi/tree/integration/all-open-prs).

</details>

The usual standard, as seen in the image attached below, is `<= LEVEL`, or `LEVEL`, not the whole line specifying the IRQL.

<img width="1026" height="1081" alt="image" src="https://github.com/user-attachments/assets/66ae0676-e66a-4be6-a4af-d2c7ea036f2f" />


This PR normalizes the IRQL entries in the frontmatters.
