### PR TITLE
fix: normalize req.irql spacing for DISPATCH_LEVEL (<= and <) across 301 files

### DIFF
--- a/wdk-ddi-src/content/dmusicks/nf-dmusicks-iallocatormxf-getbuffer.md
+++ b/wdk-ddi-src/content/dmusicks/nf-dmusicks-iallocatormxf-getbuffer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/dmusicks/nf-dmusicks-iallocatormxf-getmessage.md
+++ b/wdk-ddi-src/content/dmusicks/nf-dmusicks-iallocatormxf-getmessage.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/dmusicks/nf-dmusicks-iallocatormxf-putbuffer.md
+++ b/wdk-ddi-src/content/dmusicks/nf-dmusicks-iallocatormxf-putbuffer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltadjustdevicestacksizeforioredirection.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltadjustdevicestacksizeforioredirection.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: FltMgr.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltisioredirectionallowed.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltisioredirectionallowed.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: FltMgr.lib
 req.dll: Fltmgr.sys
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltisioredirectionallowedforoperation.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltisioredirectionallowedforoperation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: FltMgr.lib
 req.dll: Fltmgr.sys
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsqueryconnectionredirectstate0.md
+++ b/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsqueryconnectionredirectstate0.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Fwpkclnt.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsqueryconnectionsioformatredirectrecords0.md
+++ b/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsqueryconnectionsioformatredirectrecords0.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Fwpkclnt.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_unsetusages.md
+++ b/wdk-ddi-src/content/hidpi/nf-hidpi-hidp_unsetusages.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Hidparse.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kscompletependingrequest.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kscompletependingrequest.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksfilterattemptprocessing.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksfilterattemptprocessing.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksfiltergenerateevents.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksfiltergenerateevents.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL (See Remarks section.)
+req.irql: <= DISPATCH_LEVEL (See Remarks section.)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksgenerateevents.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksgenerateevents.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspinattemptprocessing.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspinattemptprocessing.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL (See Remarks)
+req.irql: <= DISPATCH_LEVEL (See Remarks)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspingenerateevents.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspingenerateevents.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL (See Remarks)
+req.irql: <= DISPATCH_LEVEL (See Remarks)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspingetfirstclonestreampointer.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspingetfirstclonestreampointer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspingetleadingedgestreampointer.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspingetleadingedgestreampointer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspingettrailingedgestreampointer.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspingettrailingedgestreampointer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspinsetpinclocktime.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspinsetpinclocktime.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspinsubmitframe.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspinsubmitframe.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspinsubmitframemdl.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspinsubmitframemdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointeradvance.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointeradvance.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointeradvanceoffsets.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointeradvanceoffsets.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointeradvanceoffsetsandunlock.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointeradvanceoffsetsandunlock.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointercanceltimeout.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointercanceltimeout.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointerclone.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointerclone.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointerdelete.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointerdelete.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointergetirp.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointergetirp.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointergetmdl.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointergetmdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointergetnextclone.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointergetnextclone.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointerlock.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointerlock.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointersetstatuscode.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointersetstatuscode.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointerunlock.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointerunlock.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisallocaterwlock.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisallocaterwlock.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ndis.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndiscosendnetbufferlists.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndiscosendnetbufferlists.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ndis.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisfreerwlock.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisfreerwlock.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ndis.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndissendnetbufferlists.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndissendnetbufferlists.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ndis.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-iosetharderrororverifydevice.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-iosetharderrororverifydevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-iosetthreadharderrormode.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-iosetthreadharderrormode.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmisaddressvalid.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmisaddressvalid.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-pshedfreememory.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-pshedfreememory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Pshed.lib
 req.dll: Pshed.dll
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-pshedregisterplugin.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-pshedregisterplugin.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Pshed.lib
 req.dll: Pshed.dll
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-wheageterrpacketfromerrrecord.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-wheageterrpacketfromerrrecord.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-wheaisvaliderrorrecordsignature.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-wheaisvaliderrorrecordsignature.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddsd/nf-ntddsd-sdbussubmitrequest.md
+++ b/wdk-ddi-src/content/ntddsd/nf-ntddsd-sdbussubmitrequest.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <DISPATCH_LEVEL
+req.irql: < DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddsd/nf-ntddsd-sdbussubmitrequestasync.md
+++ b/wdk-ddi-src/content/ntddsd/nf-ntddsd-sdbussubmitrequestasync.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlnotifyvolumeeventex.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlnotifyvolumeeventex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 ms.custom: RS5

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-postartnextpowerirp.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-postartnextpowerirp.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-psgetprocessexittime.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-psgetprocessexittime.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-psissystemthread.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-psissystemthread.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-idmachannelslave-readcounter.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-idmachannelslave-readcounter.md
@@ -15,7 +15,7 @@ req.kmdf-ver:
 req.umdf-ver: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.ddi-compliance: 
 req.unicode-ansi: 
 req.idl: 

