### PR TITLE
Update FwpsQueryConnectionSioFormatRedirectRecords0 with SAL annotations and new return value

### DIFF
--- a/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsqueryconnectionsioformatredirectrecords0.md
+++ b/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsqueryconnectionsioformatredirectrecords0.md
@@ -58,7 +58,7 @@ The redirect records handle that the  ALE_CONNECT_REDIRECT callout function rece
 
 A WFP redirect record is a buffer of opaque data that WFP must set on an outbound proxy connection so that the redirected connection and the original connection are logically related.
 
-### -param OutputBuffer [_Out_writes_bytes_opt_(outputBufferLength)]
+### -param OutputBuffer [_Out_writes_bytes_opt_(OutputBufferLength)]
 
 
 A pointer to an output buffer that receives the redirect records. The buffer must be pointer-aligned.
@@ -111,7 +111,7 @@ The <i>RedirectRecords</i> parameter was null.
 </dl>
 </td>
 <td width="60%">
-The <i>bytesTransferred</i> parameter was null.
+The <i>BytesTransferred</i> parameter was null.
 
 </td>
 </tr>

--- a/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsqueryconnectionsioformatredirectrecords0.md
+++ b/wdk-ddi-src/content/fwpsk/nf-fwpsk-fwpsqueryconnectionsioformatredirectrecords0.md
@@ -51,24 +51,24 @@ The <b>FwpsQueryConnectionSioFormatRedirectRecords0</b> function returns the con
 
 ## -parameters
 
-### -param RedirectRecords [in]
+### -param RedirectRecords [_In_]
 
 
 The redirect records handle that the  ALE_CONNECT_REDIRECT callout function received in the  <i>inMetaValues</i> parameter of its <a href="/windows-hardware/drivers/ddi/_netvista/">classifyFn</a> function. This handle can be found in the <b>redirectRecords</b>   member of the <a href="/windows-hardware/drivers/ddi/fwpsk/ns-fwpsk-fwps_incoming_metadata_values0_">FWPS_INCOMING_METADATA_VALUES0</a> structure.
 
 A WFP redirect record is a buffer of opaque data that WFP must set on an outbound proxy connection so that the redirected connection and the original connection are logically related.
 
-### -param OutputBuffer [out, optional]
+### -param OutputBuffer [_Out_writes_bytes_opt_(outputBufferLength)]
 
 
 A pointer to an output buffer that receives the redirect records. The buffer must be pointer-aligned.
 
-### -param OutputBufferLength [in]
+### -param OutputBufferLength [_In_]
 
 
 The size, in bytes, of the output buffer.
 
-### -param BytesTransferred [out, optional]
+### -param BytesTransferred [_Out_]
 
 
 A pointer to a variable that receives the number of bytes that were transferred. If the return value is <b>STATUS_BUFFER_TOO_SMALL</b>, this parameter receives the required buffer size.
@@ -101,6 +101,17 @@ The output buffer was too small to contain all of the bytes to be transferred. T
 </td>
 <td width="60%">
 The <i>RedirectRecords</i> parameter was null.
+
+</td>
+</tr>
+<tr>
+<td width="40%">
+<dl>
+<dt><b>STATUS_INVALID_PARAMETER</b></dt>
+</dl>
+</td>
+<td width="60%">
+The <i>bytesTransferred</i> parameter was null.
 
 </td>
 </tr>


### PR DESCRIPTION
This PR updates the `FwpsQueryConnectionSioFormatRedirectRecords0` documentation with two changes:

1. **SAL annotations** — Replaced bracket-style parameter annotations (`[in]`, `[out, optional]`) with SAL annotations (`_In_`, `_Out_writes_bytes_opt_`, `_Out_`).
2. **New return value** — Added `STATUS_INVALID_PARAMETER` return value entry for when the `bytesTransferred` parameter is null.