### PR TITLE
Add wdm.h DDI docs for GetRuntimeAttestationReport structures

### DIFF
--- a/wdk-ddi-src/content/wdm/ne-wdm-runtime_report_type.md
+++ b/wdk-ddi-src/content/wdm/ne-wdm-runtime_report_type.md
@@ -1,0 +1,83 @@
+---
+UID: NE:wdm._RUNTIME_REPORT_TYPE
+title: _RUNTIME_REPORT_TYPE (wdm.h)
+description: Specifies the type of runtime report contained in a runtime report package.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["RUNTIME_REPORT_TYPE enumeration"]
+ms.keywords: "RUNTIME_REPORT_TYPE, RUNTIME_REPORT_TYPE enumeration [Kernel-Mode Driver Architecture], RuntimeReportTypeCodeIntegrity, RuntimeReportTypeDriver, RuntimeReportTypeHotpatch, RuntimeReportTypeMax, _RUNTIME_REPORT_TYPE, kernel.runtime_report_type, wdm/RUNTIME_REPORT_TYPE"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: RUNTIME_REPORT_TYPE
+f1_keywords:
+ - _RUNTIME_REPORT_TYPE
+ - wdm/_RUNTIME_REPORT_TYPE
+ - RUNTIME_REPORT_TYPE
+ - wdm/RUNTIME_REPORT_TYPE
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _RUNTIME_REPORT_TYPE
+ - RUNTIME_REPORT_TYPE
+---
+
+# _RUNTIME_REPORT_TYPE enumeration
+
+
+## -description
+
+The <b>RUNTIME_REPORT_TYPE</b> enumeration specifies the type of runtime report contained in a runtime report package.
+
+## -enum-fields
+
+### -field RuntimeReportTypeDriver:0
+
+The report is a driver runtime report.
+
+### -field RuntimeReportTypeCodeIntegrity:1
+
+The report is a code integrity runtime report.
+
+### -field RuntimeReportTypeHotpatch:2
+
+The report is a hotpatch runtime report.
+
+### -field RuntimeReportTypeMax:3
+
+Marks the count of defined report types. This is a sentinel value and does not identify a real report type.
+
+## -remarks
+
+Use the <b>RUNTIME_REPORT_TYPE_TO_MASK</b> macro to convert an enumeration value to a bitmap mask. The <b>RUNTIME_REPORT_TYPE_MASK_ALL</b> macro produces a bitmap mask that contains all valid report types.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_package_header">RUNTIME_REPORT_PACKAGE_HEADER</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+<a href="/windows/win32/api/winnt/ne-winnt-runtime_report_type">RUNTIME_REPORT_TYPE (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_report_generation_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_report_generation_header.md
@@ -1,0 +1,79 @@
+---
+UID: NS:wdm._CODE_INTEGRITY_REPORT_GENERATION_HEADER
+title: _CODE_INTEGRITY_REPORT_GENERATION_HEADER (wdm.h)
+description: Describes a single policy generation within a code integrity runtime report.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["CODE_INTEGRITY_REPORT_GENERATION_HEADER structure"]
+ms.keywords: "CODE_INTEGRITY_REPORT_GENERATION_HEADER, CODE_INTEGRITY_REPORT_GENERATION_HEADER structure [Kernel-Mode Driver Architecture], _CODE_INTEGRITY_REPORT_GENERATION_HEADER, kernel.code_integrity_report_generation_header, wdm/CODE_INTEGRITY_REPORT_GENERATION_HEADER"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: CODE_INTEGRITY_REPORT_GENERATION_HEADER
+f1_keywords:
+ - _CODE_INTEGRITY_REPORT_GENERATION_HEADER
+ - wdm/_CODE_INTEGRITY_REPORT_GENERATION_HEADER
+ - CODE_INTEGRITY_REPORT_GENERATION_HEADER
+ - wdm/CODE_INTEGRITY_REPORT_GENERATION_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _CODE_INTEGRITY_REPORT_GENERATION_HEADER
+ - CODE_INTEGRITY_REPORT_GENERATION_HEADER
+---
+
+# _CODE_INTEGRITY_REPORT_GENERATION_HEADER structure
+
+
+## -description
+
+The <b>CODE_INTEGRITY_REPORT_GENERATION_HEADER</b> structure describes a single policy generation within a code integrity runtime report.
+
+## -struct-fields
+
+### -field Version
+
+Version of this structure.
+
+### -field Reserved
+
+Reserved field.
+
+### -field RecordSize
+
+The number of bytes consumed by this generation, including this header and all <b>CODE_INTEGRITY_REPORT_RECORD_HEADER</b> structures and payloads.
+
+### -field CommitTime
+
+Secure Kernel / Hypervisor secure time reference when this policy was committed.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_runtime_report">CODE_INTEGRITY_RUNTIME_REPORT</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_record_header">CODE_INTEGRITY_REPORT_RECORD_HEADER</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-code_integrity_report_generation_header">CODE_INTEGRITY_REPORT_GENERATION_HEADER (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_report_record_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_report_record_header.md
@@ -1,0 +1,79 @@
+---
+UID: NS:wdm._CODE_INTEGRITY_REPORT_RECORD_HEADER
+title: _CODE_INTEGRITY_REPORT_RECORD_HEADER (wdm.h)
+description: Describes a single record within a code integrity report generation.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["CODE_INTEGRITY_REPORT_RECORD_HEADER structure"]
+ms.keywords: "CODE_INTEGRITY_REPORT_RECORD_HEADER, CODE_INTEGRITY_REPORT_RECORD_HEADER structure [Kernel-Mode Driver Architecture], _CODE_INTEGRITY_REPORT_RECORD_HEADER, kernel.code_integrity_report_record_header, wdm/CODE_INTEGRITY_REPORT_RECORD_HEADER"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: CODE_INTEGRITY_REPORT_RECORD_HEADER
+f1_keywords:
+ - _CODE_INTEGRITY_REPORT_RECORD_HEADER
+ - wdm/_CODE_INTEGRITY_REPORT_RECORD_HEADER
+ - CODE_INTEGRITY_REPORT_RECORD_HEADER
+ - wdm/CODE_INTEGRITY_REPORT_RECORD_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _CODE_INTEGRITY_REPORT_RECORD_HEADER
+ - CODE_INTEGRITY_REPORT_RECORD_HEADER
+---
+
+# _CODE_INTEGRITY_REPORT_RECORD_HEADER structure
+
+
+## -description
+
+The <b>CODE_INTEGRITY_REPORT_RECORD_HEADER</b> structure describes a single record within a code integrity report generation.
+
+## -struct-fields
+
+### -field Version
+
+Version of this structure.
+
+### -field Reserved
+
+Reserved field.
+
+### -field RecordSize
+
+The number of bytes consumed by this record, including this header.
+
+### -field SipaEventCode
+
+The event code (type) of this record. The same codes as the Measured Boot TCG Log are used, for example <b>SIPAEVENT_OS_REVOCATION_LIST</b>, and indicate the structure type of the payload that immediately follows this header.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_runtime_report">CODE_INTEGRITY_RUNTIME_REPORT</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_generation_header">CODE_INTEGRITY_REPORT_GENERATION_HEADER</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-code_integrity_report_record_header">CODE_INTEGRITY_REPORT_RECORD_HEADER (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_runtime_report.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_runtime_report.md
@@ -1,0 +1,77 @@
+---
+UID: NS:wdm._CODE_INTEGRITY_RUNTIME_REPORT
+title: _CODE_INTEGRITY_RUNTIME_REPORT (wdm.h)
+description: Contains a runtime report describing the code integrity state of the system.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["CODE_INTEGRITY_RUNTIME_REPORT structure"]
+ms.keywords: "CODE_INTEGRITY_RUNTIME_REPORT, CODE_INTEGRITY_RUNTIME_REPORT structure [Kernel-Mode Driver Architecture], _CODE_INTEGRITY_RUNTIME_REPORT, kernel.code_integrity_runtime_report, wdm/CODE_INTEGRITY_RUNTIME_REPORT"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: CODE_INTEGRITY_RUNTIME_REPORT
+f1_keywords:
+ - _CODE_INTEGRITY_RUNTIME_REPORT
+ - wdm/_CODE_INTEGRITY_RUNTIME_REPORT
+ - CODE_INTEGRITY_RUNTIME_REPORT
+ - wdm/CODE_INTEGRITY_RUNTIME_REPORT
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _CODE_INTEGRITY_RUNTIME_REPORT
+ - CODE_INTEGRITY_RUNTIME_REPORT
+---
+
+# _CODE_INTEGRITY_RUNTIME_REPORT structure
+
+
+## -description
+
+The <b>CODE_INTEGRITY_RUNTIME_REPORT</b> structure contains a runtime report describing the code integrity state of the system.
+
+## -struct-fields
+
+### -field Header
+
+The Code Integrity runtime report header.
+
+### -field CurrentGeneration
+
+The number of generations (updates) of policy there have been since boot. The initial generation at boot is 1.
+
+### -field NumberOfGenerations
+
+The number of generations of policy that are in this report. This is non-zero, with the current generation reported first, followed by prior generations in order of ascending age.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_generation_header">CODE_INTEGRITY_REPORT_GENERATION_HEADER</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_record_header">CODE_INTEGRITY_REPORT_RECORD_HEADER</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-code_integrity_runtime_report">CODE_INTEGRITY_RUNTIME_REPORT (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-driver_info_entry.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-driver_info_entry.md
@@ -1,0 +1,126 @@
+---
+UID: NS:wdm._DRIVER_INFO_ENTRY
+title: _DRIVER_INFO_ENTRY (wdm.h)
+description: Describes a single driver image in a driver runtime report.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["DRIVER_INFO_ENTRY structure"]
+ms.keywords: "*PDRIVER_INFO_ENTRY, DRIVER_INFO_ENTRY, DRIVER_INFO_ENTRY structure [Kernel-Mode Driver Architecture], PDRIVER_INFO_ENTRY, _DRIVER_INFO_ENTRY, kernel.driver_info_entry, wdm/DRIVER_INFO_ENTRY, wdm/PDRIVER_INFO_ENTRY"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: DRIVER_INFO_ENTRY, *PDRIVER_INFO_ENTRY
+f1_keywords:
+ - _DRIVER_INFO_ENTRY
+ - wdm/_DRIVER_INFO_ENTRY
+ - PDRIVER_INFO_ENTRY
+ - wdm/PDRIVER_INFO_ENTRY
+ - DRIVER_INFO_ENTRY
+ - wdm/DRIVER_INFO_ENTRY
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _DRIVER_INFO_ENTRY
+ - PDRIVER_INFO_ENTRY
+ - DRIVER_INFO_ENTRY
+---
+
+# _DRIVER_INFO_ENTRY structure
+
+
+## -description
+
+The <b>DRIVER_INFO_ENTRY</b> structure describes a single driver image in a driver runtime report.
+
+## -struct-fields
+
+### -field InternalName
+
+Internal name of the driver from the resource section. This field is <b>DRIVER_REPORT_NAME_MAX_LENGTH</b> (32) characters.
+
+### -field ImageHashAlgorithm
+
+Hash algorithm used to calculate the image digest.
+
+### -field PublisherThumbprintHashAlgorithm
+
+Hash algorithm used to calculate the thumbprint of the leaf certificate that validates the entire image.
+
+### -field ImageHashOffset
+
+Offset from the start of the driver report to a buffer containing the digest of the driver image on disk.
+
+### -field PublisherThumbprintOffset
+
+Offset from the start of the driver report to a buffer containing the thumbprint of the leaf certificate validating the entire image.
+
+### -field LoadCount
+
+Number of times that this driver image has been loaded into the system.
+
+### -field OemNameSize
+
+Size of a string indicating the OEM name stored in the authenticated OPUS block of the image digital signature. There is no OEM name for inbox Windows-signed drivers. The size does *not* include the NULL terminator (even though the string is NULL-terminated).
+
+### -field OemNameOffset
+
+Offset of a string indicating the OEM name stored in the authenticated OPUS block of the image digital signature.
+
+### -field Flags
+
+Flags indicating various properties of the current driver image.
+
+### -field Flags.Unloaded
+
+Set to 1 in case the driver is currently unloaded.
+
+### -field Flags.BootDriver
+
+Set to 1 in case the image is a boot driver; 0 otherwise (the image is a runtime driver).
+
+### -field Flags.HotPatch
+
+Set to 1 in case the image can be also loaded as a hotpatch.
+
+### -field Flags.Reserved
+
+Reserved flags bits.
+
+### -field Flags.AsUInt16
+
+The flags as a single 16-bit value.
+
+### -field Padding
+
+Padding field.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-driver_runtime_report">DRIVER_RUNTIME_REPORT</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-driver_info_entry">DRIVER_INFO_ENTRY (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-driver_runtime_report.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-driver_runtime_report.md
@@ -1,0 +1,106 @@
+---
+UID: NS:wdm._DRIVER_RUNTIME_REPORT
+title: _DRIVER_RUNTIME_REPORT (wdm.h)
+description: Contains a runtime report describing the drivers loaded on the system.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["DRIVER_RUNTIME_REPORT structure"]
+ms.keywords: "*PDRIVER_RUNTIME_REPORT, DRIVER_RUNTIME_REPORT, DRIVER_RUNTIME_REPORT structure [Kernel-Mode Driver Architecture], PDRIVER_RUNTIME_REPORT, _DRIVER_RUNTIME_REPORT, kernel.driver_runtime_report, wdm/DRIVER_RUNTIME_REPORT, wdm/PDRIVER_RUNTIME_REPORT"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: DRIVER_RUNTIME_REPORT, *PDRIVER_RUNTIME_REPORT
+f1_keywords:
+ - _DRIVER_RUNTIME_REPORT
+ - wdm/_DRIVER_RUNTIME_REPORT
+ - PDRIVER_RUNTIME_REPORT
+ - wdm/PDRIVER_RUNTIME_REPORT
+ - DRIVER_RUNTIME_REPORT
+ - wdm/DRIVER_RUNTIME_REPORT
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _DRIVER_RUNTIME_REPORT
+ - PDRIVER_RUNTIME_REPORT
+ - DRIVER_RUNTIME_REPORT
+---
+
+# _DRIVER_RUNTIME_REPORT structure
+
+
+## -description
+
+The <b>DRIVER_RUNTIME_REPORT</b> structure contains a runtime report describing the drivers loaded on the system.
+
+## -struct-fields
+
+### -field Header
+
+The driver runtime report header.
+
+### -field NumberOfDrivers
+
+The current number of unique drivers in the report.
+
+### -field Flags
+
+Flags indicating various properties of the report.
+
+### -field Flags.ReportOverflowed
+
+Secure Kernel places a limit on the number of drivers it can list in the report. If this is set, it indicates that some loaded drivers might be missing from the report.
+
+### -field Flags.PartialReport
+
+Indicates whether the report contains only a subset of NT loaded drivers.
+
+### -field Flags.IncludeBootDrivers
+
+Set to 1 in case the report includes boot-loaded drivers; 0 otherwise (in that case the information is stored in the TCG Log).
+
+### -field Flags.Reserved
+
+Reserved flags bits.
+
+### -field Flags.AsUInt16
+
+The flags as a single 16-bit value.
+
+### -field DriverEntries
+
+A list, of size zero up to the maximum number of drivers recorded, containing driver entries. Unloaded drivers are not removed from the list.
+
+## -remarks
+
+After the <b>DriverEntries</b> array, the driver runtime report stores hashes, strings, and information that are dynamic in size. This dynamic buffer, for each driver, is composed of the image hash, the publisher hash, and the OEM name.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-driver_info_entry">DRIVER_INFO_ENTRY</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-driver_runtime_report">DRIVER_RUNTIME_REPORT (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-hotpatch_info_entry.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-hotpatch_info_entry.md
@@ -1,0 +1,88 @@
+---
+UID: NS:wdm._HOTPATCH_INFO_ENTRY
+title: _HOTPATCH_INFO_ENTRY (wdm.h)
+description: Describes a single hotpatched base image in a hotpatch runtime report.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["HOTPATCH_INFO_ENTRY structure"]
+ms.keywords: "*PHOTPATCH_INFO_ENTRY, HOTPATCH_INFO_ENTRY, HOTPATCH_INFO_ENTRY structure [Kernel-Mode Driver Architecture], PHOTPATCH_INFO_ENTRY, _HOTPATCH_INFO_ENTRY, kernel.hotpatch_info_entry, wdm/HOTPATCH_INFO_ENTRY, wdm/PHOTPATCH_INFO_ENTRY"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: HOTPATCH_INFO_ENTRY, *PHOTPATCH_INFO_ENTRY
+f1_keywords:
+ - _HOTPATCH_INFO_ENTRY
+ - wdm/_HOTPATCH_INFO_ENTRY
+ - PHOTPATCH_INFO_ENTRY
+ - wdm/PHOTPATCH_INFO_ENTRY
+ - HOTPATCH_INFO_ENTRY
+ - wdm/HOTPATCH_INFO_ENTRY
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _HOTPATCH_INFO_ENTRY
+ - PHOTPATCH_INFO_ENTRY
+ - HOTPATCH_INFO_ENTRY
+---
+
+# _HOTPATCH_INFO_ENTRY structure
+
+
+## -description
+
+The <b>HOTPATCH_INFO_ENTRY</b> structure describes a single hotpatched base image in a hotpatch runtime report.
+
+## -struct-fields
+
+### -field BaseCheckSum
+
+PE identity of the base image that was hotpatched.
+
+### -field BaseTimeDateStamp
+
+PE identity of the base image that was hotpatched.
+
+### -field BaseAddress
+
+VTL0 load address of the base image.
+
+### -field ImageSize
+
+Size of the base image.
+
+### -field LatestSequenceNumber
+
+Highest patch sequence number successfully applied.
+
+### -field BaseImageName
+
+Short name of the base image (for example, "ntoskrnl.exe"), UTF-8 string stored inline. Truncated to (<b>HOTPATCH_REPORT_NAME_MAX_LENGTH</b> - 1) characters if necessary to ensure NULL termination. This field is informational - the authoritative identity is (<b>BaseCheckSum</b>, <b>BaseTimeDateStamp</b>).
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-hotpatch_runtime_report">HOTPATCH_RUNTIME_REPORT</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-hotpatch_info_entry">HOTPATCH_INFO_ENTRY (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-hotpatch_runtime_report.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-hotpatch_runtime_report.md
@@ -1,0 +1,90 @@
+---
+UID: NS:wdm._HOTPATCH_RUNTIME_REPORT
+title: _HOTPATCH_RUNTIME_REPORT (wdm.h)
+description: Contains a runtime report describing the hotpatched base images on the system.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["HOTPATCH_RUNTIME_REPORT structure"]
+ms.keywords: "*PHOTPATCH_RUNTIME_REPORT, HOTPATCH_RUNTIME_REPORT, HOTPATCH_RUNTIME_REPORT structure [Kernel-Mode Driver Architecture], PHOTPATCH_RUNTIME_REPORT, _HOTPATCH_RUNTIME_REPORT, kernel.hotpatch_runtime_report, wdm/HOTPATCH_RUNTIME_REPORT, wdm/PHOTPATCH_RUNTIME_REPORT"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: HOTPATCH_RUNTIME_REPORT, *PHOTPATCH_RUNTIME_REPORT
+f1_keywords:
+ - _HOTPATCH_RUNTIME_REPORT
+ - wdm/_HOTPATCH_RUNTIME_REPORT
+ - PHOTPATCH_RUNTIME_REPORT
+ - wdm/PHOTPATCH_RUNTIME_REPORT
+ - HOTPATCH_RUNTIME_REPORT
+ - wdm/HOTPATCH_RUNTIME_REPORT
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _HOTPATCH_RUNTIME_REPORT
+ - PHOTPATCH_RUNTIME_REPORT
+ - HOTPATCH_RUNTIME_REPORT
+---
+
+# _HOTPATCH_RUNTIME_REPORT structure
+
+
+## -description
+
+The <b>HOTPATCH_RUNTIME_REPORT</b> structure contains a runtime report describing the hotpatched base images on the system.
+
+## -struct-fields
+
+### -field Header
+
+Standard runtime report header.
+
+### -field NumberOfEntries
+
+Number of hotpatched base images in this report.
+
+### -field Reserved1
+
+Reserved for future use.
+
+### -field Reserved2
+
+Reserved for future use; also provides explicit padding for 8-byte alignment of the <b>Entries</b> array.
+
+### -field Entries
+
+Variable-length array of hotpatch entries.
+
+## -remarks
+
+The <b>Entries</b> array is a variable-length array that immediately follows the fixed portion of the structure. It contains <b>NumberOfEntries</b> <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-hotpatch_info_entry">HOTPATCH_INFO_ENTRY</a> structures.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-hotpatch_info_entry">HOTPATCH_INFO_ENTRY</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-hotpatch_runtime_report">HOTPATCH_RUNTIME_REPORT (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_digest_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_digest_header.md
@@ -1,0 +1,80 @@
+---
+UID: NS:wdm._RUNTIME_REPORT_DIGEST_HEADER
+title: _RUNTIME_REPORT_DIGEST_HEADER (wdm.h)
+description: Describes the digest of a runtime report within a runtime report package.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["RUNTIME_REPORT_DIGEST_HEADER structure"]
+ms.keywords: "*PRUNTIME_REPORT_DIGEST_HEADER, RUNTIME_REPORT_DIGEST_HEADER, RUNTIME_REPORT_DIGEST_HEADER structure [Kernel-Mode Driver Architecture], PRUNTIME_REPORT_DIGEST_HEADER, _RUNTIME_REPORT_DIGEST_HEADER, kernel.runtime_report_digest_header, wdm/RUNTIME_REPORT_DIGEST_HEADER, wdm/PRUNTIME_REPORT_DIGEST_HEADER"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: RUNTIME_REPORT_DIGEST_HEADER, *PRUNTIME_REPORT_DIGEST_HEADER
+f1_keywords:
+ - _RUNTIME_REPORT_DIGEST_HEADER
+ - wdm/_RUNTIME_REPORT_DIGEST_HEADER
+ - PRUNTIME_REPORT_DIGEST_HEADER
+ - wdm/PRUNTIME_REPORT_DIGEST_HEADER
+ - RUNTIME_REPORT_DIGEST_HEADER
+ - wdm/RUNTIME_REPORT_DIGEST_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _RUNTIME_REPORT_DIGEST_HEADER
+ - PRUNTIME_REPORT_DIGEST_HEADER
+ - RUNTIME_REPORT_DIGEST_HEADER
+---
+
+# _RUNTIME_REPORT_DIGEST_HEADER structure
+
+
+## -description
+
+The <b>RUNTIME_REPORT_DIGEST_HEADER</b> structure contains the digest of a runtime report within a runtime report package.
+
+## -struct-fields
+
+### -field ReportType
+
+Indicates the type of report that was hashed. The current valid values are <b>RuntimeReportTypeDriver</b> (0), <b>RuntimeReportTypeCodeIntegrity</b> (1), and <b>RuntimeReportTypeHotpatch</b> (2).
+
+### -field Reserved
+
+Reserved field.
+
+### -field ReportDigest
+
+Digest of the report, including the report header. This is a SHA-512 digest. The buffer is <b>RUNTIME_REPORT_DIGEST_MAX_SIZE</b> (64) bytes.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_package_header">RUNTIME_REPORT_PACKAGE_HEADER</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-runtime_report_type">RUNTIME_REPORT_TYPE</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-runtime_report_digest_header">RUNTIME_REPORT_DIGEST_HEADER (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_header.md
@@ -1,0 +1,80 @@
+---
+UID: NS:wdm._RUNTIME_REPORT_HEADER
+title: _RUNTIME_REPORT_HEADER (wdm.h)
+description: Describes the header of an individual runtime report.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["RUNTIME_REPORT_HEADER structure"]
+ms.keywords: "*PRUNTIME_REPORT_HEADER, RUNTIME_REPORT_HEADER, RUNTIME_REPORT_HEADER structure [Kernel-Mode Driver Architecture], PRUNTIME_REPORT_HEADER, _RUNTIME_REPORT_HEADER, kernel.runtime_report_header, wdm/RUNTIME_REPORT_HEADER, wdm/PRUNTIME_REPORT_HEADER"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: RUNTIME_REPORT_HEADER, *PRUNTIME_REPORT_HEADER
+f1_keywords:
+ - _RUNTIME_REPORT_HEADER
+ - wdm/_RUNTIME_REPORT_HEADER
+ - PRUNTIME_REPORT_HEADER
+ - wdm/PRUNTIME_REPORT_HEADER
+ - RUNTIME_REPORT_HEADER
+ - wdm/RUNTIME_REPORT_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _RUNTIME_REPORT_HEADER
+ - PRUNTIME_REPORT_HEADER
+ - RUNTIME_REPORT_HEADER
+---
+
+# _RUNTIME_REPORT_HEADER structure
+
+
+## -description
+
+The <b>RUNTIME_REPORT_HEADER</b> structure describes the header of an individual runtime report within a runtime report package.
+
+## -struct-fields
+
+### -field ReportType
+
+Indicates the type of report. The current valid values are <b>RuntimeReportTypeDriver</b> (0), <b>RuntimeReportTypeCodeIntegrity</b> (1), and <b>RuntimeReportTypeHotpatch</b> (2).
+
+### -field Reserved
+
+Reserved field.
+
+### -field ReportSize
+
+The number of bytes consumed by this report, including the header.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_package_header">RUNTIME_REPORT_PACKAGE_HEADER</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-runtime_report_type">RUNTIME_REPORT_TYPE</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-driver_runtime_report">DRIVER_RUNTIME_REPORT</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-runtime_report_header">RUNTIME_REPORT_HEADER (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_package_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_package_header.md
@@ -1,0 +1,145 @@
+---
+UID: NS:wdm._RUNTIME_REPORT_PACKAGE_HEADER
+title: _RUNTIME_REPORT_PACKAGE_HEADER (wdm.h)
+description: Describes the header of a runtime report package.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["RUNTIME_REPORT_PACKAGE_HEADER structure"]
+ms.keywords: "*PRUNTIME_REPORT_PACKAGE_HEADER, RUNTIME_REPORT_PACKAGE_HEADER, RUNTIME_REPORT_PACKAGE_HEADER structure [Kernel-Mode Driver Architecture], PRUNTIME_REPORT_PACKAGE_HEADER, _RUNTIME_REPORT_PACKAGE_HEADER, kernel.runtime_report_package_header, wdm/RUNTIME_REPORT_PACKAGE_HEADER, wdm/PRUNTIME_REPORT_PACKAGE_HEADER"
+req.header: wdm.h
+req.include-header: Wdm.h
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: RUNTIME_REPORT_PACKAGE_HEADER, *PRUNTIME_REPORT_PACKAGE_HEADER
+f1_keywords:
+ - _RUNTIME_REPORT_PACKAGE_HEADER
+ - wdm/_RUNTIME_REPORT_PACKAGE_HEADER
+ - PRUNTIME_REPORT_PACKAGE_HEADER
+ - wdm/PRUNTIME_REPORT_PACKAGE_HEADER
+ - RUNTIME_REPORT_PACKAGE_HEADER
+ - wdm/RUNTIME_REPORT_PACKAGE_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _RUNTIME_REPORT_PACKAGE_HEADER
+ - PRUNTIME_REPORT_PACKAGE_HEADER
+ - RUNTIME_REPORT_PACKAGE_HEADER
+---
+
+# _RUNTIME_REPORT_PACKAGE_HEADER structure
+
+
+## -description
+
+The <b>RUNTIME_REPORT_PACKAGE_HEADER</b> structure describes the header of a runtime report package.
+
+## -struct-fields
+
+### -field Magic
+
+Set to <b>RUNTIME_REPORT_PACKAGE_MAGIC</b> = 0x52545250 ("RTRP").
+
+### -field PackageVersion
+
+The version of the package format.
+
+### -field NumberOfReports
+
+Number of different report types contained in the package.
+
+### -field ReportTypesBitmap
+
+A bitmap of all the report types in the package. Use the <b>RUNTIME_REPORT_TYPE_TO_MASK</b> macro to convert enumeration values to bitmap masks. The current valid report types are <b>RuntimeReportTypeDriver</b> (0), <b>RuntimeReportTypeCodeIntegrity</b> (1), and <b>RuntimeReportTypeHotpatch</b> (2).
+
+### -field PackageSize
+
+The size of the total package, including the package header, the various runtime reports, their digests, and the signature blob.
+
+### -field ReportDigestType
+
+The type of digest contained in the report digest headers. The current valid value is <b>CALG_SHA_512</b> (see wincrypt.h).
+
+### -field TotalReportDigestsSize
+
+Total size of the signed runtime report digest headers that follow the package header.
+
+### -field Reserved
+
+Reserved field. Must be set to zero.
+
+### -field SignatureScheme
+
+The signature scheme used to sign the runtime reports. The current valid value is <b>RUNTIME_REPORT_SIGNATURE_SCHEME_SHA512_RSA_PSS_SHA512</b> (1).
+
+### -field SignatureSize
+
+Size of the signature blob that follows the runtime report digests.
+
+### -field TotalAuthenticatedReportsSize
+
+Total size of the authenticated (but unsigned) runtime reports that follow the signature blob.
+
+## -remarks
+
+A runtime report package has the following layout:
+
+```
+------------------------------------- Signed part Begin
+
+    RUNTIME_REPORT_PACKAGE_HEADER
+
+    BYTE Nonce[RUNTIME_REPORT_NONCE_SIZE]
+
+    RUNTIME_REPORT_DIGEST_HEADER_A
+
+    RUNTIME_REPORT_DIGEST_HEADER_B
+    ...
+
+------------------------------------- Signed part End
+
+    Signature Blob
+
+------------------------------------- Authenticated part Begin
+
+    RUNTIME_REPORT_HEADER
+    REPORT_A
+
+    RUNTIME_REPORT_HEADER
+    REPORT_B
+
+------------------------------------- Authenticated part End
+```
+
+The nonce that follows the package header is <b>RUNTIME_REPORT_NONCE_SIZE</b> (32) bytes.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_digest_header">RUNTIME_REPORT_DIGEST_HEADER</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+<a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-runtime_report_type">RUNTIME_REPORT_TYPE</a>
+
+<a href="/windows/win32/api/winnt/ns-winnt-runtime_report_package_header">RUNTIME_REPORT_PACKAGE_HEADER (winnt.h)</a>
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>


### PR DESCRIPTION
## Summary

Adds driver-facing DDI reference documentation for the 11 data structures and enumeration used by **GetRuntimeAttestationReport**, as they appear in the **wdm.h** driver header. This is the kernel/driver companion to the Win32 PR that documents the same types under **winnt.h**; field prose matches the app-facing docs in substance, with only header/metadata differing.

All field descriptions are derived faithfully from the source header's inline comments — no invented behavior, values, sizes, or IRQL/usage notes.

## New files (`wdk-ddi-src/content/wdm/`)

| File | Type |
|------|------|
| `ne-wdm-runtime_report_type.md` | enum `RUNTIME_REPORT_TYPE` |
| `ns-wdm-runtime_report_package_header.md` | `RUNTIME_REPORT_PACKAGE_HEADER` |
| `ns-wdm-runtime_report_digest_header.md` | `RUNTIME_REPORT_DIGEST_HEADER` |
| `ns-wdm-runtime_report_header.md` | `RUNTIME_REPORT_HEADER` |
| `ns-wdm-driver_info_entry.md` | `DRIVER_INFO_ENTRY` |
| `ns-wdm-driver_runtime_report.md` | `DRIVER_RUNTIME_REPORT` |
| `ns-wdm-code_integrity_runtime_report.md` | `CODE_INTEGRITY_RUNTIME_REPORT` |
| `ns-wdm-code_integrity_report_generation_header.md` | `CODE_INTEGRITY_REPORT_GENERATION_HEADER` |
| `ns-wdm-code_integrity_report_record_header.md` | `CODE_INTEGRITY_REPORT_RECORD_HEADER` |
| `ns-wdm-hotpatch_info_entry.md` | `HOTPATCH_INFO_ENTRY` |
| `ns-wdm-hotpatch_runtime_report.md` | `HOTPATCH_RUNTIME_REPORT` |

## Notes / for reviewer confirmation

- **`tech.root`** set to `kernel` (mirrors neighboring general kernel `ns-wdm-*` structs).
- **`req.irql`** left blank (no IRQL info in header; these are data-structure definitions).
- **`req.include-header`** set to `Wdm.h` (matches existing samples).
- `RuntimeReportTypeMax` documented as a sentinel/count marker (no explicit value in header, = 3), not a real report type.
- Bitfield `Flags` unions in `DRIVER_INFO_ENTRY` and `DRIVER_RUNTIME_REPORT` documented member-by-member (incl. `AsUInt16`). Variable-length trailing arrays and the per-driver dynamic buffer layout are explained in `## -remarks`.
- Cross-links added to related wdm structures, the Win32 winnt.h counterparts, and `GetRuntimeAttestationReport`.

Draft — do not merge.
