### PR TITLE
Fix description of RtlUTF8StringToUnicodeString 

### DIFF
--- a/wdk-ddi-src/content/wdm/nf-wdm-rtlutf8stringtounicodestring.md
+++ b/wdk-ddi-src/content/wdm/nf-wdm-rtlutf8stringtounicodestring.md
@@ -40,7 +40,7 @@ f1_keywords:
 
 ## -description
 
-The **RtlUTF8StringToUnicodeString** function converts the specified UTF8 source string into a Unicode string in accordance with the current system locale information.
+The **RtlUTF8StringToUnicodeString** function converts the specified UTF8 source string into a Unicode string.
 
 ## -parameters
 


### PR DESCRIPTION
UTF-8 and Unicode String are independent of system locale information.