### PR TITLE
fix: normalize req.irql trailing periods and case variants across 133 files

### DIFF
--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltdocompletionprocessingwhensafe.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltdocompletionprocessingwhensafe.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Fltmgr.lib
 req.dll: 
-req.irql: Any.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsetcallbackdatadirty.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsetcallbackdatadirty.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Fltmgr.lib
 req.dll: Fltmgr.sys
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsettransactioncontext.md
+++ b/wdk-ddi-src/content/fltkernel/nf-fltkernel-fltsettransactioncontext.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: FltMgr.lib
 req.dll: FltMgr.sys
-req.irql: <= APC_LEVEL.
+req.irql: <= APC_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kscreateallocator.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kscreateallocator.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: PASSIVE_LEVEL (See Remarks section)
+req.irql: PASSIVE_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksdevicegetbusdata.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksdevicegetbusdata.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: PASSIVE_LEVEL (See Remarks section)
+req.irql: PASSIVE_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksgenerateevent.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksgenerateevent.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-ksgenerateeventlist.md
+++ b/wdk-ddi-src/content/ks/nf-ks-ksgenerateeventlist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspinattachandgate.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspinattachandgate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: PASSIVE_LEVEL (See Remarks section)
+req.irql: PASSIVE_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ks/nf-ks-kspinattachorgate.md
+++ b/wdk-ddi-src/content/ks/nf-ks-kspinattachorgate.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ks.lib
 req.dll: 
-req.irql: PASSIVE_LEVEL (See Remarks section)
+req.irql: PASSIVE_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/minitape/nf-minitape-rtlzeromemory.md
+++ b/wdk-ddi-src/content/minitape/nf-minitape-rtlzeromemory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: TAPE_STATUS, *PTAPE_STATUS
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-ioisfileobjectignoringsharing.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-ioisfileobjectignoringsharing.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-ioisvalidirpstatus.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-ioisvalidirpstatus.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-iosetfileobjectignoresharing.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-iosetfileobjectignoresharing.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-iosetmasterirpstatus.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-iosetmasterirpstatus.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-iosetpartitioninformation.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-iosetpartitioninformation.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: PASSIVE_LEVEL (See Remarks section)
+req.irql: PASSIVE_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-iosetpartitioninformationex.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-iosetpartitioninformationex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: PASSIVE_LEVEL (See Remarks section)
+req.irql: PASSIVE_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-pshedissystemwheaenabled.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-pshedissystemwheaenabled.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Pshed.lib
 req.dll: Pshed.dll
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlcopystring.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlcopystring.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlgetelementgenerictable.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlgetelementgenerictable.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks)
+req.irql: Any level (see Remarks)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntddk/nf-ntddk-rtlgetelementgenerictableavl.md
+++ b/wdk-ddi-src/content/ntddk/nf-ntddk-rtlgetelementgenerictableavl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks)
+req.irql: Any level (see Remarks)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlsupportsperfilecontexts.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlsupportsperfilecontexts.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-mapsecurityerror.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-mapsecurityerror.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-ntflushbuffersfileex.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-ntflushbuffersfileex.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: PASSIVE_LEVEL (See Remarks section.)
+req.irql: PASSIVE_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-psisdiskcountersenabled.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-psisdiskcountersenabled.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-rtlequalsid.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-rtlequalsid.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe (kernel mode); Ntdll.dll (user mode)
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-zwflushbuffersfileex.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-zwflushbuffersfileex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: PASSIVE_LEVEL (See Remarks section.)
+req.irql: PASSIVE_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-idmachannelslave-waitfortc.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-idmachannelslave-waitfortc.md
@@ -15,7 +15,7 @@ req.kmdf-ver:
 req.umdf-ver: 
 req.lib: 
 req.dll: 