--- a/wdk-ddi-src/content/portcls/nf-portcls-idmachannelslave-stop.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-idmachannelslave-stop.md
@@ -15,7 +15,7 @@ req.kmdf-ver:
 req.umdf-ver: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.ddi-compliance: 
 req.unicode-ansi: 
 req.idl: 

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavecyclicstream-getposition.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavecyclicstream-getposition.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavepcistream-getmapping.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavepcistream-getmapping.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavepcistream-releasemapping.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavepcistream-releasemapping.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavepcistream-terminatepacket.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavepcistream-terminatepacket.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iservicegroup-supportdelayedservice.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iservicegroup-supportdelayedservice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-pccompleteirp.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-pccompleteirp.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Portcls.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-pccompletependingpropertyrequest.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-pccompletependingpropertyrequest.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Portcls.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportallocatecontiguousmemoryspecifycachenode.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportallocatecontiguousmemoryspecifycachenode.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportallocatemdl.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportallocatemdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportallocatepool.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportallocatepool.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportbuildmdlfornonpagedpool.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportbuildmdlfornonpagedpool.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportfreecontiguousmemoryspecifycache.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportfreecontiguousmemoryspecifycache.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportfreemdl.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportfreemdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportfreepool.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportfreepool.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetactivegroupcount.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetactivegroupcount.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetactivenodecount.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetactivenodecount.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetcurrentprocessornumber.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetcurrentprocessornumber.md
@@ -20,7 +20,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetgroupaffinity.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetgroupaffinity.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgethighestnodenumber.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgethighestnodenumber.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetlogicalprocessorrelationship.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetlogicalprocessorrelationship.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetnodeaffinity.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetnodeaffinity.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetsystemaddress.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetsystemaddress.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/strmini/nf-strmini-streamclassquerymasterclocksync.md
+++ b/wdk-ddi-src/content/strmini/nf-strmini-streamclassquerymasterclocksync.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Stream.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL (See Remarks section)
+req.irql: <= DISPATCH_LEVEL (See Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucmtcpciportcontroller/nf-ucmtcpciportcontroller-ucmtcpciportcontrolleralert.md
+++ b/wdk-ddi-src/content/ucmtcpciportcontroller/nf-ucmtcpciportcontroller-ucmtcpciportcontrolleralert.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucmtcpciportcontroller/nf-ucmtcpciportcontroller-ucmtcpciportcontrollersethardwarerequestqueue.md
+++ b/wdk-ddi-src/content/ucmtcpciportcontroller/nf-ucmtcpciportcontroller-ucmtcpciportcontrollersethardwarerequestqueue.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucmucsippm/nf-ucmucsippm-ucmucsippmnotification.md
+++ b/wdk-ddi-src/content/ucmucsippm/nf-ucmucsippm-ucmucsippmnotification.md
@@ -15,7 +15,7 @@ req.kmdf-ver: 1.27
 req.umdf-ver: N/A
 req.lib: UcmUcsiCxStub.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.ddi-compliance: 
 req.unicode-ansi: 
 req.idl: 

--- a/wdk-ddi-src/content/ucxcontroller/nf-ucxcontroller-ucxcontrollerneedsreset.md
+++ b/wdk-ddi-src/content/ucxcontroller/nf-ucxcontroller-ucxcontrollerneedsreset.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucxcontroller/nf-ucxcontroller-ucxcontrollerresetcomplete.md
+++ b/wdk-ddi-src/content/ucxcontroller/nf-ucxcontroller-ucxcontrollerresetcomplete.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucxcontroller/nf-ucxcontroller-ucxiodevicecontrol.md
+++ b/wdk-ddi-src/content/ucxcontroller/nf-ucxcontroller-ucxiodevicecontrol.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointabortcomplete.md
+++ b/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointabortcomplete.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointgetstaticstreamsreferenced.md
+++ b/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointgetstaticstreamsreferenced.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointneedtocanceltransfers.md
+++ b/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointneedtocanceltransfers.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointnopingresponseerror.md
+++ b/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointnopingresponseerror.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointpurgecomplete.md
+++ b/wdk-ddi-src/content/ucxendpoint/nf-ucxendpoint-ucxendpointpurgecomplete.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucxroothub/nf-ucxroothub-ucxroothubportchanged.md
+++ b/wdk-ddi-src/content/ucxroothub/nf-ucxroothub-ucxroothubportchanged.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ucxusbdevice/nf-ucxusbdevice-ucxusbdeviceremotewakenotification.md
+++ b/wdk-ddi-src/content/ucxusbdevice/nf-ucxusbdevice-ucxusbdeviceremotewakenotification.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/udecxwdfdevice/nf-udecxwdfdevice-udecxwdfdeviceresetcomplete.md
+++ b/wdk-ddi-src/content/udecxwdfdevice/nf-udecxwdfdevice-udecxwdfdeviceresetcomplete.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Udecxstub.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usbdlib/nf-usbdlib-composite_device_capabilities_init.md
+++ b/wdk-ddi-src/content/usbdlib/nf-usbdlib-composite_device_capabilities_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Usbdex.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_assignurbtoiostacklocation.md
+++ b/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_assignurbtoiostacklocation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Usbdex.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_calculateusbbandwidth.md
+++ b/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_calculateusbbandwidth.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Usbd.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_getusbdiversion.md
+++ b/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_getusbdiversion.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Usbd.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL (See Remarks)
+req.irql: <= DISPATCH_LEVEL (See Remarks)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_isochurballocate.md
+++ b/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_isochurballocate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Usbdex.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_urbfree.md
+++ b/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_urbfree.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Usbdex.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/vhf/nf-vhf-vhfasyncoperationcomplete.md
+++ b/wdk-ddi-src/content/vhf/nf-vhf-vhfasyncoperationcomplete.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: VhfKm.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/vhf/nf-vhf-vhfstart.md
+++ b/wdk-ddi-src/content/vhf/nf-vhf-vhfstart.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: VhfKm.lib
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/video/nf-video-videoportacquirespinlock.md
+++ b/wdk-ddi-src/content/video/nf-video-videoportacquirespinlock.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Videoprt.lib
 req.dll: Videoprt.sys
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/video/nf-video-videoportcompletedma.md
+++ b/wdk-ddi-src/content/video/nf-video-videoportcompletedma.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Videoprt.lib
 req.dll: Videoprt.sys
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/video/nf-video-videoportdeletespinlock.md
+++ b/wdk-ddi-src/content/video/nf-video-videoportdeletespinlock.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Videoprt.lib
 req.dll: Videoprt.sys
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/video/nf-video-videoportstartdma.md
+++ b/wdk-ddi-src/content/video/nf-video-videoportstartdma.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Videoprt.lib
 req.dll: Videoprt.sys
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/video/nf-video-videoportstarttimer.md
+++ b/wdk-ddi-src/content/video/nf-video-videoportstarttimer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Videoprt.lib
 req.dll: Videoprt.sys
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/video/nf-video-videoportstoptimer.md
+++ b/wdk-ddi-src/content/video/nf-video-videoportstoptimer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Videoprt.lib
 req.dll: Videoprt.sys
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdeviceremovedependentusagedeviceobject.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdeviceremovedependentusagedeviceobject.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetbusinformationforchildren.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetbusinformationforchildren.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetcharacteristics.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetcharacteristics.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetfailed.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetfailed.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetpnpcapabilities.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetpnpcapabilities.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetpowercapabilities.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetpowercapabilities.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetspecialfilesupport.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetspecialfilesupport.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetstaticstopremove.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicesetstaticstopremove.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicewdmgetdeviceobject.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicewdmgetdeviceobject.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicewdmgetphysicaldevice.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdevicewdmgetphysicaldevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfwdmdevicegetwdfdevicehandle.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfwdmdevicegetwdfdevicehandle.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmaenabler/nf-wdfdmaenabler-wdfdmaenablergetfragmentlength.md
+++ b/wdk-ddi-src/content/wdfdmaenabler/nf-wdfdmaenabler-wdfdmaenablergetfragmentlength.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmaenabler/nf-wdfdmaenabler-wdfdmaenablergetmaximumlength.md
+++ b/wdk-ddi-src/content/wdfdmaenabler/nf-wdfdmaenabler-wdfdmaenablergetmaximumlength.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmaenabler/nf-wdfdmaenabler-wdfdmaenablergetmaximumscattergatherelements.md
+++ b/wdk-ddi-src/content/wdfdmaenabler/nf-wdfdmaenabler-wdfdmaenablergetmaximumscattergatherelements.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmaenabler/nf-wdfdmaenabler-wdfdmaenablerwdmgetdmaadapter.md
+++ b/wdk-ddi-src/content/wdfdmaenabler/nf-wdfdmaenabler-wdfdmaenablerwdmgetdmaadapter.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionallocateresources.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionallocateresources.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioncancel.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioncancel.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioncreate.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioncreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiondmacompleted.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiondmacompleted.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiondmacompletedfinal.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiondmacompletedfinal.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiondmacompletedwithlength.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiondmacompletedwithlength.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionexecute.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionexecute.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionfreeresources.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionfreeresources.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongetbytestransferred.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongetbytestransferred.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongetcurrentdmatransferlength.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongetcurrentdmatransferlength.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongetdevice.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongetdevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongetrequest.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongetrequest.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongettransferinfo.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactiongettransferinfo.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioninitialize.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioninitialize.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioninitializeusingoffset.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioninitializeusingoffset.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioninitializeusingrequest.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactioninitializeusingrequest.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionrelease.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionrelease.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetchannelconfigurationcallback.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetchannelconfigurationcallback.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetdeviceaddressoffset.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetdeviceaddressoffset.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetimmediateexecution.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetimmediateexecution.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetmaximumlength.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetmaximumlength.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetsingletransferrequirement.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsetsingletransferrequirement.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsettransfercompletecallback.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionsettransfercompletecallback.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionstopsystemtransfer.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionstopsystemtransfer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionwdmgettransfercontext.md
+++ b/wdk-ddi-src/content/wdfdmatransaction/nf-wdfdmatransaction-wdfdmatransactionwdmgettransfercontext.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdpc/nf-wdfdpc-wdfdpccreate.md
+++ b/wdk-ddi-src/content/wdfdpc/nf-wdfdpc-wdfdpccreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdffileobject/nf-wdffileobject-wdffileobjectgetdevice.md
+++ b/wdk-ddi-src/content/wdffileobject/nf-wdffileobject-wdffileobjectgetdevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdffileobject/nf-wdffileobject-wdffileobjectgetflags.md
+++ b/wdk-ddi-src/content/wdffileobject/nf-wdffileobject-wdffileobjectgetflags.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdffileobject/nf-wdffileobject-wdffileobjectwdmgetfileobject.md
+++ b/wdk-ddi-src/content/wdffileobject/nf-wdffileobject-wdffileobjectwdmgetfileobject.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptcreate.md
+++ b/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptcreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptgetinfo.md
+++ b/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptgetinfo.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptreportactive.md
+++ b/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptreportactive.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptreportinactive.md
+++ b/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptreportinactive.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptsetextendedpolicy.md
+++ b/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptsetextendedpolicy.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptsetpolicy.md
+++ b/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptsetpolicy.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptsynchronize.md
+++ b/wdk-ddi-src/content/wdfinterrupt/nf-wdfinterrupt-wdfinterruptsynchronize.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfio/nf-wdfio-wdfioqueuestopandpurge.md
+++ b/wdk-ddi-src/content/wdfio/nf-wdfio-wdfioqueuestopandpurge.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforinternalioctl.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforinternalioctl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforinternalioctlothers.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforinternalioctlothers.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforioctl.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforioctl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforread.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforread.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforwrite.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetformatrequestforwrite.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetgetdevice.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetgetdevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetgetstate.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetgetstate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetstart.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetstart.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetdeviceobject.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetdeviceobject.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetfilehandle.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetfilehandle.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetfileobject.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetfileobject.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetphysicaldevice.md
+++ b/wdk-ddi-src/content/wdfiotarget/nf-wdfiotarget-wdfiotargetwdmgettargetphysicaldevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfmemory/nf-wdfmemory-wdfmemorycreatepreallocated.md
+++ b/wdk-ddi-src/content/wdfmemory/nf-wdfmemory-wdfmemorycreatepreallocated.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfobject/nf-wdfobject-wdfobjectallocatecontext.md
+++ b/wdk-ddi-src/content/wdfobject/nf-wdfobject-wdfobjectallocatecontext.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfobject/nf-wdfobject-wdfobjectcreate.md
+++ b/wdk-ddi-src/content/wdfobject/nf-wdfobject-wdfobjectcreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfobject/nf-wdfobject-wdfobjectdereferenceactual.md
+++ b/wdk-ddi-src/content/wdfobject/nf-wdfobject-wdfobjectdereferenceactual.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfobject/nf-wdfobject-wdfobjectreferenceactual.md
+++ b/wdk-ddi-src/content/wdfobject/nf-wdfobject-wdfobjectreferenceactual.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestallocatetimer.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestallocatetimer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcancelsentrequest.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcancelsentrequest.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestchangetarget.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestchangetarget.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcomplete.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcomplete.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcompletewithinformation.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcompletewithinformation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcompletewithpriorityboost.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcompletewithpriorityboost.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcreate.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcreatefromirp.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestcreatefromirp.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestformatrequestusingcurrenttype.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestformatrequestusingcurrenttype.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestforwardtoioqueue.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestforwardtoioqueue.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestforwardtoparentdeviceioqueue.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestforwardtoparentdeviceioqueue.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetcompletionparams.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetcompletionparams.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetfileobject.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetfileobject.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetinformation.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetinformation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetioqueue.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetioqueue.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetparameters.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetparameters.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetrequestormode.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetrequestormode.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetrequestorprocessid.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetrequestorprocessid.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.lib
 req.dll: WUDFx02000.dll
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetstatus.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestgetstatus.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestiscanceled.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestiscanceled.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestisfrom32bitprocess.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestisfrom32bitprocess.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestisreserved.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestisreserved.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestmarkcancelable.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestmarkcancelable.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestmarkcancelableex.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestmarkcancelableex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestrequeue.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestrequeue.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveinputbuffer.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveinputbuffer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveinputmemory.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveinputmemory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveinputwdmmdl.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveinputwdmmdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveoutputbuffer.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveoutputbuffer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveoutputmemory.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveoutputmemory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveoutputwdmmdl.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestretrieveoutputwdmmdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestreuse.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestreuse.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestsetcompletionroutine.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestsetcompletionroutine.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestsetinformation.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestsetinformation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequeststopacknowledge.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequeststopacknowledge.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestunmarkcancelable.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestunmarkcancelable.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestwdmformatusingstacklocation.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestwdmformatusingstacklocation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestwdmgetirp.md
+++ b/wdk-ddi-src/content/wdfrequest/nf-wdfrequest-wdfrequestwdmgetirp.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistappenddescriptor.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistappenddescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistgetcount.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistgetcount.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistgetdescriptor.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistgetdescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistinsertdescriptor.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistinsertdescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistremove.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistremove.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistremovebydescriptor.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfcmresourcelistremovebydescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistappenddescriptor.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistappenddescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistcreate.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistcreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistgetcount.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistgetcount.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistgetdescriptor.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistgetdescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistinsertdescriptor.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistinsertdescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistremove.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistremove.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistremovebydescriptor.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistremovebydescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistupdatedescriptor.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcelistupdatedescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistappendioreslist.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistappendioreslist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistgetcount.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistgetcount.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistgetioreslist.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistgetioreslist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistinsertioreslist.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistinsertioreslist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistremove.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistremove.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistremovebyioreslist.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistremovebyioreslist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistsetinterfacetype.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistsetinterfacetype.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistsetslotnumber.md
+++ b/wdk-ddi-src/content/wdfresource/nf-wdfresource-wdfioresourcerequirementslistsetslotnumber.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfobjectreleaselock.md
+++ b/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfobjectreleaselock.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: "*PWDF_REQUEST_SEND_OPTIONS, WDF_REQUEST_SEND_OPTIONS"
 f1_keywords:

--- a/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfspinlockacquire.md
+++ b/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfspinlockacquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdfsync.h
 req.idl: 
 req.include-header: Wdf.h
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 1.0
 req.umdf-ver: 2.0
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)

