### PR TITLE
Add wdm.h runtime report structure DDI docs (GetRuntimeAttestationReport)

### DIFF
--- a/wdk-ddi-src/content/wdm/ne-wdm-runtime_report_type.md
+++ b/wdk-ddi-src/content/wdm/ne-wdm-runtime_report_type.md
@@ -1,0 +1,93 @@
+---
+UID: NE:wdm._RUNTIME_REPORT_TYPE
+title: _RUNTIME_REPORT_TYPE (wdm.h)
+description: The RUNTIME_REPORT_TYPE enumeration identifies the type of runtime report contained in a runtime report package.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["RUNTIME_REPORT_TYPE enumeration"]
+ms.keywords: "RUNTIME_REPORT_TYPE, RUNTIME_REPORT_TYPE enumeration [Kernel-Mode Driver Architecture], _RUNTIME_REPORT_TYPE, RuntimeReportTypeDriver, RuntimeReportTypeCodeIntegrity, RuntimeReportTypeHotpatch, RuntimeReportTypeMax, wdm/RUNTIME_REPORT_TYPE, wdm/RuntimeReportTypeDriver, wdm/RuntimeReportTypeCodeIntegrity, wdm/RuntimeReportTypeHotpatch, wdm/RuntimeReportTypeMax"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: RUNTIME_REPORT_TYPE
+f1_keywords:
+ - _RUNTIME_REPORT_TYPE
+ - wdm/_RUNTIME_REPORT_TYPE
+ - RUNTIME_REPORT_TYPE
+ - wdm/RUNTIME_REPORT_TYPE
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _RUNTIME_REPORT_TYPE
+ - RUNTIME_REPORT_TYPE
+---
+
+# _RUNTIME_REPORT_TYPE enumeration
+
+
+## -description
+
+The <b>RUNTIME_REPORT_TYPE</b> enumeration identifies the type of runtime report contained in a runtime report package.
+
+## -enum-fields
+
+### -field RuntimeReportTypeDriver:0
+
+A driver runtime report.
+
+### -field RuntimeReportTypeCodeIntegrity:1
+
+A code integrity runtime report.
+
+### -field RuntimeReportTypeHotpatch:2
+
+A hotpatch runtime report.
+
+### -field RuntimeReportTypeMax
+
+Marks the count of defined report types. This enumerator has no explicit value in the header and therefore evaluates to 3. It is not itself a report type; it is used as a sentinel, for example to build a bitmap mask of all valid report types.
+
+## -remarks
+
+Use the <b>RUNTIME_REPORT_TYPE_TO_MASK</b> macro to convert an enumerator value to a bitmap mask. The <b>RUNTIME_REPORT_TYPE_MASK_ALL</b> macro produces a bitmap that contains all valid report types.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_package_header">RUNTIME_REPORT_PACKAGE_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_digest_header">RUNTIME_REPORT_DIGEST_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+
+
+<a href="/windows/win32/api/winnt/ne-winnt-runtime_report_type">RUNTIME_REPORT_TYPE (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_report_generation_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_report_generation_header.md
@@ -1,0 +1,85 @@
+---
+UID: NS:wdm._CODE_INTEGRITY_REPORT_GENERATION_HEADER
+title: _CODE_INTEGRITY_REPORT_GENERATION_HEADER (wdm.h)
+description: The CODE_INTEGRITY_REPORT_GENERATION_HEADER structure is the header of a single policy generation in a code integrity runtime report.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["CODE_INTEGRITY_REPORT_GENERATION_HEADER structure"]
+ms.keywords: "CODE_INTEGRITY_REPORT_GENERATION_HEADER, CODE_INTEGRITY_REPORT_GENERATION_HEADER structure [Kernel-Mode Driver Architecture], _CODE_INTEGRITY_REPORT_GENERATION_HEADER, wdm/CODE_INTEGRITY_REPORT_GENERATION_HEADER"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: CODE_INTEGRITY_REPORT_GENERATION_HEADER
+f1_keywords:
+ - _CODE_INTEGRITY_REPORT_GENERATION_HEADER
+ - wdm/_CODE_INTEGRITY_REPORT_GENERATION_HEADER
+ - CODE_INTEGRITY_REPORT_GENERATION_HEADER
+ - wdm/CODE_INTEGRITY_REPORT_GENERATION_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _CODE_INTEGRITY_REPORT_GENERATION_HEADER
+ - CODE_INTEGRITY_REPORT_GENERATION_HEADER
+---
+
+# _CODE_INTEGRITY_REPORT_GENERATION_HEADER structure
+
+
+## -description
+
+The <b>CODE_INTEGRITY_REPORT_GENERATION_HEADER</b> structure is the header of a single policy generation in a <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_runtime_report">CODE_INTEGRITY_RUNTIME_REPORT</a>.
+
+## -struct-fields
+
+### -field Version
+
+Version of this structure.
+
+### -field Reserved
+
+Reserved field.
+
+### -field RecordSize
+
+The number of bytes consumed by this generation, including this header and all <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_record_header">CODE_INTEGRITY_REPORT_RECORD_HEADER</a> structures and payloads.
+
+### -field CommitTime
+
+Secure Kernel / Hypervisor secure time reference when this policy was committed.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_runtime_report">CODE_INTEGRITY_RUNTIME_REPORT</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_record_header">CODE_INTEGRITY_REPORT_RECORD_HEADER</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-code_integrity_report_generation_header">CODE_INTEGRITY_REPORT_GENERATION_HEADER (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_report_record_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_report_record_header.md
@@ -1,0 +1,85 @@
+---
+UID: NS:wdm._CODE_INTEGRITY_REPORT_RECORD_HEADER
+title: _CODE_INTEGRITY_REPORT_RECORD_HEADER (wdm.h)
+description: The CODE_INTEGRITY_REPORT_RECORD_HEADER structure is the header of a single record within a code integrity report generation.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["CODE_INTEGRITY_REPORT_RECORD_HEADER structure"]
+ms.keywords: "CODE_INTEGRITY_REPORT_RECORD_HEADER, CODE_INTEGRITY_REPORT_RECORD_HEADER structure [Kernel-Mode Driver Architecture], _CODE_INTEGRITY_REPORT_RECORD_HEADER, wdm/CODE_INTEGRITY_REPORT_RECORD_HEADER"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: CODE_INTEGRITY_REPORT_RECORD_HEADER
+f1_keywords:
+ - _CODE_INTEGRITY_REPORT_RECORD_HEADER
+ - wdm/_CODE_INTEGRITY_REPORT_RECORD_HEADER
+ - CODE_INTEGRITY_REPORT_RECORD_HEADER
+ - wdm/CODE_INTEGRITY_REPORT_RECORD_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _CODE_INTEGRITY_REPORT_RECORD_HEADER
+ - CODE_INTEGRITY_REPORT_RECORD_HEADER
+---
+
+# _CODE_INTEGRITY_REPORT_RECORD_HEADER structure
+
+
+## -description
+
+The <b>CODE_INTEGRITY_REPORT_RECORD_HEADER</b> structure is the header of a single record within a code integrity report generation. The record header is immediately followed by a payload whose structure type is indicated by <b>SipaEventCode</b>.
+
+## -struct-fields
+
+### -field Version
+
+Version of this structure.
+
+### -field Reserved
+
+Reserved field.
+
+### -field RecordSize
+
+The number of bytes consumed by this record, including this header.
+
+### -field SipaEventCode
+
+The event code (type) of this record. The same codes as the Measured Boot TCG Log are used, for example SIPAEVENT_OS_REVOCATION_LIST, and indicate the structure type of the payload that immediately follows this header.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_generation_header">CODE_INTEGRITY_REPORT_GENERATION_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_runtime_report">CODE_INTEGRITY_RUNTIME_REPORT</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-code_integrity_report_record_header">CODE_INTEGRITY_REPORT_RECORD_HEADER (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_runtime_report.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-code_integrity_runtime_report.md
@@ -1,0 +1,89 @@
+---
+UID: NS:wdm._CODE_INTEGRITY_RUNTIME_REPORT
+title: _CODE_INTEGRITY_RUNTIME_REPORT (wdm.h)
+description: The CODE_INTEGRITY_RUNTIME_REPORT structure contains the code integrity runtime report.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["CODE_INTEGRITY_RUNTIME_REPORT structure"]
+ms.keywords: "CODE_INTEGRITY_RUNTIME_REPORT, CODE_INTEGRITY_RUNTIME_REPORT structure [Kernel-Mode Driver Architecture], _CODE_INTEGRITY_RUNTIME_REPORT, wdm/CODE_INTEGRITY_RUNTIME_REPORT"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: CODE_INTEGRITY_RUNTIME_REPORT
+f1_keywords:
+ - _CODE_INTEGRITY_RUNTIME_REPORT
+ - wdm/_CODE_INTEGRITY_RUNTIME_REPORT
+ - CODE_INTEGRITY_RUNTIME_REPORT
+ - wdm/CODE_INTEGRITY_RUNTIME_REPORT
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _CODE_INTEGRITY_RUNTIME_REPORT
+ - CODE_INTEGRITY_RUNTIME_REPORT
+---
+
+# _CODE_INTEGRITY_RUNTIME_REPORT structure
+
+
+## -description
+
+The <b>CODE_INTEGRITY_RUNTIME_REPORT</b> structure contains the code integrity runtime report.
+
+## -struct-fields
+
+### -field Header
+
+The Code Integrity runtime report header. See <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>.
+
+### -field CurrentGeneration
+
+The number of generations (updates) of policy there have been since boot. The initial generation at boot is 1.
+
+### -field NumberOfGenerations
+
+The number of generations of policy that are in this report. This is non-zero, with the current generation reported first, followed by prior generations in order of ascending age.
+
+## -remarks
+
+Each generation in the report is described by a <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_generation_header">CODE_INTEGRITY_REPORT_GENERATION_HEADER</a>, which is followed by one or more <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_record_header">CODE_INTEGRITY_REPORT_RECORD_HEADER</a> structures and their payloads.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_generation_header">CODE_INTEGRITY_REPORT_GENERATION_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_report_record_header">CODE_INTEGRITY_REPORT_RECORD_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-code_integrity_runtime_report">CODE_INTEGRITY_RUNTIME_REPORT (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-driver_info_entry.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-driver_info_entry.md
@@ -1,0 +1,128 @@
+---
+UID: NS:wdm._DRIVER_INFO_ENTRY
+title: _DRIVER_INFO_ENTRY (wdm.h)
+description: The DRIVER_INFO_ENTRY structure describes a single driver image in a driver runtime report.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["DRIVER_INFO_ENTRY structure"]
+ms.keywords: "*PDRIVER_INFO_ENTRY, DRIVER_INFO_ENTRY, DRIVER_INFO_ENTRY structure [Kernel-Mode Driver Architecture], PDRIVER_INFO_ENTRY, _DRIVER_INFO_ENTRY, wdm/DRIVER_INFO_ENTRY, wdm/PDRIVER_INFO_ENTRY"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: DRIVER_INFO_ENTRY, *PDRIVER_INFO_ENTRY
+f1_keywords:
+ - _DRIVER_INFO_ENTRY
+ - wdm/_DRIVER_INFO_ENTRY
+ - PDRIVER_INFO_ENTRY
+ - wdm/PDRIVER_INFO_ENTRY
+ - DRIVER_INFO_ENTRY
+ - wdm/DRIVER_INFO_ENTRY
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _DRIVER_INFO_ENTRY
+ - PDRIVER_INFO_ENTRY
+ - DRIVER_INFO_ENTRY
+---
+
+# _DRIVER_INFO_ENTRY structure
+
+
+## -description
+
+The <b>DRIVER_INFO_ENTRY</b> structure describes a single driver image in a <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-driver_runtime_report">DRIVER_RUNTIME_REPORT</a>.
+
+## -struct-fields
+
+### -field InternalName
+
+Internal name of the driver from the resource section. The array is <b>DRIVER_REPORT_NAME_MAX_LENGTH</b> (32) characters.
+
+### -field ImageHashAlgorithm
+
+Hash algorithm used to calculate the image digest.
+
+### -field PublisherThumbprintHashAlgorithm
+
+Hash algorithm used to calculate the thumbprint of the leaf certificate that validates the entire image.
+
+### -field ImageHashOffset
+
+Offset from the start of the driver report to a buffer containing the digest of the driver image on disk.
+
+### -field PublisherThumbprintOffset
+
+Offset from the start of the driver report to a buffer containing the thumbprint of the leaf certificate validating the entire image.
+
+### -field LoadCount
+
+Number of times that this driver image has been loaded into the system.
+
+### -field OemNameSize
+
+Size of a string indicating the OEM name stored in the authenticated OPUS block of the image digital signature. There is no OEM name for inbox Windows signed drivers. The size does *not* include the NULL terminator (even though the string is NULL-terminated).
+
+### -field OemNameOffset
+
+Offset of a string indicating the OEM name stored in the authenticated OPUS block of the image digital signature. There is no OEM name for inbox Windows signed drivers.
+
+### -field Flags
+
+Flags indicating various properties of the current driver image.
+
+### -field Flags.Unloaded
+
+Set to 1 in case the driver is currently unloaded.
+
+### -field Flags.BootDriver
+
+Set to 1 in case the image is a Boot Driver; 0 otherwise (the image is a Runtime driver).
+
+### -field Flags.HotPatch
+
+Set to 1 in case the image can also be loaded as Hotpatch.
+
+### -field Flags.Reserved
+
+Reserved flags bits.
+
+### -field Flags.AsUInt16
+
+The flags as a single 16-bit value.
+
+### -field Padding
+
+Padding. 
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-driver_runtime_report">DRIVER_RUNTIME_REPORT</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-driver_info_entry">DRIVER_INFO_ENTRY (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-driver_runtime_report.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-driver_runtime_report.md
@@ -1,0 +1,112 @@
+---
+UID: NS:wdm._DRIVER_RUNTIME_REPORT
+title: _DRIVER_RUNTIME_REPORT (wdm.h)
+description: The DRIVER_RUNTIME_REPORT structure contains the runtime report for loaded drivers.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["DRIVER_RUNTIME_REPORT structure"]
+ms.keywords: "*PDRIVER_RUNTIME_REPORT, DRIVER_RUNTIME_REPORT, DRIVER_RUNTIME_REPORT structure [Kernel-Mode Driver Architecture], PDRIVER_RUNTIME_REPORT, _DRIVER_RUNTIME_REPORT, wdm/DRIVER_RUNTIME_REPORT, wdm/PDRIVER_RUNTIME_REPORT"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: DRIVER_RUNTIME_REPORT, *PDRIVER_RUNTIME_REPORT
+f1_keywords:
+ - _DRIVER_RUNTIME_REPORT
+ - wdm/_DRIVER_RUNTIME_REPORT
+ - PDRIVER_RUNTIME_REPORT
+ - wdm/PDRIVER_RUNTIME_REPORT
+ - DRIVER_RUNTIME_REPORT
+ - wdm/DRIVER_RUNTIME_REPORT
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _DRIVER_RUNTIME_REPORT
+ - PDRIVER_RUNTIME_REPORT
+ - DRIVER_RUNTIME_REPORT
+---
+
+# _DRIVER_RUNTIME_REPORT structure
+
+
+## -description
+
+The <b>DRIVER_RUNTIME_REPORT</b> structure contains the runtime report for loaded drivers. It consists of a runtime report header, a count and flags, and a variable-length array of driver entries followed by a dynamic buffer.
+
+## -struct-fields
+
+### -field Header
+
+The driver runtime report header. See <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>.
+
+### -field NumberOfDrivers
+
+The current number of unique drivers in the report.
+
+### -field Flags
+
+Flags indicating various properties of the report.
+
+### -field Flags.ReportOverflowed
+
+Secure Kernel places a limit on the number of drivers it can list in the report. If this is set, it indicates that some loaded drivers might be missing from the report.
+
+### -field Flags.PartialReport
+
+Indicates whether the report contains only a subset of NT loaded drivers.
+
+### -field Flags.IncludeBootDrivers
+
+Set to 1 in case the report includes boot-loaded drivers; 0 otherwise (in that case the information is stored in the TCG Log).
+
+### -field Flags.Reserved
+
+Reserved flags bits.
+
+### -field Flags.AsUInt16
+
+The flags as a single 16-bit value.
+
+### -field DriverEntries
+
+A variable-length array, of size zero up to the maximum number of drivers recorded, containing driver entries. Unloaded drivers are not removed from the list. Each element is a <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-driver_info_entry">DRIVER_INFO_ENTRY</a>.
+
+## -remarks
+
+After the <b>DriverEntries</b> array, the driver runtime report stores hashes, strings, and information that are dynamic in size. This dynamic buffer follows the array and, for each driver, is composed of the image hash, the publisher hash, and the OEM name. The <b>ImageHashOffset</b>, <b>PublisherThumbprintOffset</b>, and <b>OemNameOffset</b> members of each <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-driver_info_entry">DRIVER_INFO_ENTRY</a> locate these items within the report.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-driver_info_entry">DRIVER_INFO_ENTRY</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-driver_runtime_report">DRIVER_RUNTIME_REPORT (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-hotpatch_info_entry.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-hotpatch_info_entry.md
@@ -1,0 +1,92 @@
+---
+UID: NS:wdm._HOTPATCH_INFO_ENTRY
+title: _HOTPATCH_INFO_ENTRY (wdm.h)
+description: The HOTPATCH_INFO_ENTRY structure describes a single hotpatched base image in a hotpatch runtime report.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["HOTPATCH_INFO_ENTRY structure"]
+ms.keywords: "*PHOTPATCH_INFO_ENTRY, HOTPATCH_INFO_ENTRY, HOTPATCH_INFO_ENTRY structure [Kernel-Mode Driver Architecture], PHOTPATCH_INFO_ENTRY, _HOTPATCH_INFO_ENTRY, wdm/HOTPATCH_INFO_ENTRY, wdm/PHOTPATCH_INFO_ENTRY"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: HOTPATCH_INFO_ENTRY, *PHOTPATCH_INFO_ENTRY
+f1_keywords:
+ - _HOTPATCH_INFO_ENTRY
+ - wdm/_HOTPATCH_INFO_ENTRY
+ - PHOTPATCH_INFO_ENTRY
+ - wdm/PHOTPATCH_INFO_ENTRY
+ - HOTPATCH_INFO_ENTRY
+ - wdm/HOTPATCH_INFO_ENTRY
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _HOTPATCH_INFO_ENTRY
+ - PHOTPATCH_INFO_ENTRY
+ - HOTPATCH_INFO_ENTRY
+---
+
+# _HOTPATCH_INFO_ENTRY structure
+
+
+## -description
+
+The <b>HOTPATCH_INFO_ENTRY</b> structure describes a single hotpatched base image in a <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-hotpatch_runtime_report">HOTPATCH_RUNTIME_REPORT</a>.
+
+## -struct-fields
+
+### -field BaseCheckSum
+
+PE identity of the base image that was hotpatched.
+
+### -field BaseTimeDateStamp
+
+PE identity of the base image that was hotpatched.
+
+### -field BaseAddress
+
+VTL0 load address of the base image.
+
+### -field ImageSize
+
+Size of the base image.
+
+### -field LatestSequenceNumber
+
+Highest patch sequence number successfully applied.
+
+### -field BaseImageName
+
+Short name of the base image (for example, "ntoskrnl.exe"), a UTF-8 string stored inline. Truncated to (<b>HOTPATCH_REPORT_NAME_MAX_LENGTH</b> - 1) characters if necessary to ensure NULL termination. This field is informational; the authoritative identity is (<b>BaseCheckSum</b>, <b>BaseTimeDateStamp</b>). The array is <b>HOTPATCH_REPORT_NAME_MAX_LENGTH</b> (32) characters.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-hotpatch_runtime_report">HOTPATCH_RUNTIME_REPORT</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-hotpatch_info_entry">HOTPATCH_INFO_ENTRY (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-hotpatch_runtime_report.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-hotpatch_runtime_report.md
@@ -1,0 +1,92 @@
+---
+UID: NS:wdm._HOTPATCH_RUNTIME_REPORT
+title: _HOTPATCH_RUNTIME_REPORT (wdm.h)
+description: The HOTPATCH_RUNTIME_REPORT structure contains the runtime report for hotpatched base images.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["HOTPATCH_RUNTIME_REPORT structure"]
+ms.keywords: "*PHOTPATCH_RUNTIME_REPORT, HOTPATCH_RUNTIME_REPORT, HOTPATCH_RUNTIME_REPORT structure [Kernel-Mode Driver Architecture], PHOTPATCH_RUNTIME_REPORT, _HOTPATCH_RUNTIME_REPORT, wdm/HOTPATCH_RUNTIME_REPORT, wdm/PHOTPATCH_RUNTIME_REPORT"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: HOTPATCH_RUNTIME_REPORT, *PHOTPATCH_RUNTIME_REPORT
+f1_keywords:
+ - _HOTPATCH_RUNTIME_REPORT
+ - wdm/_HOTPATCH_RUNTIME_REPORT
+ - PHOTPATCH_RUNTIME_REPORT
+ - wdm/PHOTPATCH_RUNTIME_REPORT
+ - HOTPATCH_RUNTIME_REPORT
+ - wdm/HOTPATCH_RUNTIME_REPORT
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _HOTPATCH_RUNTIME_REPORT
+ - PHOTPATCH_RUNTIME_REPORT
+ - HOTPATCH_RUNTIME_REPORT
+---
+
+# _HOTPATCH_RUNTIME_REPORT structure
+
+
+## -description
+
+The <b>HOTPATCH_RUNTIME_REPORT</b> structure contains the runtime report for hotpatched base images. It consists of a runtime report header, a count, reserved fields, and a variable-length array of hotpatch entries.
+
+## -struct-fields
+
+### -field Header
+
+The standard runtime report header. See <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>.
+
+### -field NumberOfEntries
+
+Number of hotpatched base images in this report.
+
+### -field Reserved1
+
+Reserved for future use.
+
+### -field Reserved2
+
+Reserved for future use; also provides explicit padding for 8-byte alignment of the <b>Entries</b> array.
+
+### -field Entries
+
+A variable-length array of hotpatch entries. Each element is a <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-hotpatch_info_entry">HOTPATCH_INFO_ENTRY</a>.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-hotpatch_info_entry">HOTPATCH_INFO_ENTRY</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-hotpatch_runtime_report">HOTPATCH_RUNTIME_REPORT (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_digest_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_digest_header.md
@@ -1,0 +1,88 @@
+---
+UID: NS:wdm._RUNTIME_REPORT_DIGEST_HEADER
+title: _RUNTIME_REPORT_DIGEST_HEADER (wdm.h)
+description: The RUNTIME_REPORT_DIGEST_HEADER structure contains the digest of a runtime report and identifies the type of report that was hashed.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["RUNTIME_REPORT_DIGEST_HEADER structure"]
+ms.keywords: "*PRUNTIME_REPORT_DIGEST_HEADER, RUNTIME_REPORT_DIGEST_HEADER, RUNTIME_REPORT_DIGEST_HEADER structure [Kernel-Mode Driver Architecture], PRUNTIME_REPORT_DIGEST_HEADER, _RUNTIME_REPORT_DIGEST_HEADER, wdm/RUNTIME_REPORT_DIGEST_HEADER, wdm/PRUNTIME_REPORT_DIGEST_HEADER"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: RUNTIME_REPORT_DIGEST_HEADER, *PRUNTIME_REPORT_DIGEST_HEADER
+f1_keywords:
+ - _RUNTIME_REPORT_DIGEST_HEADER
+ - wdm/_RUNTIME_REPORT_DIGEST_HEADER
+ - PRUNTIME_REPORT_DIGEST_HEADER
+ - wdm/PRUNTIME_REPORT_DIGEST_HEADER
+ - RUNTIME_REPORT_DIGEST_HEADER
+ - wdm/RUNTIME_REPORT_DIGEST_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _RUNTIME_REPORT_DIGEST_HEADER
+ - PRUNTIME_REPORT_DIGEST_HEADER
+ - RUNTIME_REPORT_DIGEST_HEADER
+---
+
+# _RUNTIME_REPORT_DIGEST_HEADER structure
+
+
+## -description
+
+The <b>RUNTIME_REPORT_DIGEST_HEADER</b> structure contains the digest of a runtime report, including the report header, and identifies the type of report that was hashed.
+
+## -struct-fields
+
+### -field ReportType
+
+Indicates the type of report that was hashed. Current valid values are RuntimeReportTypeDriver (0), RuntimeReportTypeCodeIntegrity (1), and RuntimeReportTypeHotpatch (2). See <a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-runtime_report_type">RUNTIME_REPORT_TYPE</a>.
+
+### -field Reserved
+
+Reserved field.
+
+### -field ReportDigest
+
+Digest of the report, including the report header. This is a SHA-512 digest. The array is <b>RUNTIME_REPORT_DIGEST_MAX_SIZE</b> (64) bytes.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_package_header">RUNTIME_REPORT_PACKAGE_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-runtime_report_type">RUNTIME_REPORT_TYPE</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-runtime_report_digest_header">RUNTIME_REPORT_DIGEST_HEADER (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_header.md
@@ -1,0 +1,96 @@
+---
+UID: NS:wdm._RUNTIME_REPORT_HEADER
+title: _RUNTIME_REPORT_HEADER (wdm.h)
+description: The RUNTIME_REPORT_HEADER structure is the header of an authenticated runtime report and identifies the report type and size.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["RUNTIME_REPORT_HEADER structure"]
+ms.keywords: "*PRUNTIME_REPORT_HEADER, RUNTIME_REPORT_HEADER, RUNTIME_REPORT_HEADER structure [Kernel-Mode Driver Architecture], PRUNTIME_REPORT_HEADER, _RUNTIME_REPORT_HEADER, wdm/RUNTIME_REPORT_HEADER, wdm/PRUNTIME_REPORT_HEADER"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: RUNTIME_REPORT_HEADER, *PRUNTIME_REPORT_HEADER
+f1_keywords:
+ - _RUNTIME_REPORT_HEADER
+ - wdm/_RUNTIME_REPORT_HEADER
+ - PRUNTIME_REPORT_HEADER
+ - wdm/PRUNTIME_REPORT_HEADER
+ - RUNTIME_REPORT_HEADER
+ - wdm/RUNTIME_REPORT_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _RUNTIME_REPORT_HEADER
+ - PRUNTIME_REPORT_HEADER
+ - RUNTIME_REPORT_HEADER
+---
+
+# _RUNTIME_REPORT_HEADER structure
+
+
+## -description
+
+The <b>RUNTIME_REPORT_HEADER</b> structure is the header of an authenticated runtime report. Each report in the authenticated part of a runtime report package begins with this header, followed by the report body.
+
+## -struct-fields
+
+### -field ReportType
+
+Indicates the type of report. Current valid values are RuntimeReportTypeDriver (0), RuntimeReportTypeCodeIntegrity (1), and RuntimeReportTypeHotpatch (2). See <a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-runtime_report_type">RUNTIME_REPORT_TYPE</a>.
+
+### -field Reserved
+
+Reserved field.
+
+### -field ReportSize
+
+The number of bytes consumed by this report, including the header.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_package_header">RUNTIME_REPORT_PACKAGE_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-driver_runtime_report">DRIVER_RUNTIME_REPORT</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-code_integrity_runtime_report">CODE_INTEGRITY_RUNTIME_REPORT</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-hotpatch_runtime_report">HOTPATCH_RUNTIME_REPORT</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-runtime_report_type">RUNTIME_REPORT_TYPE</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-runtime_report_header">RUNTIME_REPORT_HEADER (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>

--- a/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_package_header.md
+++ b/wdk-ddi-src/content/wdm/ns-wdm-runtime_report_package_header.md
@@ -1,0 +1,124 @@
+---
+UID: NS:wdm._RUNTIME_REPORT_PACKAGE_HEADER
+title: _RUNTIME_REPORT_PACKAGE_HEADER (wdm.h)
+description: The RUNTIME_REPORT_PACKAGE_HEADER structure describes a runtime report package, including the report types it contains, its size, and its signature.
+tech.root: kernel
+ms.date: 07/24/2026
+ai-usage: ai-assisted
+keywords: ["RUNTIME_REPORT_PACKAGE_HEADER structure"]
+ms.keywords: "*PRUNTIME_REPORT_PACKAGE_HEADER, RUNTIME_REPORT_PACKAGE_HEADER, RUNTIME_REPORT_PACKAGE_HEADER structure [Kernel-Mode Driver Architecture], PRUNTIME_REPORT_PACKAGE_HEADER, _RUNTIME_REPORT_PACKAGE_HEADER, wdm/RUNTIME_REPORT_PACKAGE_HEADER, wdm/PRUNTIME_REPORT_PACKAGE_HEADER"
+req.header: wdm.h
+req.include-header: 
+req.target-type: Windows
+req.target-min-winverclnt: 
+req.target-min-winversvr: 
+req.kmdf-ver: 
+req.umdf-ver: 
+req.ddi-compliance: 
+req.unicode-ansi: 
+req.idl: 
+req.max-support: 
+req.namespace: 
+req.assembly: 
+req.type-library: 
+req.lib: 
+req.dll: 
+req.irql: 
+targetos: Windows
+req.typenames: RUNTIME_REPORT_PACKAGE_HEADER, *PRUNTIME_REPORT_PACKAGE_HEADER
+f1_keywords:
+ - _RUNTIME_REPORT_PACKAGE_HEADER
+ - wdm/_RUNTIME_REPORT_PACKAGE_HEADER
+ - PRUNTIME_REPORT_PACKAGE_HEADER
+ - wdm/PRUNTIME_REPORT_PACKAGE_HEADER
+ - RUNTIME_REPORT_PACKAGE_HEADER
+ - wdm/RUNTIME_REPORT_PACKAGE_HEADER
+topic_type:
+ - APIRef
+ - kbSyntax
+api_type:
+ - HeaderDef
+api_location:
+ - wdm.h
+api_name:
+ - _RUNTIME_REPORT_PACKAGE_HEADER
+ - PRUNTIME_REPORT_PACKAGE_HEADER
+ - RUNTIME_REPORT_PACKAGE_HEADER
+---
+
+# _RUNTIME_REPORT_PACKAGE_HEADER structure
+
+
+## -description
+
+The <b>RUNTIME_REPORT_PACKAGE_HEADER</b> structure is the header of a runtime report package. The package contains the package header, a nonce, one or more runtime report digest headers, a signature blob, and the authenticated runtime reports.
+
+## -struct-fields
+
+### -field Magic
+
+Set to <b>RUNTIME_REPORT_PACKAGE_MAGIC</b> = 0x52545250 ("RTRP").
+
+### -field PackageVersion
+
+The version of the package format.
+
+### -field NumberOfReports
+
+Number of different report types contained in the package.
+
+### -field ReportTypesBitmap
+
+A bitmap of all the report types in the package. Use the <b>RUNTIME_REPORT_TYPE_TO_MASK</b> macro to convert <a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-runtime_report_type">RUNTIME_REPORT_TYPE</a> enumerator values to bitmap masks. Current valid report types are RuntimeReportTypeDriver (0), RuntimeReportTypeCodeIntegrity (1), and RuntimeReportTypeHotpatch (2).
+
+### -field PackageSize
+
+The size of the total package, including the package header, the various runtime reports, their digests, and the signature blob.
+
+### -field ReportDigestType
+
+The type of digest contained in the report digest headers. The current valid value is CALG_SHA_512 (see wincrypt.h).
+
+### -field TotalReportDigestsSize
+
+Total size of the signed runtime report digest headers that follow the package header.
+
+### -field Reserved
+
+Reserved field. Must be set to zero.
+
+### -field SignatureScheme
+
+The signature scheme used to sign the runtime reports. The current valid value is RUNTIME_REPORT_SIGNATURE_SCHEME_SHA512_RSA_PSS_SHA512 = 1.
+
+### -field SignatureSize
+
+Size of the signature blob that follows the runtime report digests.
+
+### -field TotalAuthenticatedReportsSize
+
+Total size of the authenticated (but unsigned) runtime reports that follow the signature blob.
+
+## -remarks
+
+The runtime report package is laid out as follows. The signed part begins with the <b>RUNTIME_REPORT_PACKAGE_HEADER</b>, followed by a nonce of <b>RUNTIME_REPORT_NONCE_SIZE</b> (32) bytes, followed by one or more <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_digest_header">RUNTIME_REPORT_DIGEST_HEADER</a> structures. The signature blob follows the signed part. The authenticated part follows the signature and consists of a <a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a> and its report body for each report.
+
+## -see-also
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_digest_header">RUNTIME_REPORT_DIGEST_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ns-wdm-runtime_report_header">RUNTIME_REPORT_HEADER</a>
+
+
+
+<a href="/windows-hardware/drivers/ddi/wdm/ne-wdm-runtime_report_type">RUNTIME_REPORT_TYPE</a>
+
+
+
+<a href="/windows/win32/api/winnt/ns-winnt-runtime_report_package_header">RUNTIME_REPORT_PACKAGE_HEADER (winnt.h)</a>
+
+
+
+<a href="/windows/win32/api/sysinfoapi/nf-sysinfoapi-getruntimeattestationreport">GetRuntimeAttestationReport</a>


### PR DESCRIPTION
## Summary

Adds driver DDI reference documentation for the `RUNTIME_REPORT_TYPE` enum and 10 data structures used by `GetRuntimeAttestationReport`, as they appear in the **wdm.h** driver header. This is the driver/kernel-facing companion to the Win32 PR documenting the same structures under **winnt.h**.

All field descriptions are derived faithfully from the source header's inline comments. Wording matches the app-facing docs in substance; only header/metadata differ.

## Files added (11)

- `ne-wdm-runtime_report_type.md` — RUNTIME_REPORT_TYPE
- `ns-wdm-runtime_report_package_header.md` — RUNTIME_REPORT_PACKAGE_HEADER
- `ns-wdm-runtime_report_digest_header.md` — RUNTIME_REPORT_DIGEST_HEADER
- `ns-wdm-runtime_report_header.md` — RUNTIME_REPORT_HEADER
- `ns-wdm-driver_info_entry.md` — DRIVER_INFO_ENTRY
- `ns-wdm-driver_runtime_report.md` — DRIVER_RUNTIME_REPORT
- `ns-wdm-code_integrity_runtime_report.md` — CODE_INTEGRITY_RUNTIME_REPORT
- `ns-wdm-code_integrity_report_generation_header.md` — CODE_INTEGRITY_REPORT_GENERATION_HEADER
- `ns-wdm-code_integrity_report_record_header.md` — CODE_INTEGRITY_REPORT_RECORD_HEADER
- `ns-wdm-hotpatch_info_entry.md` — HOTPATCH_INFO_ENTRY
- `ns-wdm-hotpatch_runtime_report.md` — HOTPATCH_RUNTIME_REPORT

## Notes for reviewers

Please confirm these DDI-specific metadata values (mirrored from neighboring general kernel `ns-wdm-*` structs, not fabricated):
- `tech.root: kernel` (assumed from neighboring kernel structs)
- `req.irql:` left blank (no IRQL guidance in source header)
- `req.include-header:` left blank (matches some neighboring samples)

Bitfield unions (`DRIVER_INFO_ENTRY.Flags`, `DRIVER_RUNTIME_REPORT.Flags`) are documented member-by-member including `AsUInt16`. Variable-length trailing arrays and the `DRIVER_RUNTIME_REPORT` dynamic buffer are described in `## -remarks`.

Do not merge — draft for review.