-req.irql: PASSIVE_LEVEL (See Remarks section.)
+req.irql: PASSIVE_LEVEL (see Remarks section)
 req.ddi-compliance: 
 req.unicode-ansi: 
 req.idl: 

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavert-getdevicedescription.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavert-getdevicedescription.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavert-init.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavert-init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavert-newstream.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavert-newstream.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertinputstream-getreadpacket.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertinputstream-getreadpacket.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertoutputstream-getoutputstreampresentationposition.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertoutputstream-getoutputstreampresentationposition.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertoutputstream-getpacketcount.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertoutputstream-getpacketcount.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertoutputstream-setwritepacket.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertoutputstream-setwritepacket.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstreamnotification-allocatebufferwithnotification.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstreamnotification-allocatebufferwithnotification.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstreamnotification-freebufferwithnotification.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstreamnotification-freebufferwithnotification.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstreamnotification-registernotificationevent.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstreamnotification-registernotificationevent.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstreamnotification-unregisternotificationevent.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iminiportwavertstreamnotification-unregisternotificationevent.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-ipinname-getpinname.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-ipinname-getpinname.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: PASSIVE_LEVEL.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportclspower-registeradapterpowermanagement.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportclspower-registeradapterpowermanagement.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: PASSIVE_LEVEL.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportclspower-setidlepowermanagement.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportclspower-setidlepowermanagement.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: PASSIVE_LEVEL.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportclspower-unregisteradapterpowermanagement.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportclspower-unregisteradapterpowermanagement.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: PASSIVE_LEVEL.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportevents-generateeventlist.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportevents-generateeventlist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level. (See Remarks section.)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-allocatecontiguouspagesformdl.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-allocatecontiguouspagesformdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-allocatepagesformdl.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-allocatepagesformdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-freepagesfrommdl.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-freepagesfrommdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-getphysicalpageaddress.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-getphysicalpageaddress.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-getphysicalpagescount.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-getphysicalpagescount.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-mapallocatedpages.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-mapallocatedpages.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-unmapallocatedpages.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwavertstream-unmapallocatedpages.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Passive level.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwmiregistration-registerwmiprovider.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwmiregistration-registerwmiprovider.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: PASSIVE_LEVEL.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-iportwmiregistration-unregisterwmiprovider.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-iportwmiregistration-unregisterwmiprovider.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: PASSIVE_LEVEL.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/portcls/nf-portcls-pcunregisteradapterpowermanagement.md
+++ b/wdk-ddi-src/content/portcls/nf-portcls-pcunregisteradapterpowermanagement.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Portcls.lib
 req.dll: 
-req.irql: PASSIVE_LEVEL.
+req.irql: PASSIVE_LEVEL
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/scsi/nf-scsi-rtlzeromemory.md
+++ b/wdk-ddi-src/content/scsi/nf-scsi-rtlzeromemory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: SES_DOWNLOAD_MICROCODE_STATE, *PSES_DOWNLOAD_MICROCODE_STATE
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_custom_receive_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_custom_receive_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_custom_receive_transaction_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_custom_receive_transaction_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_custom_transmit_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_custom_transmit_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_custom_transmit_transaction_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_custom_transmit_transaction_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_pio_receive_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_pio_receive_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_pio_transmit_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_pio_transmit_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_system_dma_receive_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_system_dma_receive_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_system_dma_receive_config_init_new_data_notification.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_system_dma_receive_config_init_new_data_notification.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx2_system_dma_transmit_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx2_system_dma_transmit_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx_activity_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx_activity_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx_buffer_descriptor_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx_buffer_descriptor_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/sercx/nf-sercx-sercx_config_init.md
+++ b/wdk-ddi-src/content/sercx/nf-sercx-sercx_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/smclib/nf-smclib-rtlzeromemory.md
+++ b/wdk-ddi-src/content/smclib/nf-smclib-rtlzeromemory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: SFFDISK_DPCMD
 f1_keywords:

--- a/wdk-ddi-src/content/spb/nf-spb-spb_transfer_list_entry_init_buffer_list.md
+++ b/wdk-ddi-src/content/spb/nf-spb-spb_transfer_list_entry_init_buffer_list.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/spb/nf-spb-spb_transfer_list_entry_init_mdl.md
+++ b/wdk-ddi-src/content/spb/nf-spb-spb_transfer_list_entry_init_mdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/spb/nf-spb-spb_transfer_list_entry_init_non_paged.md
+++ b/wdk-ddi-src/content/spb/nf-spb-spb_transfer_list_entry_init_non_paged.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/spb/nf-spb-spb_transfer_list_entry_init_simple.md
+++ b/wdk-ddi-src/content/spb/nf-spb-spb_transfer_list_entry_init_simple.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/spbcx/nf-spbcx-spb_connection_parameters_init.md
+++ b/wdk-ddi-src/content/spbcx/nf-spbcx-spb_connection_parameters_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/spbcx/nf-spbcx-spb_controller_config_init.md
+++ b/wdk-ddi-src/content/spbcx/nf-spbcx-spb_controller_config_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/spbcx/nf-spbcx-spb_request_parameters_init.md
+++ b/wdk-ddi-src/content/spbcx/nf-spbcx-spb_request_parameters_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/spbcx/nf-spbcx-spb_transfer_descriptor_init.md
+++ b/wdk-ddi-src/content/spbcx/nf-spbcx-spb_transfer_descriptor_init.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-rtlzeromemory.md
+++ b/wdk-ddi-src/content/storport/nf-storport-rtlzeromemory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: STOR_SPINLOCK
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportasyncnotificationdetected.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportasyncnotificationdetected.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetactivityidsrb.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetactivityidsrb.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Storport.lib
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetdatainbuffermdl.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetdatainbuffermdl.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Storport.lib
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetdatainbufferscattergatherlist.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetdatainbufferscattergatherlist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Storport.lib
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetmsiinfo.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetmsiinfo.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportgetrequestinfo.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportgetrequestinfo.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportlogtelemetry.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportlogtelemetry.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 ms.custom: 19H1

