### PR TITLE
Fix incorrect annotation for LengthReturned parameter

### DIFF
--- a/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlquerykerneleafile.md
+++ b/wdk-ddi-src/content/ntifs/nf-ntifs-fsrtlquerykerneleafile.md
@@ -95,7 +95,7 @@ Supplies the optional index of an EA whose value is to be
 Specifies whether the scan of the EAs should be restarted
         from the beginning.
 
-### -param LengthReturned [out, optional]
+### -param LengthReturned [out]
 
 
 Specifies the amount of valid data that is returned in the


### PR DESCRIPTION
The LengthReturned parameter was incorrectly marked "optional" because the actual DDK header incorrectly annotates it as `_Out_opt_`. I'm fixing the DDK header as well.