### PR TITLE
fix: normalize prose-form relational operators in req.irql across 239 files

### DIFF
--- a/wdk-ddi-src/content/ndis/nf-ndis-ndiscurrentgroupandprocessor.md
+++ b/wdk-ddi-src/content/ndis/nf-ndis-ndiscurrentgroupandprocessor.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Ndis.lib
 req.dll: 
-req.irql: Greater than or equal to DISPATCH_LEVEL
+req.irql: '>= DISPATCH_LEVEL'
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlcheckoplockforfsfiltercallback.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlcheckoplockforfsfiltercallback.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: ntifs.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: 
 req.max-support: 

--- a/wdk-ddi-src/content/strmini/nf-strmini-streamclassabortoutstandingrequests.md
+++ b/wdk-ddi-src/content/strmini/nf-strmini-streamclassabortoutstandingrequests.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Stream.lib
 req.dll: 
-req.irql: Greater than DISPATCH_LEVEL
+req.irql: '> DISPATCH_LEVEL'
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usbcamdi/nf-usbcamdi-usbcamd_controlvendorcommand.md
+++ b/wdk-ddi-src/content/usbcamdi/nf-usbcamdi-usbcamd_controlvendorcommand.md
@@ -22,7 +22,7 @@ req.assembly:
 req.type-library: 
 req.lib: Usbcamd2.lib
 req.dll: 
