### PR TITLE
Update remarks for IddCxCheckOsFeatureSupport

### DIFF
--- a/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxcheckosfeaturesupport.md
+++ b/wdk-ddi-src/content/iddcx/nf-iddcx-iddcxcheckosfeaturesupport.md
@@ -58,6 +58,9 @@ The method returns STATUS_SUCCESS if the operation succeeds, otherwise an approp
 
 ## -remarks
 
+> [!IMPORTANT]
+> This function MUST be called before any adapters are created, in other words, before any calls to IddCxAdapterInitAsync.
+
 Once a driver has confirmed it's running on an OS that supports IddCx 1.11 or later by checking the value returned by [**IddCxGetVersion**](nf-iddcx-iddcxgetversion.md), it must call **IddCxCheckOsFeatureSupport** to check which specific features are supported from each 1.11 and later IddCx version. The flags in **[IDARG_OUT_FEATURES_SUPPORTED](ns-iddcx-idarg_out_features_supported.md)::Features_1_11** tell the driver which of the IddCx 1.11 features are available.
 
 **IddCxCheckOsFeatureSupport** isn't intended to be a replacement for [**IddCxGetVersion**](nf-iddcx-iddcxgetversion.md). Drivers should use both to determine the OS capabilities. As a general rule when new features are added, typically requiring DDI updates, the IddCx version changes and new fields are added to **IDARG_OUT_FEATURES_SUPPORTED** and a call to **IddCxCheckOsFeatureSupport** indicates which features are supported. If OS updates such as bugfixes are made that don't need a DDI update, then only the value returned by **IddCxGetVersion** is updated.


### PR DESCRIPTION
Clarified the importance of calling IddCxCheckOsFeatureSupport before adapter creation and explained its role alongside IddCxGetVersion.