### PR TITLE
fix: strip redundant `IRQL ` from the start of req.irql frontmatter entries 

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltacquireresourceexclusive.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltacquireresourceexclusive.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: fltkernel.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: FltMgr.lib
 req.max-support: 

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltacquireresourceshared.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltacquireresourceshared.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: fltkernel.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: FltMgr.lib
 req.max-support: 

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltreleaseresource.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltreleaseresource.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: fltkernel.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: FltMgr.lib
 req.max-support: 

--- a/wdk-ddi-src/content/ks/nf-ks-ksstreampointerscheduletimeout.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksstreampointerscheduletimeout.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisallocatebuffer.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisallocatebuffer.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: Ndis.h
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: Ndis.lib
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisallocatebufferpool.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisallocatebufferpool.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisallocatepacketpoolex.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisallocatepacketpoolex.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: Ndis.lib
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndiscancelsendpackets.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndiscancelsendpackets.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: Ndis.h
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: Ndis.lib
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndiscopyfrompackettopacketsafe.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndiscopyfrompackettopacketsafe.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: Ndis.h
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: Ndis.lib
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisfreepacketpool.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisfreepacketpool.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisgetreceivedpacket.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisgetreceivedpacket.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: Ndis.h
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: Ndis.lib
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisimgetdevicecontext.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisimgetdevicecontext.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: Ndis.lib
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndispacketpoolusage.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndispacketpoolusage.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisrequest.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisrequest.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: Ndis.h
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: Ndis.lib
 req.max-support: 

--- a/wdk-ddi-src/content/ndis/nf-ndis-ndisscheduleworkitem.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndisscheduleworkitem.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ndis.h
 req.idl: 
 req.include-header: Ndis.h
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-ioraiseharderror.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-ioraiseharderror.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmallocatecontiguousmemory.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmallocatecontiguousmemory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycachenode.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmallocatecontiguousmemoryspecifycachenode.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-mmallocatecontiguousnodememory.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-mmallocatecontiguousnodememory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-pshedallocatememory.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-pshedallocatememory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Pshed.lib
 req.dll: Pshed.dll
-req.irql: IRQL <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-pshedsynchronizeexecution.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-pshedsynchronizeexecution.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Pshed.lib
 req.dll: Pshed.dll
-req.irql: IRQL <= DIRQL
+req.irql: <= DIRQL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlenumerategenerictable.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlenumerategenerictable.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL < DISPATCH_LEVEL (see Remarks section)
+req.irql: < DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlenumerategenerictableavl.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlenumerategenerictableavl.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL < DISPATCH_LEVEL (see Remarks section)
+req.irql: < DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlinitializegenerictable.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlinitializegenerictable.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlinitializegenerictableavl.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlinitializegenerictableavl.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtllookupelementgenerictableavl.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtllookupelementgenerictableavl.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL < DISPATCH_LEVEL (see Remarks section)
+req.irql: < DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-wheafinderrorrecordsection.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-wheafinderrorrecordsection.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: IRQL <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-wheafindnexterrorrecordsection.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-wheafindnexterrorrecordsection.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlcheckupperoplock.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlcheckupperoplock.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 ms.custom: RS5

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlupperoplockfsctrl.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-_fsrtl_advanced_fcb_header-fsrtlupperoplockfsctrl.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 ms.custom: RS5

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-rtlgetacesbuffersize.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-rtlgetacesbuffersize.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ntifs.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/storport/nf-storport-storportiscurrentosinstallationupgrade.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportiscurrentosinstallationupgrade.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: IRQL == PASSIVE_LEVEL
+req.irql: == PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportisdeviceoperationallowed.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportisdeviceoperationallowed.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: IRQL == PASSIVE_LEVEL
+req.irql: == PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportpofxactivatecomponent.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportpofxactivatecomponent.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Storport.lib
 req.dll: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-clfscreatemarshallingarea.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-clfscreatemarshallingarea.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Clfs.lib
 req.dll: Clfs.sys
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-clfsflushtolsn.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-clfsflushtolsn.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Clfs.lib
 req.dll: Clfs.sys
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-clfsmgmthandlelogfilefull.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-clfsmgmthandlelogfilefull.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Clfs.lib
 req.dll: Clfs.sys
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-clfsterminatereadlog.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-clfsterminatereadlog.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Clfs.lib
 req.dll: Clfs.sys
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-cmcallbackgetkeyobjectidex.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-cmcallbackgetkeyobjectidex.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-dbgprint.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-dbgprint.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtDll.lib (user mode); NtosKrnl.lib (kernel mode)
 req.dll: NtDll.dll (user mode); NtosKrnl.exe (kernel mode)