--- a/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfspinlockcreate.md
+++ b/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfspinlockcreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfwaitlockcreate.md
+++ b/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfwaitlockcreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfwaitlockrelease.md
+++ b/wdk-ddi-src/content/wdfsync/nf-wdfsync-wdfwaitlockrelease.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 ms.custom: RS5

--- a/wdk-ddi-src/content/wdftimer/nf-wdftimer-wdftimercreate.md
+++ b/wdk-ddi-src/content/wdftimer/nf-wdftimer-wdftimercreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdftimer/nf-wdftimer-wdftimergetparentobject.md
+++ b/wdk-ddi-src/content/wdftimer/nf-wdftimer-wdftimergetparentobject.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdftimer/nf-wdftimer-wdftimerstart.md
+++ b/wdk-ddi-src/content/wdftimer/nf-wdftimer-wdftimerstart.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetconfiguredpipe.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetconfiguredpipe.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetconfiguredsettingindex.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetconfiguredsettingindex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetdescriptor.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetdescriptor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetendpointinformation.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetendpointinformation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetinterfacenumber.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetinterfacenumber.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetnumconfiguredpipes.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetnumconfiguredpipes.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetnumendpoints.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetnumendpoints.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetnumsettings.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbinterfacegetnumsettings.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicecreateisochurb.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicecreateisochurb.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicecreateurb.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicecreateurb.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceformatrequestforcontroltransfer.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceformatrequestforcontroltransfer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceformatrequestforcycleport.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceformatrequestforcycleport.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceformatrequestforstring.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceformatrequestforstring.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceformatrequestforurb.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceformatrequestforurb.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicegetinterface.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicegetinterface.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicegetiotarget.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicegetiotarget.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicegetnuminterfaces.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicegetnuminterfaces.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceretrievecurrentframenumber.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceretrievecurrentframenumber.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceretrieveinformation.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdeviceretrieveinformation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicewdmgetconfigurationhandle.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetdevicewdmgetconfigurationhandle.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeconfigcontinuousreader.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeconfigcontinuousreader.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforabort.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforabort.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforread.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforread.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforreset.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforreset.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforurb.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforurb.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforwrite.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeformatrequestforwrite.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipegetinformation.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipegetinformation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipegettype.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipegettype.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeisinendpoint.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeisinendpoint.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeisoutendpoint.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipeisoutendpoint.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipesetnomaximumpacketsizecheck.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipesetnomaximumpacketsizecheck.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (KMDF); WUDFx02000.dll (UMDF)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipewdmgetpipehandle.md
+++ b/wdk-ddi-src/content/wdfusb/nf-wdfusb-wdfusbtargetpipewdmgetpipehandle.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstancecreate.md
+++ b/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstancecreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstancederegister.md
+++ b/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstancederegister.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstancegetdevice.md
+++ b/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstancegetdevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstancegetprovider.md
+++ b/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstancegetprovider.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstanceregister.md
+++ b/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiinstanceregister.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiprovidercreate.md
+++ b/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiprovidercreate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiprovidergetdevice.md
+++ b/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiprovidergetdevice.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiprovidergettracinghandle.md
+++ b/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiprovidergettracinghandle.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiproviderisenabled.md
+++ b/wdk-ddi-src/content/wdfwmi/nf-wdfwmi-wdfwmiproviderisenabled.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-ioacquirecancelspinlock.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-ioacquirecancelspinlock.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-iobuildpartialmdl.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iobuildpartialmdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-iocopycurrentirpstacklocationtonext.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iocopycurrentirpstacklocationtonext.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-ioreuseirp.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-ioreuseirp.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-keresetevent.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-keresetevent.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-kesrcufree.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-kesrcufree.md
@@ -14,7 +14,7 @@ req.dll: NtosKrnl.exe
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h, Ntddk.h, Ntifs.h
-req.irql: <DISPATCH_LEVEL
+req.irql: < DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: NtosKrnl.lib
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-kesrcusynchronize.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-kesrcusynchronize.md
@@ -14,7 +14,7 @@ req.dll: NtosKrnl.exe
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h, Ntddk.h, Ntifs.h
-req.irql: <DISPATCH_LEVEL
+req.irql: < DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: NtosKrnl.lib
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmadvancemdl.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmadvancemdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmbuildmdlfornonpagedpool.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmbuildmdlfornonpagedpool.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmmapiospaceex.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmmapiospaceex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmmapmdl.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmmapmdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe (kernel mode)
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmprotectmdlsystemaddress.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmprotectmdlsystemaddress.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmunlockpages.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmunlockpages.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmunmapiospace.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmunmapiospace.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmunmapreservedmapping.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmunmapreservedmapping.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-obfreferenceobject.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-obfreferenceobject.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-obreferenceobject.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-obreferenceobject.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-pogetsystemwake.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-pogetsystemwake.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-posetsystemstate.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-posetsystemstate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-postartnextpowerirp.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-postartnextpowerirp.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
> **Context:** This is part of a series of pull requests.
>
> I am working on a sister project to [sparse](https://github.com/cristeigabriela/sparse), the sdk-api parser, and in the process, I automated finding issues in windows-driver-docs-ddi (I've also done this for sdk-api.)
>
> I'm now submitting patches for everything I've found for review. All the changes were tested in a branch where all of them are applied, and every single YAML frontmatter parses correctly.

<details>
<summary><b>All 12 PRs in this series — merging guide</b></summary>

| # | PR | Branch | Files |
|---|----|--------|-------|
| 1 | #1660 | `fix/typos-frontmatter` | 5 |
| 2 | #1661 | `fix/acxmisc-acxobjectbagretrieveblob-irql` | 1 |
| 3 | #1662 | `fix/iddcx-irql-empty` | 14 |
| 4 | #1663 | `fix/silo-and-reparse-irql` | 8 |
| 5 | #1664 | `fix/portcls-na-dll` | 2 |
| 6 | #1665 | `fix/irql-apc-level-spacing` | 41 |
| 7 | #1666 | `fix/irql-passive-abbreviation` | 2 |
| 8 | #1667 | `fix/irql-dispatch-level-spacing` | 301 |
| 9 | #1668 | `fix/ntoskrnl-lib-misfiled-as-dll` | 3 |
| 10 | #1669 | `fix/strip-irql-prose-prefix` | 80 |
| 11 | #1670 | `fix/irql-trailing-period-and-passive-case` | 133 |
| 12 | #1671 | `fix/irql-prose-to-operator` | 239 |

All of the 12 PRs have zero pairwise file overlap. They can be merged individually, in any order, and there will not be merge conflicts between them.

After every PR is merged, all 10,915 `nf-*.md` frontmatter blocks will *still* parse cleanly as YAML.

A reference branch with all of the PRs merged at once is at [`integration/all-open-prs`](https://github.com/cristeigabriela/windows-driver-docs-ddi/tree/integration/all-open-prs).

</details>

Like other previous PRs, normalizes `req.irql`.

| Before | After | Files |
|--------|-------|-------|
| `<=DISPATCH_LEVEL` (no space) | `<= DISPATCH_LEVEL` | 298 |
| `<DISPATCH_LEVEL` (no space) | `< DISPATCH_LEVEL` | 3 |

The three `<` (strictly less than) entries are kept distinct from `<=`. Only the missing space after the operator is normalized.
