### PR TITLE
fix: req.dll for `ntoskrnl` ending in `.lib` instead of `.exe`

### DIFF
--- a/wdk-ddi-src/content/ntddk/nf-ntddk-zwpowerinformation.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-zwpowerinformation.md
@@ -22,7 +22,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: Ntoskrnl.lib
-req.dll: Ntoskrnl.lib
+req.dll: NtosKrnl.exe
 req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 

--- a/wdk-ddi-src/content/ntpoapi/nf-ntpoapi-ntpowerinformation.md
+++ b/wdk-ddi-src/content/ntpoapi/nf-ntpoapi-ntpowerinformation.md
@@ -22,7 +22,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: Ntoskrnl.lib
-req.dll: Ntoskrnl.lib
+req.dll: NtosKrnl.exe
 req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-ntpowerinformation.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-ntpowerinformation.md
@@ -22,7 +22,7 @@ req.namespace:
 req.assembly: 
 req.type-library: 
 req.lib: Ntoskrnl.lib
-req.dll: Ntoskrnl.lib
+req.dll: NtosKrnl.exe
 req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 


### PR DESCRIPTION
> **Context:** This is part of a series of pull requests.
>
> I am working on a sister project to [sparse](https://github.com/cristeigabriela/sparse), the sdk-api parser, and in the process, I automated finding issues in windows-driver-docs-ddi (I've also done this for sdk-api.)
>
> I'm now submitting patches for everything I've found for review. All the changes were tested in a branch where all of them are applied, and every single YAML frontmatter parses correctly.

<details>
<summary><b>All 12 PRs in this series — merging guide</b></summary>

| # | PR | Branch | Files |
|---|----|--------|-------|
| 1 | #1660 | `fix/typos-frontmatter` | 5 |
| 2 | #1661 | `fix/acxmisc-acxobjectbagretrieveblob-irql` | 1 |
| 3 | #1662 | `fix/iddcx-irql-empty` | 14 |
| 4 | #1663 | `fix/silo-and-reparse-irql` | 8 |
| 5 | #1664 | `fix/portcls-na-dll` | 2 |
| 6 | #1665 | `fix/irql-apc-level-spacing` | 41 |
| 7 | #1666 | `fix/irql-passive-abbreviation` | 2 |
| 8 | #1667 | `fix/irql-dispatch-level-spacing` | 301 |
| 9 | #1668 | `fix/ntoskrnl-lib-misfiled-as-dll` | 3 |
| 10 | #1669 | `fix/strip-irql-prose-prefix` | 80 |
| 11 | #1670 | `fix/irql-trailing-period-and-passive-case` | 133 |
| 12 | #1671 | `fix/irql-prose-to-operator` | 239 |

All of the 12 PRs have zero pairwise file overlap. They can be merged individually, in any order, and there will not be merge conflicts between them.

After every PR is merged, all 10,915 `nf-*.md` frontmatter blocks will *still* parse cleanly as YAML.

A reference branch with all of the PRs merged at once is at [`integration/all-open-prs`](https://github.com/cristeigabriela/windows-driver-docs-ddi/tree/integration/all-open-prs).

</details>

Fixes cases where frontmatter `req.dll` ended in `.lib` for `ntoskrnl` instead of `.exe`.