--- a/wdk-ddi-src/content/storport/nf-storport-storportmarkdumpmemory.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportmarkdumpmemory.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportpofxidlecomponent.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportpofxidlecomponent.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportqueryperformancecounter.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportqueryperformancecounter.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportrequesttimer.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportrequesttimer.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportsetpowersettingnotificationguids.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportsetpowersettingnotificationguids.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportsetunitattributes.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportsetunitattributes.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/storport/nf-storport-storportstatechangedetected.md
+++ b/wdk-ddi-src/content/storport/nf-storport-storportstatechangedetected.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_createconfigurationrequestex.md
+++ b/wdk-ddi-src/content/usbdlib/nf-usbdlib-usbd_createconfigurationrequestex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Usbd.lib
 req.dll: 
-req.irql: DISPATCH_LEVEL (See Remarks)
+req.irql: DISPATCH_LEVEL (see Remarks)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfcore/nf-wdfcore-wdf_align_size_down.md
+++ b/wdk-ddi-src/content/wdfcore/nf-wdfcore-wdf_align_size_down.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: Any IRQL.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfcore/nf-wdfcore-wdf_align_size_up.md
+++ b/wdk-ddi-src/content/wdfcore/nf-wdfcore-wdf_align_size_up.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: Any IRQL.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdeviceenqueuerequest.md
+++ b/wdk-ddi-src/content/wdfdevice/nf-wdfdevice-wdfdeviceenqueuerequest.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Wdf01000.sys (see Framework Library Versioning.)
 req.dll: 
-req.irql: <= DISPATCH_LEVEL (See remarks section)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_drained.md
+++ b/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_drained.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: None
 req.dll: 
-req.irql: Any IRQL.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_idle.md
+++ b/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_idle.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: None
 req.dll: 
-req.irql: Any IRQL.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_purged.md
+++ b/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_purged.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: None
 req.dll: 
-req.irql: Any IRQL.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_ready.md
+++ b/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_ready.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: None
 req.dll: 
-req.irql: Any IRQL.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_stopped.md
+++ b/wdk-ddi-src/content/wdfio/nf-wdfio-wdf_io_queue_stopped.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: None
 req.dll: 
-req.irql: Any IRQL.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-appendtaillist.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-appendtaillist.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exacquirespinlockshared.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exacquirespinlockshared.md
@@ -15,7 +15,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: 
-req.irql: DISPATCH_LEVEL (See Remarks.)
+req.irql: DISPATCH_LEVEL (see Remarks)
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-exinitializedeletetimerparameters.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exinitializedeletetimerparameters.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exinitializesettimerparameters.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exinitializesettimerparameters.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exquerytimerresolution.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exquerytimerresolution.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ntoskrnl.lib
 req.dll: 