-req.irql: Greater than or equal to PASSIVE_LEVEL (See Remarks section)
+req.irql: '>= PASSIVE_LEVEL (see Remarks section)'
 targetos: Windows
 req.typenames: 
 f1_keywords:

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfrommodealigned.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfrommodealigned.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfrommodenontemporal.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfrommodenontemporal.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfromuseraligned.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfromuseraligned.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfromusernontemporal.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfromusernontemporal.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfromusertomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copyfromusertomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytomodenontemporal.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytomodenontemporal.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytouserfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytouserfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytousernontemporal.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-copytousernontemporal.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-fillmodememory.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-fillmodememory.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-fillusermemory.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-fillusermemory.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedand64tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedand64tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedand64touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedand64touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedandtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedandtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedandtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedandtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedcompareexchange64tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedcompareexchange64tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedcompareexchange64touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedcompareexchange64touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedcompareexchangetomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedcompareexchangetomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedcompareexchangetouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedcompareexchangetouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedor64tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedor64tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedor64touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedor64touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedortomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedortomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedortouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-interlockedortouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-movetouserfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-movetouserfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readbooleanfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readbooleanfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readbooleanfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readbooleanfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readbooleanfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readbooleanfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readcharfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readcharfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readcharfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readcharfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readcharfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readcharfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readhandlefrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readhandlefrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readhandlefromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readhandlefromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readhandlefromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readhandlefromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint16frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint16frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint16fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint16fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint16fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint16fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint32frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint32frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint32fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint32fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint32fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint32fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint64frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint64frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint64fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint64fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint64fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint64fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint8frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint8frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint8fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint8fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint8fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readint8fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readintptrfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readintptrfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readintptrfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readintptrfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readintptrfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readintptrfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlargeintegerfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlargeintegerfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlargeintegerfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlargeintegerfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlong64frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlong64frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlong64fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlong64fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlong64fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlong64fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlonglongfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlonglongfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlonglongfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlonglongfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlonglongfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlonglongfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongptrfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongptrfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongptrfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongptrfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongptrfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readlongptrfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readntstatusfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readntstatusfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readntstatusfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readntstatusfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readntstatusfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readntstatusfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readpointerfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readpointerfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readpointerfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readpointerfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readpointerfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readpointerfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readshortfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readshortfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readshortfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readshortfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readshortfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readshortfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readsizetfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readsizetfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readsizetfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readsizetfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readsizetfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readsizetfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readssizetfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readssizetfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readssizetfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readssizetfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readssizetfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readssizetfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfrommodealigned.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfrommodealigned.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfrommodehelper.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfrommodehelper.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfromuseraligned.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfromuseraligned.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfromuserhelper.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readstructfromuserhelper.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readucharfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readucharfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readucharfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readucharfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readucharfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readucharfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint16frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint16frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint16fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint16fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint16fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint16fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint32frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint32frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint32fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint32fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint32fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint32fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint64frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint64frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint64fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint64fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint64fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint64fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint8frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint8frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint8fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint8fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint8fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuint8fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuintptrfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuintptrfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuintptrfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuintptrfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuintptrfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readuintptrfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulargeintegerfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulargeintegerfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulargeintegerfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulargeintegerfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulong64frommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulong64frommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulong64fromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulong64fromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulong64fromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulong64fromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulonglongfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulonglongfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulonglongfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulonglongfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulonglongfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulonglongfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongptrfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongptrfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongptrfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongptrfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongptrfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readulongptrfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readunicodestringfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readunicodestringfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readunicodestringfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readunicodestringfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readushortfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readushortfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readushortfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readushortfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readushortfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readushortfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readwcharfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readwcharfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readwcharfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readwcharfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readwcharfromuseracquire.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-readwcharfromuseracquire.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-setmodememory.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-setmodememory.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-setusermemory.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-setusermemory.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-stringlengthfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-stringlengthfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-stringlengthfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-stringlengthfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-umaexceptionfilter.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-umaexceptionfilter.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-widestringlengthfrommode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-widestringlengthfrommode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-widestringlengthfromuser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-widestringlengthfromuser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writebooleantomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writebooleantomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writebooleantouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writebooleantouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writebooleantouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writebooleantouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writechartomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writechartomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writechartouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writechartouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writechartouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writechartouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writehandletomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writehandletomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writehandletouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writehandletouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writehandletouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writehandletouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint16tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint16tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint16touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint16touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint16touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint16touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint32tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint32tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint32touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint32touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint32touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint32touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint64tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint64tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint64touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint64touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint64touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint64touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint8tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint8tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint8touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint8touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint8touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeint8touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeintptrtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeintptrtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeintptrtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeintptrtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeintptrtouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeintptrtouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelargeintegertomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelargeintegertomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelargeintegertouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelargeintegertouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelong64tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelong64tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelong64touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelong64touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelong64touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelong64touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelonglongtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelonglongtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelonglongtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelonglongtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelonglongtouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelonglongtouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongptrtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongptrtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongptrtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongptrtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongptrtouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongptrtouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongtouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writelongtouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writentstatustomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writentstatustomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writentstatustouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writentstatustouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writentstatustouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writentstatustouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writepointertomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writepointertomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writepointertouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writepointertouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writepointertouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writepointertouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeshorttomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeshorttomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeshorttouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeshorttouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeshorttouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeshorttouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writesizettomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writesizettomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writesizettouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writesizettouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writesizettouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writesizettouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writessizettomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writessizettomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writessizettouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writessizettouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writessizettouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writessizettouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtomodealigned.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtomodealigned.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtomodehelper.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtomodehelper.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtouseraligned.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtouseraligned.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtouserhelper.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writestructtouserhelper.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuchartomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuchartomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuchartouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuchartouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuchartouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuchartouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint16tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint16tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint16touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint16touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint16touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint16touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint32tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint32tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint32touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint32touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint32touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint32touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint64tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint64tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint64touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint64touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint64touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint64touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint8tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint8tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint8touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint8touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint8touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuint8touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuintptrtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuintptrtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuintptrtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuintptrtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuintptrtouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeuintptrtouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulargeintegertomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulargeintegertomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulargeintegertouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulargeintegertouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulong64tomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulong64tomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulong64touser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulong64touser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulong64touserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulong64touserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulonglongtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulonglongtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulonglongtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulonglongtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulonglongtouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulonglongtouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongptrtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongptrtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongptrtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongptrtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongptrtouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongptrtouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongtouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeulongtouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeunicodestringtomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeunicodestringtomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeunicodestringtouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeunicodestringtouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeushorttomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeushorttomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeushorttouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeushorttouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeushorttouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writeushorttouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writewchartomode.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writewchartomode.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writewchartouser.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writewchartouser.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writewchartouserrelease.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-writewchartouserrelease.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-zeromodememory.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-zeromodememory.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-zerousermemory.md
+++ b/wdk-ddi-src/content/usermode_accessors/nf-usermode_accessors-zerousermemory.md
@@ -13,7 +13,7 @@ req.dll:
 req.header: usermode_accessors.h
 req.idl: 
 req.include-header: 
