### PR TITLE
Fix mailslot time from milliseconds to 100-ns intervals

### DIFF
--- a/wdk-ddi-src/content/ntifs/ns-ntifs-_file_mailslot_query_information.md
+++ b/wdk-ddi-src/content/ntifs/ns-ntifs-_file_mailslot_query_information.md
@@ -74,7 +74,12 @@ The total number of messages waiting to be read from the mailslot.
 ### -field ReadTimeout
 
   
-The time, in milliseconds, that a read operation can wait for a message to be written to the mailslot before a time-out occurs. A value of –1 requests that the read wait forever for a message, without timing out. A value of 0 requests that the read not wait and return immediately whether a pending message is available to be read or not.
+The time that a read operation can wait for a message to be written to the mailslot before a time-out occurs.
+
+* A positive value specifies the operation time-out as an absolute system time, represented as a count of 100-nanosecond intervals since January 1, 1601.
+* A negative value specifies the number of 100-nanosecond intervals for the operation to time out relative to the current time.
+* A value of -1 requests that the read wait forever for a message without timing out.
+* A value of 0 requests that the read not wait and return immediately, whether a pending message is available to be read or not.
 
 ## -remarks
 

--- a/wdk-ddi-src/content/ntifs/ns-ntifs-_file_mailslot_set_information.md
+++ b/wdk-ddi-src/content/ntifs/ns-ntifs-_file_mailslot_set_information.md
@@ -57,7 +57,12 @@ The <b>FILE_MAILSLOT_SET_INFORMATION</b> structure is used to set a value on a  
 
 ### -field ReadTimeout
 
-The time, in milliseconds, that a read operation can wait for a message to be written to the mailslot before a time-out occurs. A value of –1 requests that the read wait forever for a message without timing out. A value of 0 requests that the read not wait and return immediately whether a pending message is available to be read or not.
+The time that a read operation can wait for a message to be written to the mailslot before a time-out occurs.
+
+* A positive value specifies the operation time-out as an absolute system time, represented as a count of 100-nanosecond intervals since January 1, 1601.
+* A negative value specifies the number of 100-nanosecond intervals for the operation to time out relative to the current time.
+* A value of -1 requests that the read wait forever for a message without timing out.
+* A value of 0 requests that the read not wait and return immediately, whether a pending message is available to be read or not.
 
 ## -remarks
 


### PR DESCRIPTION
Code references:

* https://github.com/wine-mirror/wine/blob/b9f5aa42b1532a80963583cabeaeec2a4b479d9f/dlls/kernel32/sync.c#L746
* https://github.com/wine-mirror/wine/blob/b9f5aa42b1532a80963583cabeaeec2a4b479d9f/dlls/kernel32/sync.c#L773

Documentation reference:
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/d3259c2b-b841-40af-9deb-b51edb0f1ef5

By the way, I believe this documentation is incorrect as well and needs a similar fix:
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/701a8cf4-99f8-4613-b2f8-3cdab1d568f2