-req.irql: Any level.
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exreleasespinlockexclusive.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exreleasespinlockexclusive.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: DISPATCH_LEVEL (See Remarks.)
+req.irql: DISPATCH_LEVEL (see Remarks)
 targetos: Windows
 req.typenames: WORK_QUEUE_TYPE
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-exreleasespinlockshared.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-exreleasespinlockshared.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: DISPATCH_LEVEL (See Remarks.)
+req.irql: DISPATCH_LEVEL (see Remarks)
 targetos: Windows
 req.typenames: WORK_QUEUE_TYPE
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-insertheadlist.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-insertheadlist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-kercureadlock.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-kercureadlock.md
@@ -14,7 +14,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h
-req.irql: Any level (See Remarks)
+req.irql: Any level (see Remarks)
 req.kmdf-ver: 
 req.lib: NtosKrnl.lib
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-kereverttouseraffinitythreadex.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-kereverttouseraffinitythreadex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <= DISPATCH_LEVEL (see Remarks section).
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-kereverttousergroupaffinitythread.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-kereverttousergroupaffinitythread.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <= DISPATCH_LEVEL (see Remarks section).
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-kesetsystemaffinitythread.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-kesetsystemaffinitythread.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <= DISPATCH_LEVEL (see Remarks section).
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-kesetsystemaffinitythreadex.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-kesetsystemaffinitythreadex.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <= DISPATCH_LEVEL (see Remarks section).
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-kesetsystemgroupaffinitythread.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-kesetsystemgroupaffinitythread.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <= DISPATCH_LEVEL (see Remarks section).
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-mmallocatenodepagesformdlex.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-mmallocatenodepagesformdlex.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: <= DISPATCH_LEVEL (See Remarks section.)
+req.irql: <= DISPATCH_LEVEL (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-pushentrylist.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-pushentrylist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-removeentrylist.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-removeentrylist.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-removeheadlist.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-removeheadlist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-removetaillist.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-removetaillist.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlcomparememory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlcomparememory.md
@@ -20,7 +20,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib; OneCoreUAP.lib on Windows 10
 req.dll: NtDll.dll (user mode); Kernel32.dll (user mode); NtosKrnl.exe (kernel mode)
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlcopymemory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlcopymemory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtDll.dll (user mode); NtosKrnl.exe (kernel mode)
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlcopyunicodestring.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlcopyunicodestring.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe (kernel mode); Ntdll.dll (user mode)
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlequaldevicememory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlequaldevicememory.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 req.kmdf-ver: 
 req.lib: volatileaccessk.lib (Kernel mode), volatileaccessu.lib (User mode)
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlequalmemory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlequalmemory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: 
 req.dll: 
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlfilldevicememory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlfilldevicememory.md
@@ -13,7 +13,7 @@ req.dll: NtosKrnl.exe
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h, Ntddk.h, Ntifs.h
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 req.kmdf-ver: 
 req.lib: volatileaccessk.lib (Kernel mode), volatileaccessu.lib (User mode)
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlfillmemory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlfillmemory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtDll.lib (user mode); NtosKrnl.lib (kernel mode)
 req.dll: Kernel32.dll (user mode); NtosKrnl.exe (kernel mode)
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlinitansistring.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlinitansistring.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlmovememory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlmovememory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlnumberofsetbitsulongptr.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlnumberofsetbitsulongptr.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any IRQL
+req.irql: Any level
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlsecurezeromemory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlsecurezeromemory.md
@@ -13,7 +13,7 @@ req.dll: NtosKrnl.exe
 req.header: wdm.h
 req.idl: 
 req.include-header: Wdm.h, Ntddk.h, Ntifs.h
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 req.kmdf-ver: 
 req.lib: NtosKrnl.lib
 req.max-support: 

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtltimefieldstotime.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtltimefieldstotime.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtltimetotimefields.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtltimetotimefields.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe (kernel mode); Ntdll.dll (user mode)
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlzeromemory.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlzeromemory.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: NtosKrnl.lib
 req.dll: NtosKrnl.exe
-req.irql: Any level (See Remarks section)
+req.irql: Any level (see Remarks section)
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
> **Context:** This is part of a series of pull requests.
>
> I am working on a sister project to [sparse](https://github.com/cristeigabriela/sparse), the sdk-api parser, and in the process, I automated finding issues in windows-driver-docs-ddi (I've also done this for sdk-api.)
>
> I'm now submitting patches for everything I've found for review. All the changes were tested in a branch where all of them are applied, and every single YAML frontmatter parses correctly.

<details>
<summary><b>All 12 PRs in this series — merging guide</b></summary>

| # | PR | Branch | Files |
|---|----|--------|-------|
| 1 | #1660 | `fix/typos-frontmatter` | 5 |
| 2 | #1661 | `fix/acxmisc-acxobjectbagretrieveblob-irql` | 1 |
| 3 | #1662 | `fix/iddcx-irql-empty` | 14 |
| 4 | #1663 | `fix/silo-and-reparse-irql` | 8 |
| 5 | #1664 | `fix/portcls-na-dll` | 2 |
| 6 | #1665 | `fix/irql-apc-level-spacing` | 41 |
| 7 | #1666 | `fix/irql-passive-abbreviation` | 2 |
| 8 | #1667 | `fix/irql-dispatch-level-spacing` | 301 |
| 9 | #1668 | `fix/ntoskrnl-lib-misfiled-as-dll` | 3 |
| 10 | #1669 | `fix/strip-irql-prose-prefix` | 80 |
| 11 | #1670 | `fix/irql-trailing-period-and-passive-case` | 133 |
| 12 | #1671 | `fix/irql-prose-to-operator` | 239 |

All of the 12 PRs have zero pairwise file overlap. They can be merged individually, in any order, and there will not be merge conflicts between them.

After every PR is merged, all 10,915 `nf-*.md` frontmatter blocks will *still* parse cleanly as YAML.

A reference branch with all of the PRs merged at once is at [`integration/all-open-prs`](https://github.com/cristeigabriela/windows-driver-docs-ddi/tree/integration/all-open-prs).

</details>

Normalizes req.irql values