-req.irql: Less than or equal to APC_LEVEL
+req.irql: <= APC_LEVEL
 req.kmdf-ver: 
 req.lib: umaccess.lib
 req.max-support: 

--- a/wdk-ddi-src/content/video/nf-video-videoportqueuedpc.md
+++ b/wdk-ddi-src/content/video/nf-video-videoportqueuedpc.md
@@ -23,7 +23,7 @@ req.assembly:
 req.type-library: 
 req.lib: Videoprt.lib
 req.dll: Videoprt.sys
-req.irql: Greater than or equal to DISPATCH_LEVEL
+req.irql: '>= DISPATCH_LEVEL'
 targetos: Windows
 req.typenames: 
 f1_keywords:


### PR DESCRIPTION
> **Context:** This is part of a series of pull requests.
>
> I am working on a sister project to [sparse](https://github.com/cristeigabriela/sparse), the sdk-api parser, and in the process, I automated finding issues in windows-driver-docs-ddi (I've also done this for sdk-api.)
>
> I'm now submitting patches for everything I've found for review. All the changes were tested in a branch where all of them are applied, and every single YAML frontmatter parses correctly.

<details>
<summary><b>All 12 PRs in this series — merging guide</b></summary>

| # | PR | Branch | Files |
|---|----|--------|-------|
| 1 | #1660 | `fix/typos-frontmatter` | 5 |
| 2 | #1661 | `fix/acxmisc-acxobjectbagretrieveblob-irql` | 1 |
| 3 | #1662 | `fix/iddcx-irql-empty` | 14 |
| 4 | #1663 | `fix/silo-and-reparse-irql` | 8 |
| 5 | #1664 | `fix/portcls-na-dll` | 2 |
| 6 | #1665 | `fix/irql-apc-level-spacing` | 41 |
| 7 | #1666 | `fix/irql-passive-abbreviation` | 2 |
| 8 | #1667 | `fix/irql-dispatch-level-spacing` | 298 |
| 9 | #1668 | `fix/ntoskrnl-lib-misfiled-as-dll` | 3 |
| 10 | #1669 | `fix/strip-irql-prose-prefix` | 80 |
| 11 | #1670 | `fix/irql-trailing-period-and-passive-case` | 133 |
| 12 | (this PR) | `fix/irql-prose-to-operator` | 239 |

All of the 12 PRs have zero pairwise file overlap. They can be merged individually, in any order, and there will not be merge conflicts between them.

After every PR is merged, all 10,915 `nf-*.md` frontmatter blocks will *still* parse cleanly as YAML.

A reference branch with all of the PRs merged at once is at [`integration/all-open-prs`](https://github.com/cristeigabriela/windows-driver-docs-ddi/tree/integration/all-open-prs).

</details>

Several `req.irql` entries spell the relational operator out in prose instead of using the canonical symbolic form that the rest of the corpus uses. This normalizes them.

| Before | After | Files |
|--------|-------|-------|
| `Less than or equal to APC_LEVEL` | `<= APC_LEVEL` | 235 |
| `Greater than or equal to DISPATCH_LEVEL` | `>= DISPATCH_LEVEL` | 2 |
| `Greater than or equal to PASSIVE_LEVEL (See Remarks section)` | `>= PASSIVE_LEVEL (see Remarks section)` | 1 |
| `Greater than DISPATCH_LEVEL` | `> DISPATCH_LEVEL` | 1 |

The four values that begin with `>` or `>=` are single-quoted in the YAML frontmatter (`req.irql: '>= DISPATCH_LEVEL'`) so the frontmatter remains valid YAML — `>` at the start of a plain scalar is the folded-scalar indicator in YAML, and an unquoted `>= DISPATCH_LEVEL` would fail to parse.

This collapses the `<= APC_LEVEL` bucket from 601 entries to 836 (it now absorbs the 235 prose-form entries), and brings the `Greater than ...` outliers into the same shape as the 1037 `<= DISPATCH_LEVEL` entries.