-req.irql: IRQL <= DIRQL (see Comments section)
+req.irql: <= DIRQL (see Comments section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exacquireresourceexclusivelite.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exacquireresourceexclusivelite.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exacquirespinlockexclusive.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exacquirespinlockexclusive.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exacquirespinlockexclusiveatdpclevel.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exacquirespinlockexclusiveatdpclevel.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL >= DISPATCH_LEVEL
+req.irql: '>= DISPATCH_LEVEL'
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exacquirespinlocksharedatdpclevel.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exacquirespinlocksharedatdpclevel.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL >= DISPATCH_LEVEL
+req.irql: '>= DISPATCH_LEVEL'
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepool.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepool.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepool2.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepool2.md
@@ -12,7 +12,7 @@ req.dll: NtosKrnl.exe
 req.header: wdm.h
 req.include-header: Wdm.h, Ntddk.h, Ntifs.h
 req.idl: 
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 req.kmdf-ver: 
 req.lib: NtosKrnl.lib
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolquotauninitialized.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolquotauninitialized.md
@@ -12,7 +12,7 @@ req.dll: NtosKrnl.exe
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h, Ntddk.h, Ntifs.h
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 req.kmdf-ver: 
 req.lib: NtosKrnl.lib
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepooluninitialized.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepooluninitialized.md
@@ -12,7 +12,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h, Ntddk.h, Ntifs.h
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolwithtag.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolwithtag.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolwithtagpriority.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolwithtagpriority.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolzero.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exallocatepoolzero.md
@@ -12,7 +12,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h, Ntddk.h, Ntifs.h
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 req.kmdf-ver: 
 req.lib: NtosKrnl.lib
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exinitializenpagedlookasidelist.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exinitializenpagedlookasidelist.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL (see Remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exqueueworkitem.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exqueueworkitem.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exregistercallback.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exregistercallback.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exreleasespinlockexclusivefromdpclevel.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exreleasespinlockexclusivefromdpclevel.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL >= DISPATCH_LEVEL
+req.irql: '>= DISPATCH_LEVEL'
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exreleasespinlocksharedfromdpclevel.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exreleasespinlocksharedfromdpclevel.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL >= DISPATCH_LEVEL
+req.irql: '>= DISPATCH_LEVEL'
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exsettimerresolution.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exsettimerresolution.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-ioallocateerrorlogentry.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-ioallocateerrorlogentry.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-iobuildasynchronousfsdrequest.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iobuildasynchronousfsdrequest.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-iocalldriver.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iocalldriver.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-iocreatedevice.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iocreatedevice.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-iofcalldriver.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iofcalldriver.md
@@ -15,7 +15,7 @@ req.kmdf-ver:
 req.umdf-ver: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.ddi-compliance: CompleteRequestStatusCheck, CompletionRoutineRegistered, DeleteDevice, ForwardedAtBadIrql, ForwardedAtBadIrqlAllocate, ForwardedAtBadIrqlFsdAsync, ForwardedAtBadIrqlFsdSync, IoAllocateForward, IoAllocateIrpSignalEventInCompletionTimeout, IoBuildDeviceControlWait, IoBuildDeviceControlWaitTimeout, IoBuildFsdForward, IoBuildSynchronousFsdRequestWait, IoBuildSynchronousFsdRequestWaitTimeout, IoSetCompletionRoutineExCheck, IrpProcessingComplete, LowerDriverReturn, MarkDevicePower, MarkingQueuedIrps, MarkIrpPending, MarkIrpPending2, MarkPower, MarkPowerDown, MarkQueryRelations, MarkStartDevice, PendedCompletedRequest, PendedCompletedRequest2, PendedCompletedRequest3, PendedCompletedRequestEx, PnpIrpCompletion, PowerDownFail, PowerUpFail, RemoveLockForward, RemoveLockForward2, RemoveLockForwardDeviceControl, RemoveLockForwardDeviceControl2, RemoveLockForwardDeviceControlInternal, RemoveLockForwardDeviceControlInternal2, RemoveLockForwardRead, RemoveLockForwardRead2, RemoveLockForwardWrite, RemoveLockForwardWrite2, RemoveLockMnRemove2, RemoveLockMnSurpriseRemove, RemoveLockQueryMnRemove, TargetRelationNeedsRef, WmiForward, HwStorPortProhibitedDDIs
 req.unicode-ansi: 
 req.idl: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-iosetcompletionroutine.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iosetcompletionroutine.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-iowithinstacklimits.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-iowithinstacklimits.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-keacquireinstackqueuedspinlock.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-keacquireinstackqueuedspinlock.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-keacquireinstackqueuedspinlockatdpclevel.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-keacquireinstackqueuedspinlockatdpclevel.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: 
-req.irql: IRQL >= DISPATCH_LEVEL
+req.irql: '>= DISPATCH_LEVEL'
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-keregisternmicallback.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-keregisternmicallback.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL (see Remarks section)
+req.irql: <= APC_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmallocatecontiguousmemory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmallocatecontiguousmemory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmallocatecontiguousmemoryspecifycachenode.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmallocatecontiguousmemoryspecifycachenode.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmgetsystemaddressformdl.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmgetsystemaddressformdl.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmmapiospace.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmmapiospace.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <=DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-obdereferenceobject.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-obdereferenceobject.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-obdereferenceobjectdeferdelete.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-obdereferenceobjectdeferdelete.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-obreferenceobjectbypointer.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-obreferenceobjectbypointer.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= DISPATCH_LEVEL
+req.irql: <= DISPATCH_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-pcwaddinstance.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-pcwaddinstance.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-pcwcloseinstance.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-pcwcloseinstance.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-pcwcreateinstance.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-pcwcreateinstance.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-pcwregister.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-pcwregister.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-pcwunregister.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-pcwunregister.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlfindclearbits.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlfindclearbits.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: IRQL <= APC_LEVEL (See Remarks section)
+req.irql: <= APC_LEVEL (See Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
> **Context:** This is part of a series of pull requests.
>
> I am working on a sister project to [sparse](https://github.com/cristeigabriela/sparse), the sdk-api parser, and in the process, I automated finding issues in windows-driver-docs-ddi (I've also done this for sdk-api.)
>
> I'm now submitting patches for everything I've found for review. All the changes were tested in a branch where all of them are applied, and every single YAML frontmatter parses correctly.

<details>
<summary><b>All 12 PRs in this series — merging guide</b></summary>

| # | PR | Branch | Files |
|---|----|--------|-------|
| 1 | #1660 | `fix/typos-frontmatter` | 5 |
| 2 | #1661 | `fix/acxmisc-acxobjectbagretrieveblob-irql` | 1 |
| 3 | #1662 | `fix/iddcx-irql-empty` | 14 |
| 4 | #1663 | `fix/silo-and-reparse-irql` | 8 |
| 5 | #1664 | `fix/portcls-na-dll` | 2 |
| 6 | #1665 | `fix/irql-apc-level-spacing` | 41 |
| 7 | #1666 | `fix/irql-passive-abbreviation` | 2 |
| 8 | #1667 | `fix/irql-dispatch-level-spacing` | 301 |
| 9 | #1668 | `fix/ntoskrnl-lib-misfiled-as-dll` | 3 |
| 10 | #1669 | `fix/strip-irql-prose-prefix` | 80 |
| 11 | #1670 | `fix/irql-trailing-period-and-passive-case` | 133 |
| 12 | #1671 | `fix/irql-prose-to-operator` | 239 |

All of the 12 PRs have zero pairwise file overlap. They can be merged individually, in any order, and there will not be merge conflicts between them.

After every PR is merged, all 10,915 `nf-*.md` frontmatter blocks will *still* parse cleanly as YAML.

A reference branch with all of the PRs merged at once is at [`integration/all-open-prs`](https://github.com/cristeigabriela/windows-driver-docs-ddi/tree/integration/all-open-prs).

</details>

Redundant text in req.irql can go away to normalize req.irql values.
