### PR TITLE
fix: normalize req.irql spacing `<=APC_LEVEL` -> `<= APC_LEVEL` across 41 files

### DIFF
--- a/wdk-ddi-src/content/ntddk/nf-ntddk-ioraiseinformationalharderror.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-ioraiseinformationalharderror.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmallocatenoncachedmemory.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmallocatenoncachedmemory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmfreenoncachedmemory.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmfreenoncachedmemory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmmapviewinsystemspace.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmmapviewinsystemspace.md
@@ -15,7 +15,7 @@ req.kmdf-ver:
 req.umdf-ver: 
 req.lib: 
 req.dll: 
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 req.ddi-compliance: 
 req.unicode-ansi: 
 req.idl: 

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmsecurevirtualmemory.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmsecurevirtualmemory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 ms.custom: 19H1

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmunsecurevirtualmemory.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmunsecurevirtualmemory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psremovecreatethreadnotifyroutine.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psremovecreatethreadnotifyroutine.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-psremoveloadimagenotifyroutine.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-psremoveloadimagenotifyroutine.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlupperchar.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlupperchar.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlupperstring.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlupperstring.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlaretherecurrentorinprogressfilelocks.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlaretherecurrentorinprogressfilelocks.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlnotifycleanupall.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlnotifycleanupall.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 ms.custom: RS5

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-cczerodata.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-cczerodata.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlinsertperfilecontext.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlinsertperfilecontext.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlremoveperfilecontext.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlremoveperfilecontext.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlteardownperfilecontexts.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlteardownperfilecontexts.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-podeletepowerrequest.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-podeletepowerrequest.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-poregistersystemstate.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-poregistersystemstate.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-pounregistersystemstate.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-pounregistersystemstate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-cmregistercallback.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-cmregistercallback.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-cmregistercallbackex.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-cmregistercallbackex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exgetfirmwaretype.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exgetfirmwaretype.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe (kernel mode)
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exissoftboot.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exissoftboot.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe (kernel mode)
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exraisestatus.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exraisestatus.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exunregistercallback.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exunregistercallback.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-iogetinitialstack.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iogetinitialstack.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmallocatemappingaddress.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmallocatemappingaddress.md
@@ -20,7 +20,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmallocatemappingaddressex.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmallocatemappingaddressex.md
@@ -14,7 +14,7 @@ req.kmdf-ver:
 req.umdf-ver: 
 req.lib: 
 req.dll: 
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 req.ddi-compliance: 
 req.unicode-ansi: 
 req.idl: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmfreemappingaddress.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmfreemappingaddress.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmisdriververifyingbyaddress.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmisdriververifyingbyaddress.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmlockpagablecodesection.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmlockpagablecodesection.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmlockpagabledatasection.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmlockpagabledatasection.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmunlockpagableimagesection.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmunlockpagableimagesection.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-ntrenametransactionmanager.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-ntrenametransactionmanager.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-ntsetinformationtransactionmanager.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-ntsetinformationtransactionmanager.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-obreleaseobjectsecurity.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-obreleaseobjectsecurity.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-podeletepowerrequest.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-podeletepowerrequest.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-poregistersystemstate.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-poregistersystemstate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-pounregistersystemstate.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-pounregistersystemstate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlfreeansistring.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlfreeansistring.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlfreeunicodestring.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlfreeunicodestring.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
> **Context:** This is part of a series of pull requests.
>
> I am working on a sister project to [sparse](https://github.com/cristeigabriela/sparse), the sdk-api parser, and in the process, I automated finding issues in windows-driver-docs-ddi (I've also done this for sdk-api.)
>
> I'm now submitting patches for everything I've found for review. All the changes were tested in a branch where all of them are applied, and every single YAML frontmatter parses correctly.

<details>
<summary><b>All 12 PRs in this series — merging guide</b></summary>

| # | PR | Branch | Files |
|---|----|--------|-------|
| 1 | #1660 | `fix/typos-frontmatter` | 5 |
| 2 | #1661 | `fix/acxmisc-acxobjectbagretrieveblob-irql` | 1 |
| 3 | #1662 | `fix/iddcx-irql-empty` | 14 |
| 4 | #1663 | `fix/silo-and-reparse-irql` | 8 |
| 5 | #1664 | `fix/portcls-na-dll` | 2 |
| 6 | #1665 | `fix/irql-apc-level-spacing` | 41 |
| 7 | #1666 | `fix/irql-passive-abbreviation` | 2 |
| 8 | #1667 | `fix/irql-dispatch-level-spacing` | 301 |
| 9 | #1668 | `fix/ntoskrnl-lib-misfiled-as-dll` | 3 |
| 10 | #1669 | `fix/strip-irql-prose-prefix` | 80 |
| 11 | #1670 | `fix/irql-trailing-period-and-passive-case` | 133 |
| 12 | #1671 | `fix/irql-prose-to-operator` | 239 |

All of the 12 PRs have zero pairwise file overlap. They can be merged individually, in any order, and there will not be merge conflicts between them.

After every PR is merged, all 10,915 `nf-*.md` frontmatter blocks will *still* parse cleanly as YAML.

A reference branch with all of the PRs merged at once is at [`integration/all-open-prs`](https://github.com/cristeigabriela/windows-driver-docs-ddi/tree/integration/all-open-prs).

</details>

If you look at the image below, you're going to see that the current `req.irql` distribution is very weird:
<img width="1026" height="1081" alt="image" src="https://github.com/user-attachments/assets/a1d9bbba-3c08-48c6-9bdd-54ddc44f3aa6" />

This is currently one of the leading `req.irql` field values, and it's kind of annoying and inconsistent, considering there's 531 other entries where it is `<= APC_LEVEL`. This will lead to all these 41 entries being absorbed by that one.

This PR attempts to even it out some.
